### PR TITLE
Improve output of buildInfo command

### DIFF
--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -16,6 +16,7 @@ package handlers
 
 import (
 	"context"
+	"github.com/FerretDB/FerretDB/internal/util/version"
 	"os"
 	"runtime"
 	"strconv"
@@ -427,12 +428,14 @@ func TestReadOnlyHandlers(t *testing.T) {
 			),
 			resp: types.MustMakeDocument(
 				"version", "5.0.42",
+				"gitVersion", version.Get().Commit,
 				"versionArray", types.Array{
 					int32(5),
 					int32(0),
 					int32(42),
 					int32(0),
 				},
+				"bits", int32(strconv.IntSize),
 				"maxBsonObjectSize", int32(bson.MaxDocumentLen),
 				"ok", float64(1),
 			),

--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -16,7 +16,6 @@ package handlers
 
 import (
 	"context"
-	"github.com/FerretDB/FerretDB/internal/util/version"
 	"os"
 	"runtime"
 	"strconv"
@@ -35,6 +34,7 @@ import (
 	"github.com/FerretDB/FerretDB/internal/pg"
 	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/util/testutil"
+	"github.com/FerretDB/FerretDB/internal/util/version"
 	"github.com/FerretDB/FerretDB/internal/wire"
 )
 

--- a/internal/handlers/shared/msg_buildinfo.go
+++ b/internal/handlers/shared/msg_buildinfo.go
@@ -16,11 +16,11 @@ package shared
 
 import (
 	"context"
-	"github.com/FerretDB/FerretDB/internal/util/version"
 
 	"github.com/FerretDB/FerretDB/internal/bson"
 	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
+	"github.com/FerretDB/FerretDB/internal/util/version"
 	"github.com/FerretDB/FerretDB/internal/wire"
 )
 

--- a/internal/handlers/shared/msg_buildinfo.go
+++ b/internal/handlers/shared/msg_buildinfo.go
@@ -16,6 +16,7 @@ package shared
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/FerretDB/FerretDB/internal/bson"
 	"github.com/FerretDB/FerretDB/internal/types"
@@ -40,7 +41,7 @@ func (h *Handler) MsgBuildInfo(ctx context.Context, msg *wire.OpMsg) (*wire.OpMs
 				int32(42),
 				int32(0),
 			},
-			"bits", version.Get().Architecture,
+			"bits", int32(strconv.IntSize),
 			"maxBsonObjectSize", int32(bson.MaxDocumentLen),
 			"ok", float64(1),
 		)},

--- a/internal/handlers/shared/msg_buildinfo.go
+++ b/internal/handlers/shared/msg_buildinfo.go
@@ -16,6 +16,7 @@ package shared
 
 import (
 	"context"
+	"github.com/FerretDB/FerretDB/internal/util/version"
 
 	"github.com/FerretDB/FerretDB/internal/bson"
 	"github.com/FerretDB/FerretDB/internal/types"
@@ -32,12 +33,14 @@ func (h *Handler) MsgBuildInfo(ctx context.Context, msg *wire.OpMsg) (*wire.OpMs
 	err := reply.SetSections(wire.OpMsgSection{
 		Documents: []types.Document{types.MustMakeDocument(
 			"version", versionValue,
+			"gitVersion", version.Get().Commit,
 			"versionArray", types.Array{
 				int32(5),
 				int32(0),
 				int32(42),
 				int32(0),
 			},
+			"bits", version.Get().Architecture,
 			"maxBsonObjectSize", int32(bson.MaxDocumentLen),
 			"ok", float64(1),
 		)},

--- a/internal/util/version/version.go
+++ b/internal/util/version/version.go
@@ -55,19 +55,6 @@ func init() {
 			info.Commit = s.Value
 		case "vcs.modified":
 			info.Dirty, _ = strconv.ParseBool(s.Value)
-		case "architecture":
-			temp, _ := strconv.ParseInt(s.Value, 10, 32)
-			if temp == 32 {
-				info.Architecture = x86
-			} else if temp == 64 {
-				info.Architecture = x64
-			}
-
 		}
 	}
 }
-
-const (
-	x86 int32 = 32
-	x64 int32 = 64
-)

--- a/internal/util/version/version.go
+++ b/internal/util/version/version.go
@@ -27,10 +27,9 @@ import (
 var version string
 
 type Info struct {
-	Version      string
-	Commit       string
-	Dirty        bool
-	Architecture int32 // either equals to 32 or 64
+	Version string
+	Commit  string
+	Dirty   bool
 }
 
 var info *Info

--- a/internal/util/version/version.go
+++ b/internal/util/version/version.go
@@ -26,9 +26,10 @@ import (
 var version string
 
 type Info struct {
-	Version string
-	Commit  string
-	Dirty   bool
+	Version      string
+	Commit       string
+	Dirty        bool
+	Architecture int32 // either equals to 32 or 64
 }
 
 var info *Info
@@ -53,6 +54,19 @@ func init() {
 			info.Commit = s.Value
 		case "gituncommitted":
 			info.Dirty, _ = strconv.ParseBool(s.Value)
+		case "architecture":
+			temp, _ := strconv.ParseInt(s.Value, 10, 32)
+			if temp == 32 {
+				info.Architecture = x86
+			} else if temp == 64 {
+				info.Architecture = x64
+			}
+
 		}
 	}
 }
+
+const (
+	x86 int32 = 32
+	x64 int32 = 64
+)


### PR DESCRIPTION
PR for #197 and #198.

Although I'm not completely sure about obtaining the value of architecture bits, but adding another flag to `buildInfo.Settings` seems a bit cleaner than parsing `GOARCH` (especially if you consider that, for example, `amd64p32` is a valid 32-bit compilation target).