### PR TITLE
Update tutorial ,add depends_on in docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See our [CONTRIBUTING.md](CONTRIBUTING.md).
 These steps describe a quick local setup.
 They are not suitable for most production use-cases because they keep all data inside containers.
 
-1. Create a folder `ferretdb` and store the following in the `docker-compose.yml` file in folder `ferretdb`:
+1. Store the following in the `docker-compose.yml` file:
 
 ```yaml
 version: "3"
@@ -57,19 +57,19 @@ services:
     image: postgres:14
     container_name: postgres_setup
     restart: on-failure
-    depends_on:
-      - postgres
     entrypoint: ["sh", "-c", "psql -h postgres -U user -d ferretdb -c 'CREATE SCHEMA IF NOT EXISTS test'"]
 
   ferretdb:
     image: ghcr.io/ferretdb/ferretdb:latest
     container_name: ferretdb
     restart: on-failure
-    depends_on:
-      - postgres_setup
     ports:
       - 27017:27017
     command: ["-listen-addr=:27017", "-postgresql-url=postgres://user@postgres:5432/ferretdb"]
+
+networks:
+  default:
+    name: ferretdb
 ```
 
 * `postgres` container runs PostgreSQL 14 that would store data.
@@ -81,7 +81,7 @@ services:
 3. If you have `mongosh` installed, just run it to connect to FerretDB database `test`.
 If not, run the following command to run `mongosh` inside the temporary MongoDB container, attaching to the same Docker network:
 ```
-docker run --rm -it --network=ferretdb_default --entrypoint=mongosh mongo:5 mongodb://ferretdb/
+docker run --rm -it --network=ferretdb --entrypoint=mongosh mongo:5 mongodb://ferretdb/
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See our [CONTRIBUTING.md](CONTRIBUTING.md).
 These steps describe a quick local setup.
 They are not suitable for most production use-cases because they keep all data inside containers.
 
-1. Store the following in the `docker-compose.yml` file:
+1. Create a folder `ferretdb` and store the following in the `docker-compose.yml` file in folder `ferretdb`:
 
 ```yaml
 version: "3"
@@ -57,12 +57,16 @@ services:
     image: postgres:14
     container_name: postgres_setup
     restart: on-failure
+    depends_on:
+      - postgres
     entrypoint: ["sh", "-c", "psql -h postgres -U user -d ferretdb -c 'CREATE SCHEMA IF NOT EXISTS test'"]
 
   ferretdb:
     image: ghcr.io/ferretdb/ferretdb:latest
     container_name: ferretdb
     restart: on-failure
+    depends_on:
+      - postgres_setup
     ports:
       - 27017:27017
     command: ["-listen-addr=:27017", "-postgresql-url=postgres://user@postgres:5432/ferretdb"]


### PR DESCRIPTION
fix 2 issues:
1. when create `docker-copose.yml` in `test` folder ,`docker-compose up` will  create a network `test_default` but not `ferretdb_default` . it will make the command 
 `docker run --rm -it --network=ferretdb_default --entrypoint=mongosh mongo:5 mongodb://ferretdb/` not work.
2. docker compose not start in correct order ,add depends_on to make sure everything run in order.
error log I met when not add depends_on:
```
(virtualenv) [centos@localhost ~]$ sudo docker-compose up
Starting postgres ...
Recreating ferretdb ...
Recreating ferretdb ... done
Attaching to postgres, postgres_setup, ferretdb
postgres          |
postgres          | PostgreSQL Database directory appears to contain a database; Skipping initialization
postgres          |
postgres          | 2022-01-19 02:51:10.956 UTC [1] LOG:  starting PostgreSQL 14.1 (Debian 14.1-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
postgres          | 2022-01-19 02:51:10.957 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
postgres          | 2022-01-19 02:51:10.957 UTC [1] LOG:  listening on IPv6 address "::", port 5432
postgres          | 2022-01-19 02:51:10.963 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
postgres          | 2022-01-19 02:51:10.968 UTC [27] LOG:  database system was shut down at 2022-01-19 02:47:30 UTC
postgres_setup    | psql: error: connection to server at "postgres" (172.18.0.2), port 5432 failed: Connection refused
postgres_setup    | 	Is the server running on that host and accepting TCP/IP connections?
postgres          | 2022-01-19 02:51:10.975 UTC [1] LOG:  database system is ready to accept connections
ferretdb          | 2022-01-19T02:51:10.932Z	INFO	ferretdb/main.go:61	Starting FerretDB v0.0.5-dirty...	{"commit": "50b04ab86d486f5d5497929a450f781bb6cfafe9", "dirty": true}
ferretdb          | 2022-01-19T02:51:10.933Z	INFO	pgconn.Pool	v4@v4.14.1/conn.go:355	Dialing PostgreSQL server	{"host": "postgres"}
ferretdb          | 2022-01-19T02:51:10.937Z	INFO	debug	debug/debug.go:36	Starting debug server on http://127.0.0.1:8088/
ferretdb          | 2022-01-19T02:51:10.947Z	ERROR	pgconn.Pool	v4@v4.14.1/conn.go:355	connect failed	{"err": "failed to connect to `host=postgres user=user database=ferretdb`: dial error (dial tcp 172.18.0.2:5432: connect: connection refused)"}
ferretdb          | github.com/jackc/pgx/v4.(*Conn).log
ferretdb          | 	github.com/jackc/pgx/v4@v4.14.1/conn.go:355
ferretdb          | github.com/jackc/pgx/v4.connect
ferretdb          | 	github.com/jackc/pgx/v4@v4.14.1/conn.go:226
ferretdb          | github.com/jackc/pgx/v4.ConnectConfig
ferretdb          | 	github.com/jackc/pgx/v4@v4.14.1/conn.go:114
ferretdb          | github.com/jackc/pgx/v4/pgxpool.ConnectConfig.func1
ferretdb          | 	github.com/jackc/pgx/v4@v4.14.1/pgxpool/pool.go:190
ferretdb          | github.com/jackc/puddle.(*Pool).constructResourceValue
ferretdb          | 	github.com/jackc/puddle@v1.2.0/pool.go:496
ferretdb          | github.com/jackc/puddle.(*Pool).doAcquire
ferretdb          | 	github.com/jackc/puddle@v1.2.0/pool.go:324
ferretdb          | github.com/jackc/puddle.(*Pool).Acquire
ferretdb          | 	github.com/jackc/puddle@v1.2.0/pool.go:265
ferretdb          | github.com/jackc/pgx/v4/pgxpool.ConnectConfig
ferretdb          | 	github.com/jackc/pgx/v4@v4.14.1/pgxpool/pool.go:233
ferretdb          | github.com/FerretDB/FerretDB/internal/pg.NewPool
ferretdb          | 	github.com/FerretDB/FerretDB/internal/pg/pool.go:88
ferretdb          | github.com/FerretDB/FerretDB/cmd/ferretdb.main
ferretdb          | 	github.com/FerretDB/FerretDB/cmd/ferretdb/main.go:87
ferretdb          | github.com/FerretDB/FerretDB/cmd/ferretdb.TestCover
ferretdb          | 	github.com/FerretDB/FerretDB/cmd/ferretdb/main_test.go:25
ferretdb          | testing.tRunner
ferretdb          | 	testing/testing.go:1440
ferretdb          | 2022-01-19T02:51:10.947Z	FATAL	ferretdb/main.go:89	pg.NewPool: failed to connect to `host=postgres user=user database=ferretdb`: dial error (dial tcp 172.18.0.2:5432: connect: connection refused)
ferretdb          | github.com/FerretDB/FerretDB/cmd/ferretdb.main
ferretdb          | 	github.com/FerretDB/FerretDB/cmd/ferretdb/main.go:89
ferretdb          | github.com/FerretDB/FerretDB/cmd/ferretdb.TestCover
ferretdb          | 	github.com/FerretDB/FerretDB/cmd/ferretdb/main_test.go:25
ferretdb          | testing.tRunner
ferretdb          | 	testing/testing.go:1440
postgres_setup exited with code 0
```