### PR TITLE
Support `serverStatus`.

### DIFF
--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/expfmt"
@@ -113,6 +114,7 @@ func main() {
 		Metrics:         listenerMetrics,
 		HandlersMetrics: handlersMetrics,
 		TestConnTimeout: *testConnTimeoutF,
+		StartUnixTime:   time.Now().UnixMilli(),
 	})
 
 	err = l.Run(ctx)

--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -114,7 +114,7 @@ func main() {
 		Metrics:         listenerMetrics,
 		HandlersMetrics: handlersMetrics,
 		TestConnTimeout: *testConnTimeoutF,
-		StartUnixTime:   time.Now().UnixMilli(),
+		StartTime:       time.Now(),
 	})
 
 	err = l.Run(ctx)

--- a/internal/clientconn/conn.go
+++ b/internal/clientconn/conn.go
@@ -69,6 +69,7 @@ type newConnOpts struct {
 	proxyAddr       string
 	mode            Mode
 	handlersMetrics *handlers.Metrics
+	startUnixTime   int64
 }
 
 // newConn creates a new client connection for given net.Conn.
@@ -95,6 +96,7 @@ func newConn(opts *newConnOpts) (*conn, error) {
 		SQLStorage:    sqlH,
 		JSONB1Storage: jsonb1H,
 		Metrics:       opts.handlersMetrics,
+		StartUnixTime: opts.startUnixTime,
 	}
 	return &conn{
 		netConn: opts.netConn,

--- a/internal/clientconn/conn.go
+++ b/internal/clientconn/conn.go
@@ -69,7 +69,7 @@ type newConnOpts struct {
 	proxyAddr       string
 	mode            Mode
 	handlersMetrics *handlers.Metrics
-	startUnixTime   int64
+	startTime       time.Time
 }
 
 // newConn creates a new client connection for given net.Conn.
@@ -96,7 +96,7 @@ func newConn(opts *newConnOpts) (*conn, error) {
 		SQLStorage:    sqlH,
 		JSONB1Storage: jsonb1H,
 		Metrics:       opts.handlersMetrics,
-		StartUnixTime: opts.startUnixTime,
+		StartTime:     opts.startTime,
 	}
 	return &conn{
 		netConn: opts.netConn,

--- a/internal/clientconn/listener.go
+++ b/internal/clientconn/listener.go
@@ -47,6 +47,7 @@ type NewListenerOpts struct {
 	Metrics         *ListenerMetrics
 	HandlersMetrics *handlers.Metrics
 	TestConnTimeout time.Duration
+	StartUnixTime   int64
 }
 
 // NewListener returns a new listener, configured by the NewListenerOpts argument.
@@ -120,6 +121,7 @@ func (l *Listener) Run(ctx context.Context) error {
 				proxyAddr:       l.opts.ProxyAddr,
 				mode:            l.opts.Mode,
 				handlersMetrics: l.opts.HandlersMetrics,
+				startUnixTime:   l.opts.StartUnixTime,
 			}
 			conn, e := newConn(opts)
 			if e != nil {

--- a/internal/clientconn/listener.go
+++ b/internal/clientconn/listener.go
@@ -47,7 +47,7 @@ type NewListenerOpts struct {
 	Metrics         *ListenerMetrics
 	HandlersMetrics *handlers.Metrics
 	TestConnTimeout time.Duration
-	StartUnixTime   int64
+	StartTime       time.Time
 }
 
 // NewListener returns a new listener, configured by the NewListenerOpts argument.
@@ -121,7 +121,7 @@ func (l *Listener) Run(ctx context.Context) error {
 				proxyAddr:       l.opts.ProxyAddr,
 				mode:            l.opts.Mode,
 				handlersMetrics: l.opts.HandlersMetrics,
-				startUnixTime:   l.opts.StartUnixTime,
+				startTime:       l.opts.StartTime,
 			}
 			conn, e := newConn(opts)
 			if e != nil {

--- a/internal/handlers/handler.go
+++ b/internal/handlers/handler.go
@@ -38,6 +38,7 @@ type Handler struct {
 	jsonb1        common.Storage
 	metrics       *Metrics
 	lastRequestID int32
+	startUnixTime int64
 }
 
 // NewOpts represents handler configuration.
@@ -48,17 +49,19 @@ type NewOpts struct {
 	JSONB1Storage common.Storage
 	Metrics       *Metrics
 	PeerAddr      string
+	StartUnixTime int64
 }
 
 // New returns a new handler.
 func New(opts *NewOpts) *Handler {
 	return &Handler{
-		pgPool:   opts.PgPool,
-		l:        opts.Logger,
-		sql:      opts.SQLStorage,
-		jsonb1:   opts.JSONB1Storage,
-		metrics:  opts.Metrics,
-		peerAddr: opts.PeerAddr,
+		pgPool:        opts.PgPool,
+		l:             opts.Logger,
+		sql:           opts.SQLStorage,
+		jsonb1:        opts.JSONB1Storage,
+		metrics:       opts.Metrics,
+		peerAddr:      opts.PeerAddr,
+		startUnixTime: opts.StartUnixTime,
 	}
 }
 

--- a/internal/handlers/handler.go
+++ b/internal/handlers/handler.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"sync/atomic"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -38,7 +39,7 @@ type Handler struct {
 	jsonb1        common.Storage
 	metrics       *Metrics
 	lastRequestID int32
-	startUnixTime int64
+	startTime     time.Time
 }
 
 // NewOpts represents handler configuration.
@@ -49,19 +50,19 @@ type NewOpts struct {
 	JSONB1Storage common.Storage
 	Metrics       *Metrics
 	PeerAddr      string
-	StartUnixTime int64
+	StartTime     time.Time
 }
 
 // New returns a new handler.
 func New(opts *NewOpts) *Handler {
 	return &Handler{
-		pgPool:        opts.PgPool,
-		l:             opts.Logger,
-		sql:           opts.SQLStorage,
-		jsonb1:        opts.JSONB1Storage,
-		metrics:       opts.Metrics,
-		peerAddr:      opts.PeerAddr,
-		startUnixTime: opts.StartUnixTime,
+		pgPool:    opts.PgPool,
+		l:         opts.Logger,
+		sql:       opts.SQLStorage,
+		jsonb1:    opts.JSONB1Storage,
+		metrics:   opts.Metrics,
+		peerAddr:  opts.PeerAddr,
+		startTime: opts.StartTime,
 	}
 }
 

--- a/internal/handlers/msg_serverstatus.go
+++ b/internal/handlers/msg_serverstatus.go
@@ -48,8 +48,7 @@ func (h *Handler) MsgServerStatus(ctx context.Context, msg *wire.OpMsg) (*wire.O
 		return nil, lazyerrors.Error(err)
 	}
 
-	uptimeMillis := time.Now().UnixMilli() - h.startUnixTime
-	uptimeSecs := uptimeMillis / 1_000
+	uptime := time.Since(h.startTime)
 
 	stats, err := h.pgPool.SchemaStats(ctx, db)
 	if err != nil {
@@ -63,9 +62,9 @@ func (h *Handler) MsgServerStatus(ctx context.Context, msg *wire.OpMsg) (*wire.O
 			"version", versionValue,
 			"process", filepath.Base(exec),
 			"pid", int64(os.Getpid()),
-			"uptime", uptimeSecs,
-			"uptimeMillis", uptimeMillis,
-			"uptimeEstimate", uptimeSecs,
+			"uptime", int64(uptime.Seconds()),
+			"uptimeMillis", uptime.Milliseconds(),
+			"uptimeEstimate", int64(uptime.Seconds()),
 			"localTime", time.Now(),
 			"catalogStats", must.NotFail(types.NewDocument(
 				"collections", stats.CountTables,

--- a/internal/handlers/msg_serverstatus.go
+++ b/internal/handlers/msg_serverstatus.go
@@ -16,20 +16,70 @@ package handlers
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"time"
 
 	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
+	"github.com/FerretDB/FerretDB/internal/util/must"
 	"github.com/FerretDB/FerretDB/internal/wire"
 )
 
 // MsgServerStatus OpMsg used to get a server status.
 func (h *Handler) MsgServerStatus(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error) {
+	document, err := msg.Document()
+	if err != nil {
+		return nil, lazyerrors.Error(err)
+	}
+
+	m := document.Map()
+	db, ok := m["$db"].(string)
+	if !ok {
+		return nil, lazyerrors.New("no db")
+	}
+
+	host, err := os.Hostname()
+	if err != nil {
+		return nil, lazyerrors.Error(err)
+	}
+	exec, err := os.Executable()
+	if err != nil {
+		return nil, lazyerrors.Error(err)
+	}
+
+	uptimeMillis := time.Now().UnixMilli() - h.startUnixTime
+	uptimeSecs := uptimeMillis / 1_000
+
+	stats, err := h.pgPool.SchemaStats(ctx, db)
+	if err != nil {
+		return nil, lazyerrors.Error(err)
+	}
+
 	var reply wire.OpMsg
-	err := reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{types.MustNewDocument(
+	err = reply.SetSections(wire.OpMsgSection{
+		Documents: []*types.Document{must.NotFail(types.NewDocument(
+			"host", host,
 			"version", versionValue,
+			"process", filepath.Base(exec),
+			"pid", int64(os.Getpid()),
+			"uptime", uptimeSecs,
+			"uptimeMillis", uptimeMillis,
+			"uptimeEstimate", uptimeSecs,
+			"localTime", time.Now(),
+			"catalogStats", must.NotFail(types.NewDocument(
+				"collections", stats.CountTables,
+				"capped", int32(0),
+				"timeseries", int32(0),
+				"views", int32(0),
+				"internalCollections", int32(0),
+				"internalViews", int32(0),
+			)),
+			"freeMonitoring", must.NotFail(types.NewDocument(
+				"state", "disabled",
+			)),
 			"ok", float64(1),
-		)},
+		))},
 	})
 	if err != nil {
 		return nil, lazyerrors.Error(err)


### PR DESCRIPTION
Closes #156 

Output example:

```sh
test> db.serverStatus()
{
  host: 'demo-ubuntu',
  version: '5.0.42',
  process: 'ferretdb-testcover',
  pid: Long("1900"),
  uptime: Long("2"),
  uptimeMillis: Long("2426"),
  uptimeEstimate: Long("2"),
  localTime: ISODate("2022-01-26T19:24:32.956Z"),
  catalogStats: {
    collections: 0,
    capped: 0,
    timeseries: 0,
    views: 0,
    internalCollections: 0,
    internalViews: 0
  },
  freeMonitoring: { state: 'disabled' },
  ok: 1
}

````