### PR TITLE
Update `insert` command's help

### DIFF
--- a/internal/handlers/command.go
+++ b/internal/handlers/command.go
@@ -152,7 +152,7 @@ var commands = map[string]command{
 	},
 	"insert": {
 		name:           "insert",
-		help:           "Inserts documents into the database. ",
+		help:           "Inserts documents into the database.",
 		storageHandler: (common.Storage).MsgInsert,
 	},
 	"update": {


### PR DESCRIPTION
There is a dangling white space in the "insert" command's help string. This PR fixes it ;)