### PR TITLE
use docker image from docker hub for quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ services:
     entrypoint: ["sh", "-c", "psql -h postgres -U user -d ferretdb -c 'CREATE SCHEMA IF NOT EXISTS test'"]
 
   ferretdb:
-    image: ghcr.io/ferretdb/ferretdb:latest
+    image: ferretdb/ferretdb:latest
     container_name: ferretdb
     restart: on-failure
     ports:


### PR DESCRIPTION
use the docker image from docker hub in the sample docker-compose.yml file as the github hosted one seems to have an invalid manifest

