### PR TITLE
Fix panic on `findOne` query

### DIFF
--- a/internal/handlers/pg/msg_count.go
+++ b/internal/handlers/pg/msg_count.go
@@ -85,6 +85,11 @@ func (h *Handler) MsgCount(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, e
 		resDocs = append(resDocs, doc)
 	}
 
+	// no documents left after filtration
+	if len(resDocs) == 0 {
+		return nil, nil
+	}
+
 	if resDocs, err = common.LimitDocuments(resDocs, limit); err != nil {
 		return nil, err
 	}

--- a/internal/handlers/pg/msg_count.go
+++ b/internal/handlers/pg/msg_count.go
@@ -85,9 +85,22 @@ func (h *Handler) MsgCount(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, e
 		resDocs = append(resDocs, doc)
 	}
 
-	// no documents left after filtration
 	if len(resDocs) == 0 {
-		return nil, nil
+		var reply wire.OpMsg
+		err = reply.SetSections(wire.OpMsgSection{
+			Documents: []*types.Document{types.MustNewDocument(
+				"cursor", types.MustNewDocument(
+					"firstBatch", types.MakeArray(0),
+					"id", int64(0), // TODO
+					"ns", db+"."+collection,
+				),
+				"ok", float64(1),
+			)},
+		})
+		if err != nil {
+			return nil, lazyerrors.Error(err)
+		}
+		return &reply, nil
 	}
 
 	if resDocs, err = common.LimitDocuments(resDocs, limit); err != nil {

--- a/internal/handlers/pg/msg_find.go
+++ b/internal/handlers/pg/msg_find.go
@@ -105,6 +105,11 @@ func (h *Handler) MsgFind(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, er
 		resDocs = append(resDocs, doc)
 	}
 
+	// no documents left after filtration
+	if len(resDocs) == 0 {
+		return nil, nil
+	}
+
 	if err = common.SortDocuments(resDocs, sort); err != nil {
 		return nil, err
 	}

--- a/internal/handlers/pg/msg_find.go
+++ b/internal/handlers/pg/msg_find.go
@@ -105,9 +105,22 @@ func (h *Handler) MsgFind(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, er
 		resDocs = append(resDocs, doc)
 	}
 
-	// no documents left after filtration
 	if len(resDocs) == 0 {
-		return nil, nil
+		var reply wire.OpMsg
+		err = reply.SetSections(wire.OpMsgSection{
+			Documents: []*types.Document{types.MustNewDocument(
+				"cursor", types.MustNewDocument(
+					"firstBatch", types.MakeArray(0),
+					"id", int64(0), // TODO
+					"ns", db+"."+collection,
+				),
+				"ok", float64(1),
+			)},
+		})
+		if err != nil {
+			return nil, lazyerrors.Error(err)
+		}
+		return &reply, nil
 	}
 
 	if err = common.SortDocuments(resDocs, sort); err != nil {


### PR DESCRIPTION
Problem: right now for queries like `db.values.findOne({"name":"there is no such name"})` that would ends up with empty result find would try to call `common.Limit` which would return slice with 1 nil document that leads to panic on document validation stage.
Solution: return if there no documents after applying filters.