### PR TITLE
Move command handlers `listCommands`, `debug_error`, `debug_panic` out of Handler interface

### DIFF
--- a/integration/commands_diagnostic_test.go
+++ b/integration/commands_diagnostic_test.go
@@ -82,12 +82,9 @@ func TestCommandsDiagnosticListCommands(t *testing.T) {
 	require.NoError(t, err)
 
 	m := actual.Map()
+
 	t.Log(m)
 
 	assert.Equal(t, 1.0, m["ok"])
 	assert.Equal(t, []string{"commands", "ok"}, CollectKeys(t, actual))
-
-	commands := m["commands"].(bson.D)
-	listCommands := commands.Map()["listCommands"].(bson.D)
-	assert.NotEmpty(t, listCommands.Map()["help"].(string))
 }

--- a/internal/handlers/common/commands.go
+++ b/internal/handlers/common/commands.go
@@ -32,10 +32,6 @@ type Command struct {
 // Commands is a map of commands that common.Handler interface can support.
 // Order of entries matches the interface definition.
 var Commands = map[string]Command{
-	"listCommands": {
-		Help:    "Returns a list of currently supported commands.",
-		Handler: (Handler).MsgListCommands,
-	},
 	"buildInfo": {
 		Help:    "Returns a summary of the build information.",
 		Handler: (Handler).MsgBuildInfo,
@@ -139,13 +135,5 @@ var Commands = map[string]Command{
 	"update": {
 		Help:    "Updates documents that are matched by the query.",
 		Handler: (Handler).MsgUpdate,
-	},
-	"debug_error": {
-		Help:    "Used for debugging purposes.",
-		Handler: (Handler).MsgDebugError,
-	},
-	"debug_panic": {
-		Help:    "Used for debugging purposes.",
-		Handler: (Handler).MsgDebugPanic,
 	},
 }

--- a/internal/handlers/common/handler.go
+++ b/internal/handlers/common/handler.go
@@ -22,9 +22,6 @@ import (
 
 // Handler interface represents common commands handlers.
 type Handler interface {
-	// MsgListCommands returns a list of currently supported commands.
-	MsgListCommands(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error)
-
 	// MsgBuildInfo returns a summary of the build information.
 	MsgBuildInfo(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error)
 
@@ -99,12 +96,6 @@ type Handler interface {
 
 	// MsgUpdate updates documents that are matched by the query.
 	MsgUpdate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error)
-
-	// MsgDebugError used for debugging purposes.
-	MsgDebugError(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error)
-
-	// MsgDebugPanic used for debugging purposes.
-	MsgDebugPanic(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error)
 
 	// CmdQuery runs query operation command.
 	CmdQuery(ctx context.Context, query *wire.OpQuery) (*wire.OpReply, error)

--- a/internal/handlers/dummy/dummy.go
+++ b/internal/handlers/dummy/dummy.go
@@ -30,11 +30,6 @@ func New() common.Handler {
 	return new(Handler)
 }
 
-// MsgListCommands returns information about the currently supported commands.
-func (h *Handler) MsgListCommands(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error) {
-	return nil, common.NewErrorMsg(common.ErrNotImplemented, "I'm a dummy, not a handler")
-}
-
 // MsgBuildInfo returns a summary of the build information.
 func (h *Handler) MsgBuildInfo(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error) {
 	return nil, common.NewErrorMsg(common.ErrNotImplemented, "I'm a dummy, not a handler")
@@ -157,16 +152,6 @@ func (h *Handler) MsgInsert(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 
 // MsgUpdate updates documents that are matched by the query.
 func (h *Handler) MsgUpdate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error) {
-	return nil, common.NewErrorMsg(common.ErrNotImplemented, "I'm a dummy, not a handler")
-}
-
-// MsgDebugError used for debugging purposes.
-func (h *Handler) MsgDebugError(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error) {
-	return nil, common.NewErrorMsg(common.ErrNotImplemented, "I'm a dummy, not a handler")
-}
-
-// MsgDebugPanic used for debugging purposes.
-func (h *Handler) MsgDebugPanic(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error) {
 	return nil, common.NewErrorMsg(common.ErrNotImplemented, "I'm a dummy, not a handler")
 }
 

--- a/internal/handlers/pg/handler.go
+++ b/internal/handlers/pg/handler.go
@@ -200,6 +200,10 @@ func (h *Handler) Handle(ctx context.Context, reqHeader *wire.MsgHeader, reqBody
 }
 
 func (h *Handler) handleOpMsg(ctx context.Context, msg *wire.OpMsg, cmd string) (*wire.OpMsg, error) {
+	if cmd == "listCommands" {
+		return h.MsgListCommands(ctx, msg)
+	}
+
 	if cmd, ok := common.Commands[cmd]; ok {
 		if cmd.Handler != nil {
 			return cmd.Handler(h, ctx, msg)


### PR DESCRIPTION
Refs #455 