### PR TITLE
Handle both `buildinfo` and `buildInfo` commands

### DIFF
--- a/integration/basic_test.go
+++ b/integration/basic_test.go
@@ -40,10 +40,14 @@ func TestMostCommandsAreCaseSensitive(t *testing.T) {
 	res = db.RunCommand(ctx, bson.D{{"listCollections", 1}})
 	assert.NoError(t, res.Err())
 
-	// special case
+	// special cases from the old `mongo` shell
 	res = db.RunCommand(ctx, bson.D{{"ismaster", 1}})
 	assert.NoError(t, res.Err())
 	res = db.RunCommand(ctx, bson.D{{"isMaster", 1}})
+	assert.NoError(t, res.Err())
+	res = db.RunCommand(ctx, bson.D{{"buildinfo", 1}})
+	assert.NoError(t, res.Err())
+	res = db.RunCommand(ctx, bson.D{{"buildInfo", 1}})
 	assert.NoError(t, res.Err())
 }
 

--- a/internal/handlers/common/msg_listcommands.go
+++ b/internal/handlers/common/msg_listcommands.go
@@ -42,7 +42,11 @@ type command struct {
 // Please keep help text in sync with handlers.Interface methods documentation.
 var Commands = map[string]command{
 	// sorted alphabetically
-	"buildInfo": {
+	"buildinfo": {
+		Help:    "Returns a summary of the build information.",
+		Handler: (handlers.Interface).MsgBuildInfo,
+	},
+	"buildInfo": { // both `buildinfo` and `buildInfo` are valid
 		Help:    "Returns a summary of the build information.",
 		Handler: (handlers.Interface).MsgBuildInfo,
 	},


### PR DESCRIPTION
The former is sent by the old `mongo` shell.