### PR TITLE
Add the default Task target

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,3 @@
+- [ ] `task all` passes
+
+See CONTRIBUTING.md for more details.

--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -1,3 +1,5 @@
-- [ ] `task all` passes
+# Checklist
+
+* [ ] `task all` passes
 
 See CONTRIBUTING.md for more details.

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,7 +46,7 @@ jobs:
         run: bin/task init
 
       - name: Regenerate and reformat
-        run: bin/task gen fmt docs-fmt
+        run: bin/task -p gen docs
 
       - name: Wait for and setup environment
         run: bin/task env-setup

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,4 +147,4 @@ Before submitting a pull request, please make sure that:
 
 ## Contributing documentation
 
-Please format documentation with `task docs-fmt`.
+Please format and lint documentation with `task docs`.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,6 +7,19 @@ vars:
   FUZZCORPUS: ../fuzz-corpus
 
 tasks:
+  # invoked when `task` is run without arguments
+  default:
+    deps: [all]
+
+  all:
+    desc: "Generate, format, build, test and lint code and documentation"
+    cmds:
+      - task: gen
+      - task: build-testcover
+      - task: test
+      - task: lint
+      - task: docs
+
   gen-version:
     cmds:
       - go generate -x ./internal/util/version
@@ -57,7 +70,7 @@ tasks:
       - docker-compose down --remove-orphans --volumes
 
   gen:
-    desc: "Generate code"
+    desc: "Generate (and format) code"
     cmds:
       - go generate -x ./...
       - task: fmt
@@ -188,11 +201,12 @@ tasks:
     cmds:
       - ../bin/go-consistent -pedantic ./...
 
-  docs-fmt:
-    desc: "Markdown formatter and linter"
+  # TODO move Docker image to Docker Compose, use some dependabot-like tool that supports Docker Compose updates
+  docs:
+    desc: "Format and lint documentation"
     cmds:
       - >
-        docker run --rm -v $PWD:/workdir ghcr.io/igorshubovych/markdownlint-cli:v0.31.1
+        docker run --platform=linux/amd64 --rm -v $PWD:/workdir ghcr.io/igorshubovych/markdownlint-cli:v0.31.1
         --fix --dot --ignore CHANGELOG.md '**/*.md'
 
   psql:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -51,7 +51,7 @@ tasks:
 
   env-up-detach:
     cmds:
-      - docker-compose up --always-recreate-deps --force-recreate --remove-orphans --renew-anon-volumes --detach
+      - docker-compose up postgres mongodb --always-recreate-deps --force-recreate --remove-orphans --renew-anon-volumes --detach
 
   env-up:
     desc: "Start development environment"
@@ -201,13 +201,11 @@ tasks:
     cmds:
       - ../bin/go-consistent -pedantic ./...
 
-  # TODO move Docker image to Docker Compose, use some dependabot-like tool that supports Docker Compose updates
   docs:
     desc: "Format and lint documentation"
     cmds:
       - >
-        docker run --platform=linux/amd64 --rm -v $PWD:/workdir ghcr.io/igorshubovych/markdownlint-cli:v0.31.1
-        --fix --dot --ignore CHANGELOG.md '**/*.md'
+        docker-compose run --rm markdownlint --fix --dot --ignore CHANGELOG.md '**/*.md'
 
   psql:
     desc: "Run psql"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
   postgres:
     image: postgres:14.3
     container_name: ferretdb_postgres
+    depends_on: [test_db]
     ports:
       - 127.0.0.1:5432:5432
     extra_hosts:
@@ -20,6 +21,7 @@ services:
   mongodb:
     image: mongo:5.0.8
     container_name: ferretdb_mongodb
+    depends_on: [test_db]
     ports:
       - 127.0.0.1:37017:27017
     extra_hosts:
@@ -35,6 +37,12 @@ services:
     container_name: ferretdb_test_db
     volumes:
       - test_db_mongodb:/test_db/mongodb:ro
+
+  markdownlint:
+    image: ghcr.io/igorshubovych/markdownlint-cli:v0.31.1
+    container_name: ferretdb_markdownlint
+    volumes:
+      - .:/workdir
 
 volumes:
   test_db_mongodb:


### PR DESCRIPTION
This adds the default Task target that should be run before submitting PRs. It can be invoked as `bin/task all` or simply as `bin/task`.

This also adds a very basic PR template that will be improved in the future.