### PR TITLE
Add `Min` and `Max` methods to `types.Array`

### DIFF
--- a/internal/types/array.go
+++ b/internal/types/array.go
@@ -116,6 +116,7 @@ func (a *Array) RemoveByPath(path Path) {
 	removeByPath(a, path)
 }
 
+// Min returns the minimum value from the array.
 func (a *Array) Min() any {
 	if a == nil || a.Len() == 0 {
 		panic("cannot get Min value; array is nil or empty")
@@ -132,6 +133,7 @@ func (a *Array) Min() any {
 	return min
 }
 
+// Max returns the maximum value from the array.
 func (a *Array) Max() any {
 	if a == nil || a.Len() == 0 {
 		panic("cannot get Max value; array is nil or empty")

--- a/internal/types/array.go
+++ b/internal/types/array.go
@@ -14,7 +14,11 @@
 
 package types
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/FerretDB/FerretDB/internal/util/must"
+)
 
 // Array represents BSON array.
 //
@@ -110,4 +114,36 @@ func (a *Array) Append(values ...any) error {
 // RemoveByPath removes document by path, doing nothing if the key does not exist.
 func (a *Array) RemoveByPath(path Path) {
 	removeByPath(a, path)
+}
+
+func (a *Array) Min() any {
+	if a == nil || a.Len() == 0 {
+		panic("cannot get Min value; array is nil or empty")
+	}
+
+	min := must.NotFail(a.Get(0))
+	for i := 1; i < a.Len(); i++ {
+		value := must.NotFail(a.Get(i))
+		if CompareOrder(min, value, Ascending) == Greater {
+			min = value
+		}
+	}
+
+	return min
+}
+
+func (a *Array) Max() any {
+	if a == nil || a.Len() == 0 {
+		panic("cannot get Max value; array is nil or empty")
+	}
+
+	max := must.NotFail(a.Get(0))
+	for i := 1; i < a.Len(); i++ {
+		value := must.NotFail(a.Get(i))
+		if CompareOrder(max, value, Ascending) == Less {
+			max = value
+		}
+	}
+
+	return max
 }

--- a/internal/types/array_test.go
+++ b/internal/types/array_test.go
@@ -15,7 +15,9 @@
 package types
 
 import (
+	"math"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -76,4 +78,135 @@ func TestArray(t *testing.T) {
 		assert.NotEqual(t, a, b)
 		assert.Equal(t, int32(42), b.s[0])
 	})
+}
+
+func TestArrayMinMax(t *testing.T) {
+	var (
+		int32Array   = must.NotFail(NewArray(int32(42), int32(50), int32(2), int32(30)))
+		int64Array   = must.NotFail(NewArray(int64(42), int64(50), int64(2), int64(30)))
+		intArray     = must.NotFail(NewArray(int64(42), int64(50), int32(50), int64(2), int32(2), int64(30)))
+		floatArray   = must.NotFail(NewArray(42.0, 50.1, 2.2, 30.3))
+		numericArray = must.NotFail(NewArray(int64(2), int32(2), 2.0))
+		zeroArray    = must.NotFail(NewArray(int64(0), int32(0), math.Copysign(0, +1), math.Copysign(0, -1)))
+
+		stingArray = must.NotFail(NewArray("foo", "zoo", "", "bar"))
+
+		scalarTypesArray = must.NotFail(NewArray(
+			int32(42),
+			int64(42),
+			float64(42),
+			"foo",
+			Binary{},
+			ObjectID{},
+			true,
+			time.Time{},
+			NullType{},
+			Regex{},
+			Timestamp(42),
+		))
+	)
+
+	const (
+		min = "min"
+		max = "max"
+	)
+
+	for name, tc := range map[string]struct {
+		arr           *Array
+		minOrMax      string
+		expectedValue any
+	}{
+		"Int32Min": {
+			arr:           int32Array,
+			minOrMax:      min,
+			expectedValue: int32(2),
+		},
+		"Int64Min": {
+			arr:           int64Array,
+			minOrMax:      min,
+			expectedValue: int64(2),
+		},
+		"IntMin": {
+			arr:           intArray,
+			minOrMax:      min,
+			expectedValue: int32(2),
+		},
+		"FloatMin": {
+			arr:           floatArray,
+			minOrMax:      min,
+			expectedValue: 2.2,
+		},
+		"NumericMin": {
+			arr:           numericArray,
+			minOrMax:      min,
+			expectedValue: 2.0,
+		},
+		"ZeroMin": {
+			arr:           zeroArray,
+			minOrMax:      min,
+			expectedValue: math.Copysign(0, -1),
+		},
+		"StringMin": {
+			arr:           stingArray,
+			minOrMax:      min,
+			expectedValue: "",
+		},
+		"AllTypeMin": {
+			arr:           scalarTypesArray,
+			minOrMax:      min,
+			expectedValue: NullType{},
+		},
+		"Int32Max": {
+			arr:           int32Array,
+			minOrMax:      max,
+			expectedValue: int32(50),
+		},
+		"Int64Max": {
+			arr:           int64Array,
+			minOrMax:      max,
+			expectedValue: int64(50),
+		},
+		"IntMax": {
+			arr:           intArray,
+			minOrMax:      max,
+			expectedValue: int64(50),
+		},
+		"FloatMax": {
+			arr:           floatArray,
+			minOrMax:      max,
+			expectedValue: 50.1,
+		},
+		"NumericMax": {
+			arr:           numericArray,
+			minOrMax:      max,
+			expectedValue: int64(2),
+		},
+		"ZeroMax": {
+			arr:           zeroArray,
+			minOrMax:      max,
+			expectedValue: int64(0),
+		},
+		"StringMax": {
+			arr:           stingArray,
+			minOrMax:      max,
+			expectedValue: "zoo",
+		},
+		"AllTypeMax": {
+			arr:           scalarTypesArray,
+			minOrMax:      max,
+			expectedValue: Regex{},
+		},
+	} {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			var res any
+			if tc.minOrMax == min {
+				res = tc.arr.Min()
+			} else {
+				res = tc.arr.Max()
+			}
+
+			assert.Equal(t, res, tc.expectedValue)
+		})
+	}
 }


### PR DESCRIPTION
Closes #637.

This implementation covers all scalar types. To cover composite, first need to implement `comparison order` of composite data types #457.