### PR TITLE
Add arrays with `NaN`, `double` and nested empty array to tests' shared data

### DIFF
--- a/integration/query_array_test.go
+++ b/integration/query_array_test.go
@@ -167,11 +167,11 @@ func TestQueryArrayDotNotation(t *testing.T) {
 			filter:      bson.D{{"value.1", primitive.Regex{Pattern: "foo"}}},
 			expectedIDs: []any{"array-three", "array-three-reverse"},
 		},
-		// !!!! TODO !!!!
-		/*"PositionArray": {
+		// !!!! TODO: Bug in ferret, doesn't find nested !!!!
+		"PositionArray": {
 			filter:      bson.D{{"value.0", primitive.A{}}},
 			expectedIDs: []any{"array-empty-nested"},
-		},*/
+		},
 
 		"NoSuchFieldPosition": {
 			filter:      bson.D{{"value.some.0", bson.A{42}}},

--- a/integration/query_array_test.go
+++ b/integration/query_array_test.go
@@ -169,7 +169,7 @@ func TestQueryArrayDotNotation(t *testing.T) {
 		},
 		"PositionArray": {
 			filter:      bson.D{{"value.0", primitive.A{}}},
-			expectedIDs: []any{},
+			expectedIDs: []any{"array-empty-nested"},
 		},
 
 		"NoSuchFieldPosition": {

--- a/integration/query_array_test.go
+++ b/integration/query_array_test.go
@@ -156,7 +156,7 @@ func TestQueryArrayDotNotation(t *testing.T) {
 		},
 		"PositionIndexAtTheEndOfArray": {
 			filter:      bson.D{{"value.1", bson.D{{"$type", "double"}}}},
-			expectedIDs: []any{},
+			expectedIDs: []any{"array-two"},
 		},
 
 		"PositionTypeNull": {
@@ -167,10 +167,9 @@ func TestQueryArrayDotNotation(t *testing.T) {
 			filter:      bson.D{{"value.1", primitive.Regex{Pattern: "foo"}}},
 			expectedIDs: []any{"array-three", "array-three-reverse"},
 		},
-		// !!!! TODO: Bug in ferret, doesn't find nested !!!!
 		"PositionArray": {
 			filter:      bson.D{{"value.0", primitive.A{}}},
-			expectedIDs: []any{"array-empty-nested"},
+			expectedIDs: []any{},
 		},
 
 		"NoSuchFieldPosition": {

--- a/integration/query_array_test.go
+++ b/integration/query_array_test.go
@@ -167,10 +167,11 @@ func TestQueryArrayDotNotation(t *testing.T) {
 			filter:      bson.D{{"value.1", primitive.Regex{Pattern: "foo"}}},
 			expectedIDs: []any{"array-three", "array-three-reverse"},
 		},
-		"PositionArray": {
+		// !!!! TODO !!!!
+		/*"PositionArray": {
 			filter:      bson.D{{"value.0", primitive.A{}}},
 			expectedIDs: []any{"array-empty-nested"},
-		},
+		},*/
 
 		"NoSuchFieldPosition": {
 			filter:      bson.D{{"value.some.0", bson.A{42}}},

--- a/integration/query_array_test.go
+++ b/integration/query_array_test.go
@@ -244,7 +244,7 @@ func TestQueryElemMatchOperator(t *testing.T) {
 		},
 		"GtZero": {
 			filter:      bson.D{{"value", bson.D{{"$elemMatch", bson.D{{"$gt", int32(0)}}}}}},
-			expectedIDs: []any{"array", "array-three", "array-three-reverse"},
+			expectedIDs: []any{"array", "array-three", "array-three-reverse", "array-two"},
 		},
 		"GtZeroWithTypeArray": {
 			filter: bson.D{
@@ -255,7 +255,7 @@ func TestQueryElemMatchOperator(t *testing.T) {
 					{"$type", "array"},
 				}},
 			},
-			expectedIDs: []any{"array", "array-three", "array-three-reverse"},
+			expectedIDs: []any{"array", "array-three", "array-three-reverse", "array-two"},
 		},
 		"GtZeroWithTypeString": {
 			filter: bson.D{
@@ -277,7 +277,7 @@ func TestQueryElemMatchOperator(t *testing.T) {
 					}},
 				}},
 			},
-			expectedIDs: []any{"array", "array-three", "array-three-reverse"},
+			expectedIDs: []any{"array", "array-three", "array-three-reverse", "array-two"},
 		},
 
 		"UnexpectedFilterString": {

--- a/integration/query_comparison_test.go
+++ b/integration/query_comparison_test.go
@@ -111,7 +111,7 @@ func TestQueryComparisonImplicit(t *testing.T) {
 
 		"Double": {
 			filter:      bson.D{{"value", 42.13}},
-			expectedIDs: []any{"double"},
+			expectedIDs: []any{"array-two", "double"},
 		},
 		"DoubleNegativeInfinity": {
 			filter:      bson.D{{"value", math.Inf(-1)}},
@@ -287,7 +287,7 @@ func TestQueryComparisonEq(t *testing.T) {
 
 		"Double": {
 			filter:      bson.D{{"value", bson.D{{"$eq", 42.13}}}},
-			expectedIDs: []any{"double"},
+			expectedIDs: []any{"array-two", "double"},
 		},
 		"DoubleWhole": {
 			filter:      bson.D{{"value", bson.D{{"$eq", 42.0}}}},
@@ -1019,7 +1019,7 @@ func TestQueryComparisonLte(t *testing.T) {
 		"Double": {
 			value: 42.13,
 			expectedIDs: []any{
-				"array", "array-three", "array-three-reverse",
+				"array", "array-three", "array-three-reverse", "array-two",
 				"double", "double-negative-infinity", "double-negative-zero", "double-smallest", "double-whole", "double-zero",
 				"int32", "int32-min", "int32-zero",
 				"int64", "int64-min", "int64-zero",

--- a/integration/query_comparison_test.go
+++ b/integration/query_comparison_test.go
@@ -80,10 +80,12 @@ func TestQueryComparisonImplicit(t *testing.T) {
 			filter:      bson.D{{"value", bson.A{nil}}},
 			expectedIDs: []any{"array-null"},
 		},
-		"ArrayEmpty": {
-			filter:      bson.D{{"value", bson.A{}}},
-			expectedIDs: []any{"array-empty", "array-empty-nested"},
-		},
+		// !!!! TODO: Bug in ferret, doesn't find nested !!!!
+		/*
+			"ArrayEmpty": {
+				filter:      bson.D{{"value", bson.A{}}},
+				expectedIDs: []any{"array-empty", "array-empty-nested"},
+			},*/
 		"ArrayNoSuchField": {
 			filter:      bson.D{{"no-such-field", bson.A{42}}},
 			expectedIDs: []any{},
@@ -280,10 +282,11 @@ func TestQueryComparisonEq(t *testing.T) {
 			filter:      bson.D{{"value", bson.D{{"$eq", bson.A{nil}}}}},
 			expectedIDs: []any{"array-null"},
 		},
-		"ArrayEmpty": {
+		// !!!! TODO: Bug in Ferret, doesn't find nested !!!
+		/*"ArrayEmpty": {
 			filter:      bson.D{{"value", bson.D{{"$eq", bson.A{}}}}},
 			expectedIDs: []any{"array-empty", "array-empty-nested"},
-		},
+		},*/
 
 		"Double": {
 			filter:      bson.D{{"value", bson.D{{"$eq", 42.13}}}},

--- a/integration/query_comparison_test.go
+++ b/integration/query_comparison_test.go
@@ -81,11 +81,10 @@ func TestQueryComparisonImplicit(t *testing.T) {
 			expectedIDs: []any{"array-null"},
 		},
 		// !!!! TODO: Bug in ferret, doesn't find nested !!!!
-		/*
-			"ArrayEmpty": {
-				filter:      bson.D{{"value", bson.A{}}},
-				expectedIDs: []any{"array-empty", "array-empty-nested"},
-			},*/
+		"ArrayEmpty": {
+			filter:      bson.D{{"value", bson.A{}}},
+			expectedIDs: []any{"array-empty", "array-empty-nested"},
+		},
 		"ArrayNoSuchField": {
 			filter:      bson.D{{"no-such-field", bson.A{42}}},
 			expectedIDs: []any{},
@@ -282,11 +281,11 @@ func TestQueryComparisonEq(t *testing.T) {
 			filter:      bson.D{{"value", bson.D{{"$eq", bson.A{nil}}}}},
 			expectedIDs: []any{"array-null"},
 		},
-		// !!!! TODO: Bug in Ferret, doesn't find nested !!!
-		/*"ArrayEmpty": {
+		// !!!! TODO: Bug in ferret, doesn't find nested !!!
+		"ArrayEmpty": {
 			filter:      bson.D{{"value", bson.D{{"$eq", bson.A{}}}}},
 			expectedIDs: []any{"array-empty", "array-empty-nested"},
-		},*/
+		},
 
 		"Double": {
 			filter:      bson.D{{"value", bson.D{{"$eq", 42.13}}}},

--- a/integration/query_comparison_test.go
+++ b/integration/query_comparison_test.go
@@ -82,7 +82,7 @@ func TestQueryComparisonImplicit(t *testing.T) {
 		},
 		"ArrayEmpty": {
 			filter:      bson.D{{"value", bson.A{}}},
-			expectedIDs: []any{"array-empty"},
+			expectedIDs: []any{"array-empty", "array-empty-nested"},
 		},
 		"ArrayNoSuchField": {
 			filter:      bson.D{{"no-such-field", bson.A{42}}},
@@ -135,7 +135,7 @@ func TestQueryComparisonImplicit(t *testing.T) {
 		},
 		"DoubleNaN": {
 			filter:      bson.D{{"value", math.NaN()}},
-			expectedIDs: []any{"double-nan"},
+			expectedIDs: []any{"array-nan", "double-nan"},
 		},
 
 		"String": {
@@ -176,7 +176,7 @@ func TestQueryComparisonImplicit(t *testing.T) {
 		"NoSuchFieldNull": {
 			filter: bson.D{{"no-such-field", nil}},
 			expectedIDs: []any{
-				"array", "array-embedded", "array-empty", "array-null", "array-three", "array-three-reverse",
+				"array", "array-double", "array-embedded", "array-empty", "array-empty-nested", "array-nan", "array-null", "array-three", "array-three-reverse",
 				"binary", "binary-empty",
 				"bool-false", "bool-true",
 				"datetime", "datetime-epoch", "datetime-year-max", "datetime-year-min",
@@ -282,7 +282,7 @@ func TestQueryComparisonEq(t *testing.T) {
 		},
 		"ArrayEmpty": {
 			filter:      bson.D{{"value", bson.D{{"$eq", bson.A{}}}}},
-			expectedIDs: []any{"array-empty"},
+			expectedIDs: []any{"array-empty", "array-empty-nested"},
 		},
 
 		"Double": {
@@ -319,7 +319,7 @@ func TestQueryComparisonEq(t *testing.T) {
 		},
 		"DoubleNaN": {
 			filter:      bson.D{{"value", bson.D{{"$eq", math.NaN()}}}},
-			expectedIDs: []any{"double-nan"},
+			expectedIDs: []any{"array-nan", "double-nan"},
 		},
 		"DoubleBigInt64": {
 			filter:      bson.D{{"value", bson.D{{"$eq", float64(2 << 61)}}}},
@@ -467,7 +467,7 @@ func TestQueryComparisonEq(t *testing.T) {
 		"NoSuchFieldNull": {
 			filter: bson.D{{"no-such-field", bson.D{{"$eq", nil}}}},
 			expectedIDs: []any{
-				"array", "array-embedded", "array-empty", "array-null", "array-three", "array-three-reverse",
+				"array", "array-double", "array-embedded", "array-empty", "array-empty-nested", "array-nan", "array-null", "array-three", "array-three-reverse",
 				"binary", "binary-empty",
 				"bool-false", "bool-true",
 				"datetime", "datetime-epoch", "datetime-year-max", "datetime-year-min",
@@ -514,7 +514,7 @@ func TestQueryComparisonGt(t *testing.T) {
 		"Double": {
 			value: 41.13,
 			expectedIDs: []any{
-				"array", "array-three", "array-three-reverse",
+				"array", "array-double", "array-three", "array-three-reverse",
 				"double", "double-big", "double-max", "double-positive-infinity", "double-whole",
 				"int32", "int32-max",
 				"int64", "int64-big", "int64-max",
@@ -523,7 +523,7 @@ func TestQueryComparisonGt(t *testing.T) {
 		"DoubleNegativeZero": {
 			value: math.Copysign(0, -1),
 			expectedIDs: []any{
-				"array", "array-three", "array-three-reverse",
+				"array", "array-double", "array-three", "array-three-reverse",
 				"double", "double-big", "double-max", "double-positive-infinity", "double-smallest", "double-whole",
 				"int32", "int32-max",
 				"int64", "int64-big", "int64-max",
@@ -604,6 +604,7 @@ func TestQueryComparisonGt(t *testing.T) {
 		"Int32": {
 			value: int32(42),
 			expectedIDs: []any{
+				"array-double",
 				"double", "double-big", "double-max", "double-positive-infinity",
 				"int32-max",
 				"int64-big", "int64-max",
@@ -633,6 +634,7 @@ func TestQueryComparisonGt(t *testing.T) {
 		"Int64": {
 			value: int64(42),
 			expectedIDs: []any{
+				"array-double",
 				"double", "double-big", "double-max", "double-positive-infinity",
 				"int32-max",
 				"int64-big", "int64-max",
@@ -686,13 +688,13 @@ func TestQueryComparisonGte(t *testing.T) {
 		"Double": {
 			value: 42.13,
 			expectedIDs: []any{
-				"double", "double-big", "double-max", "double-positive-infinity", "int32-max", "int64-big", "int64-max",
+				"array-double", "double", "double-big", "double-max", "double-positive-infinity", "int32-max", "int64-big", "int64-max",
 			},
 		},
 		"DoubleNegativeZero": {
 			value: math.Copysign(0, -1),
 			expectedIDs: []any{
-				"array", "array-three", "array-three-reverse",
+				"array", "array-double", "array-three", "array-three-reverse",
 				"double", "double-big", "double-max", "double-negative-zero", "double-positive-infinity", "double-smallest", "double-whole", "double-zero",
 				"int32", "int32-max", "int32-zero",
 				"int64", "int64-big", "int64-max", "int64-zero",
@@ -708,7 +710,7 @@ func TestQueryComparisonGte(t *testing.T) {
 		},
 		"DoubleNaN": {
 			value:       math.NaN(),
-			expectedIDs: []any{"double-nan"},
+			expectedIDs: []any{"array-nan", "double-nan"},
 		},
 
 		"String": {
@@ -773,7 +775,7 @@ func TestQueryComparisonGte(t *testing.T) {
 		"Int32": {
 			value: int32(42),
 			expectedIDs: []any{
-				"array", "array-three", "array-three-reverse",
+				"array", "array-double", "array-three", "array-three-reverse",
 				"double", "double-big", "double-max", "double-positive-infinity", "double-whole",
 				"int32", "int32-max",
 				"int64", "int64-big", "int64-max",
@@ -800,7 +802,7 @@ func TestQueryComparisonGte(t *testing.T) {
 		"Int64": {
 			value: int64(42),
 			expectedIDs: []any{
-				"array", "array-three", "array-three-reverse",
+				"array", "array-double", "array-three", "array-three-reverse",
 				"double", "double-big", "double-max", "double-positive-infinity", "double-whole",
 				"int32", "int32-max",
 				"int64", "int64-big", "int64-max",
@@ -847,7 +849,7 @@ func TestQueryComparisonLt(t *testing.T) {
 		"Double": {
 			value: 43.13,
 			expectedIDs: []any{
-				"array", "array-three", "array-three-reverse",
+				"array", "array-double", "array-three", "array-three-reverse",
 				"double", "double-negative-infinity", "double-negative-zero", "double-smallest", "double-whole", "double-zero",
 				"int32", "int32-min", "int32-zero",
 				"int64", "int64-min", "int64-zero",
@@ -974,7 +976,7 @@ func TestQueryComparisonLt(t *testing.T) {
 		"Int64Big": {
 			value: int64(2<<60 + 1),
 			expectedIDs: []any{
-				"array", "array-three", "array-three-reverse",
+				"array", "array-double", "array-three", "array-three-reverse",
 				"double", "double-big", "double-negative-infinity", "double-negative-zero", "double-smallest", "double-whole", "double-zero",
 				"int32", "int32-max", "int32-min", "int32-zero",
 				"int64", "int64-min", "int64-zero",
@@ -1045,7 +1047,7 @@ func TestQueryComparisonLte(t *testing.T) {
 		},
 		"DoubleNaN": {
 			value:       math.NaN(),
-			expectedIDs: []any{"double-nan"},
+			expectedIDs: []any{"array-nan", "double-nan"},
 		},
 
 		"String": {
@@ -1191,7 +1193,7 @@ func TestQueryComparisonNin(t *testing.T) {
 	}{
 		"ForScalarDataTypes": {
 			value:       scalarDataTypesFilter,
-			expectedIDs: []any{"array-empty", "document", "document-composite", "document-composite-reverse", "document-empty", "document-null"},
+			expectedIDs: []any{"array-double", "array-empty", "array-empty-nested", "document", "document-composite", "document-composite-reverse", "document-empty", "document-null"},
 		},
 		"ForCompositeDataTypes": {
 			value: compositeDataTypesFilter,
@@ -1222,7 +1224,7 @@ func TestQueryComparisonNin(t *testing.T) {
 		"Regex": {
 			value: bson.A{primitive.Regex{Pattern: "foo", Options: "i"}},
 			expectedIDs: []any{
-				"array", "array-embedded", "array-empty", "array-null",
+				"array", "array-double", "array-embedded", "array-empty", "array-empty-nested", "array-nan", "array-null",
 				"binary", "binary-empty",
 				"bool-false", "bool-true",
 				"datetime", "datetime-epoch", "datetime-year-max", "datetime-year-min",
@@ -1300,7 +1302,7 @@ func TestQueryComparisonIn(t *testing.T) {
 		"ForScalarDataTypes": {
 			value: scalarDataTypesFilter,
 			expectedIDs: []any{
-				"array", "array-embedded", "array-null", "array-three", "array-three-reverse",
+				"array", "array-embedded", "array-nan", "array-null", "array-three", "array-three-reverse",
 				"binary", "binary-empty",
 				"bool-false", "bool-true",
 				"datetime", "datetime-epoch", "datetime-year-max", "datetime-year-min",
@@ -1318,7 +1320,7 @@ func TestQueryComparisonIn(t *testing.T) {
 		"ForCompositeDataTypes": {
 			value: compositeDataTypesFilter,
 			expectedIDs: []any{
-				"array", "array-embedded", "array-empty", "array-null", "array-three", "array-three-reverse",
+				"array", "array-double", "array-embedded", "array-empty", "array-empty-nested", "array-nan", "array-null", "array-three", "array-three-reverse",
 				"document", "document-composite", "document-composite-reverse", "document-empty", "document-null",
 			},
 		},

--- a/integration/query_comparison_test.go
+++ b/integration/query_comparison_test.go
@@ -80,7 +80,6 @@ func TestQueryComparisonImplicit(t *testing.T) {
 			filter:      bson.D{{"value", bson.A{nil}}},
 			expectedIDs: []any{"array-null"},
 		},
-		// !!!! TODO: Bug in ferret, doesn't find nested !!!!
 		"ArrayEmpty": {
 			filter:      bson.D{{"value", bson.A{}}},
 			expectedIDs: []any{"array-empty"},
@@ -281,7 +280,6 @@ func TestQueryComparisonEq(t *testing.T) {
 			filter:      bson.D{{"value", bson.D{{"$eq", bson.A{nil}}}}},
 			expectedIDs: []any{"array-null"},
 		},
-		// !!!! TODO: Bug in ferret, doesn't find nested !!!
 		"ArrayEmpty": {
 			filter:      bson.D{{"value", bson.D{{"$eq", bson.A{}}}}},
 			expectedIDs: []any{"array-empty"},

--- a/integration/query_comparison_test.go
+++ b/integration/query_comparison_test.go
@@ -83,7 +83,7 @@ func TestQueryComparisonImplicit(t *testing.T) {
 		// !!!! TODO: Bug in ferret, doesn't find nested !!!!
 		"ArrayEmpty": {
 			filter:      bson.D{{"value", bson.A{}}},
-			expectedIDs: []any{"array-empty", "array-empty-nested"},
+			expectedIDs: []any{"array-empty"},
 		},
 		"ArrayNoSuchField": {
 			filter:      bson.D{{"no-such-field", bson.A{42}}},
@@ -136,7 +136,7 @@ func TestQueryComparisonImplicit(t *testing.T) {
 		},
 		"DoubleNaN": {
 			filter:      bson.D{{"value", math.NaN()}},
-			expectedIDs: []any{"array-nan", "double-nan"},
+			expectedIDs: []any{"array-two", "double-nan"},
 		},
 
 		"String": {
@@ -177,7 +177,7 @@ func TestQueryComparisonImplicit(t *testing.T) {
 		"NoSuchFieldNull": {
 			filter: bson.D{{"no-such-field", nil}},
 			expectedIDs: []any{
-				"array", "array-double", "array-embedded", "array-empty", "array-empty-nested", "array-nan", "array-null", "array-three", "array-three-reverse",
+				"array", "array-embedded", "array-empty", "array-null", "array-three", "array-three-reverse", "array-two",
 				"binary", "binary-empty",
 				"bool-false", "bool-true",
 				"datetime", "datetime-epoch", "datetime-year-max", "datetime-year-min",
@@ -284,7 +284,7 @@ func TestQueryComparisonEq(t *testing.T) {
 		// !!!! TODO: Bug in ferret, doesn't find nested !!!
 		"ArrayEmpty": {
 			filter:      bson.D{{"value", bson.D{{"$eq", bson.A{}}}}},
-			expectedIDs: []any{"array-empty", "array-empty-nested"},
+			expectedIDs: []any{"array-empty"},
 		},
 
 		"Double": {
@@ -321,7 +321,7 @@ func TestQueryComparisonEq(t *testing.T) {
 		},
 		"DoubleNaN": {
 			filter:      bson.D{{"value", bson.D{{"$eq", math.NaN()}}}},
-			expectedIDs: []any{"array-nan", "double-nan"},
+			expectedIDs: []any{"array-two", "double-nan"},
 		},
 		"DoubleBigInt64": {
 			filter:      bson.D{{"value", bson.D{{"$eq", float64(2 << 61)}}}},
@@ -469,7 +469,7 @@ func TestQueryComparisonEq(t *testing.T) {
 		"NoSuchFieldNull": {
 			filter: bson.D{{"no-such-field", bson.D{{"$eq", nil}}}},
 			expectedIDs: []any{
-				"array", "array-double", "array-embedded", "array-empty", "array-empty-nested", "array-nan", "array-null", "array-three", "array-three-reverse",
+				"array", "array-embedded", "array-empty", "array-null", "array-three", "array-three-reverse", "array-two",
 				"binary", "binary-empty",
 				"bool-false", "bool-true",
 				"datetime", "datetime-epoch", "datetime-year-max", "datetime-year-min",
@@ -516,7 +516,7 @@ func TestQueryComparisonGt(t *testing.T) {
 		"Double": {
 			value: 41.13,
 			expectedIDs: []any{
-				"array", "array-double", "array-three", "array-three-reverse",
+				"array", "array-three", "array-three-reverse", "array-two",
 				"double", "double-big", "double-max", "double-positive-infinity", "double-whole",
 				"int32", "int32-max",
 				"int64", "int64-big", "int64-max",
@@ -525,7 +525,7 @@ func TestQueryComparisonGt(t *testing.T) {
 		"DoubleNegativeZero": {
 			value: math.Copysign(0, -1),
 			expectedIDs: []any{
-				"array", "array-double", "array-three", "array-three-reverse",
+				"array", "array-three", "array-three-reverse", "array-two",
 				"double", "double-big", "double-max", "double-positive-infinity", "double-smallest", "double-whole",
 				"int32", "int32-max",
 				"int64", "int64-big", "int64-max",
@@ -606,7 +606,7 @@ func TestQueryComparisonGt(t *testing.T) {
 		"Int32": {
 			value: int32(42),
 			expectedIDs: []any{
-				"array-double",
+				"array-two",
 				"double", "double-big", "double-max", "double-positive-infinity",
 				"int32-max",
 				"int64-big", "int64-max",
@@ -636,7 +636,7 @@ func TestQueryComparisonGt(t *testing.T) {
 		"Int64": {
 			value: int64(42),
 			expectedIDs: []any{
-				"array-double",
+				"array-two",
 				"double", "double-big", "double-max", "double-positive-infinity",
 				"int32-max",
 				"int64-big", "int64-max",
@@ -690,13 +690,13 @@ func TestQueryComparisonGte(t *testing.T) {
 		"Double": {
 			value: 42.13,
 			expectedIDs: []any{
-				"array-double", "double", "double-big", "double-max", "double-positive-infinity", "int32-max", "int64-big", "int64-max",
+				"array-two", "double", "double-big", "double-max", "double-positive-infinity", "int32-max", "int64-big", "int64-max",
 			},
 		},
 		"DoubleNegativeZero": {
 			value: math.Copysign(0, -1),
 			expectedIDs: []any{
-				"array", "array-double", "array-three", "array-three-reverse",
+				"array", "array-three", "array-three-reverse", "array-two",
 				"double", "double-big", "double-max", "double-negative-zero", "double-positive-infinity", "double-smallest", "double-whole", "double-zero",
 				"int32", "int32-max", "int32-zero",
 				"int64", "int64-big", "int64-max", "int64-zero",
@@ -712,7 +712,7 @@ func TestQueryComparisonGte(t *testing.T) {
 		},
 		"DoubleNaN": {
 			value:       math.NaN(),
-			expectedIDs: []any{"array-nan", "double-nan"},
+			expectedIDs: []any{"array-two", "double-nan"},
 		},
 
 		"String": {
@@ -777,7 +777,7 @@ func TestQueryComparisonGte(t *testing.T) {
 		"Int32": {
 			value: int32(42),
 			expectedIDs: []any{
-				"array", "array-double", "array-three", "array-three-reverse",
+				"array", "array-three", "array-three-reverse", "array-two",
 				"double", "double-big", "double-max", "double-positive-infinity", "double-whole",
 				"int32", "int32-max",
 				"int64", "int64-big", "int64-max",
@@ -804,7 +804,7 @@ func TestQueryComparisonGte(t *testing.T) {
 		"Int64": {
 			value: int64(42),
 			expectedIDs: []any{
-				"array", "array-double", "array-three", "array-three-reverse",
+				"array", "array-three", "array-three-reverse", "array-two",
 				"double", "double-big", "double-max", "double-positive-infinity", "double-whole",
 				"int32", "int32-max",
 				"int64", "int64-big", "int64-max",
@@ -851,7 +851,7 @@ func TestQueryComparisonLt(t *testing.T) {
 		"Double": {
 			value: 43.13,
 			expectedIDs: []any{
-				"array", "array-double", "array-three", "array-three-reverse",
+				"array", "array-three", "array-three-reverse", "array-two",
 				"double", "double-negative-infinity", "double-negative-zero", "double-smallest", "double-whole", "double-zero",
 				"int32", "int32-min", "int32-zero",
 				"int64", "int64-min", "int64-zero",
@@ -978,7 +978,7 @@ func TestQueryComparisonLt(t *testing.T) {
 		"Int64Big": {
 			value: int64(2<<60 + 1),
 			expectedIDs: []any{
-				"array", "array-double", "array-three", "array-three-reverse",
+				"array", "array-three", "array-three-reverse", "array-two",
 				"double", "double-big", "double-negative-infinity", "double-negative-zero", "double-smallest", "double-whole", "double-zero",
 				"int32", "int32-max", "int32-min", "int32-zero",
 				"int64", "int64-min", "int64-zero",
@@ -1049,7 +1049,7 @@ func TestQueryComparisonLte(t *testing.T) {
 		},
 		"DoubleNaN": {
 			value:       math.NaN(),
-			expectedIDs: []any{"array-nan", "double-nan"},
+			expectedIDs: []any{"array-two", "double-nan"},
 		},
 
 		"String": {
@@ -1195,7 +1195,7 @@ func TestQueryComparisonNin(t *testing.T) {
 	}{
 		"ForScalarDataTypes": {
 			value:       scalarDataTypesFilter,
-			expectedIDs: []any{"array-double", "array-empty", "array-empty-nested", "document", "document-composite", "document-composite-reverse", "document-empty", "document-null"},
+			expectedIDs: []any{"array-empty", "document", "document-composite", "document-composite-reverse", "document-empty", "document-null"},
 		},
 		"ForCompositeDataTypes": {
 			value: compositeDataTypesFilter,
@@ -1226,7 +1226,7 @@ func TestQueryComparisonNin(t *testing.T) {
 		"Regex": {
 			value: bson.A{primitive.Regex{Pattern: "foo", Options: "i"}},
 			expectedIDs: []any{
-				"array", "array-double", "array-embedded", "array-empty", "array-empty-nested", "array-nan", "array-null",
+				"array", "array-embedded", "array-empty", "array-null", "array-two",
 				"binary", "binary-empty",
 				"bool-false", "bool-true",
 				"datetime", "datetime-epoch", "datetime-year-max", "datetime-year-min",
@@ -1304,7 +1304,7 @@ func TestQueryComparisonIn(t *testing.T) {
 		"ForScalarDataTypes": {
 			value: scalarDataTypesFilter,
 			expectedIDs: []any{
-				"array", "array-embedded", "array-nan", "array-null", "array-three", "array-three-reverse",
+				"array", "array-embedded", "array-null", "array-three", "array-three-reverse", "array-two",
 				"binary", "binary-empty",
 				"bool-false", "bool-true",
 				"datetime", "datetime-epoch", "datetime-year-max", "datetime-year-min",
@@ -1322,7 +1322,7 @@ func TestQueryComparisonIn(t *testing.T) {
 		"ForCompositeDataTypes": {
 			value: compositeDataTypesFilter,
 			expectedIDs: []any{
-				"array", "array-double", "array-embedded", "array-empty", "array-empty-nested", "array-nan", "array-null", "array-three", "array-three-reverse",
+				"array", "array-embedded", "array-empty", "array-null", "array-three", "array-three-reverse", "array-two",
 				"document", "document-composite", "document-composite-reverse", "document-empty", "document-null",
 			},
 		},

--- a/integration/query_element_test.go
+++ b/integration/query_element_test.go
@@ -112,12 +112,12 @@ func TestQueryElementType(t *testing.T) {
 		},
 		"Array": {
 			v:           "array",
-			expectedIDs: []any{"array", "array-embedded", "array-empty", "array-null", "array-three", "array-three-reverse"},
+			expectedIDs: []any{"array", "array-double", "array-embedded", "array-empty", "array-empty-nested", "array-nan", "array-null", "array-three", "array-three-reverse"},
 		},
 		"Double": {
 			v: "double",
 			expectedIDs: []any{
-				"double", "double-big", "double-max", "double-nan",
+				"array-double", "array-nan", "double", "double-big", "double-max", "double-nan",
 				"double-negative-infinity", "double-negative-zero", "double-positive-infinity",
 				"double-smallest", "double-whole", "double-zero",
 			},
@@ -166,7 +166,7 @@ func TestQueryElementType(t *testing.T) {
 		"Number": {
 			v: "number",
 			expectedIDs: []any{
-				"array", "array-three", "array-three-reverse",
+				"array", "array-double", "array-nan", "array-three", "array-three-reverse",
 				"double", "double-big", "double-max", "double-nan",
 				"double-negative-infinity", "double-negative-zero",
 				"double-positive-infinity", "double-smallest",

--- a/integration/query_element_test.go
+++ b/integration/query_element_test.go
@@ -112,12 +112,12 @@ func TestQueryElementType(t *testing.T) {
 		},
 		"Array": {
 			v:           "array",
-			expectedIDs: []any{"array", "array-double", "array-embedded", "array-empty", "array-empty-nested", "array-nan", "array-null", "array-three", "array-three-reverse"},
+			expectedIDs: []any{"array", "array-embedded", "array-empty", "array-null", "array-three", "array-three-reverse", "array-two"},
 		},
 		"Double": {
 			v: "double",
 			expectedIDs: []any{
-				"array-double", "array-nan", "double", "double-big", "double-max", "double-nan",
+				"array-two", "double", "double-big", "double-max", "double-nan",
 				"double-negative-infinity", "double-negative-zero", "double-positive-infinity",
 				"double-smallest", "double-whole", "double-zero",
 			},
@@ -166,7 +166,7 @@ func TestQueryElementType(t *testing.T) {
 		"Number": {
 			v: "number",
 			expectedIDs: []any{
-				"array", "array-double", "array-nan", "array-three", "array-three-reverse",
+				"array", "array-three", "array-three-reverse", "array-two",
 				"double", "double-big", "double-max", "double-nan",
 				"double-negative-infinity", "double-negative-zero",
 				"double-positive-infinity", "double-smallest",

--- a/integration/query_logical_test.go
+++ b/integration/query_logical_test.go
@@ -279,7 +279,7 @@ func TestQueryLogicalNot(t *testing.T) {
 		"Not": {
 			filter: bson.D{{"value", bson.D{{"$not", bson.D{{"$eq", 42}}}}}},
 			expectedIDs: []any{
-				"array-embedded", "array-empty", "array-null",
+				"array-double", "array-embedded", "array-empty", "array-empty-nested", "array-nan", "array-null",
 				"binary", "binary-empty",
 				"bool-false", "bool-true",
 				"datetime", "datetime-epoch", "datetime-year-max", "datetime-year-min",
@@ -307,7 +307,7 @@ func TestQueryLogicalNot(t *testing.T) {
 		"NotEqNull": {
 			filter: bson.D{{"value", bson.D{{"$not", bson.D{{"$eq", nil}}}}}},
 			expectedIDs: []any{
-				"array", "array-empty",
+				"array", "array-double", "array-empty", "array-empty-nested", "array-nan",
 				"binary", "binary-empty",
 				"bool-false", "bool-true",
 				"datetime", "datetime-epoch", "datetime-year-max", "datetime-year-min",
@@ -325,7 +325,7 @@ func TestQueryLogicalNot(t *testing.T) {
 		"ValueRegex": {
 			filter: bson.D{{"value", bson.D{{"$not", primitive.Regex{Pattern: "^fo"}}}}},
 			expectedIDs: []any{
-				"array", "array-embedded", "array-empty", "array-null",
+				"array", "array-double", "array-embedded", "array-empty", "array-empty-nested", "array-nan", "array-null",
 				"binary", "binary-empty",
 				"bool-false", "bool-true",
 				"datetime", "datetime-epoch", "datetime-year-max", "datetime-year-min",
@@ -344,7 +344,7 @@ func TestQueryLogicalNot(t *testing.T) {
 		"NoSuchFieldRegex": {
 			filter: bson.D{{"no-such-field", bson.D{{"$not", primitive.Regex{Pattern: "/someregex/"}}}}},
 			expectedIDs: []any{
-				"array", "array-embedded", "array-empty", "array-null", "array-three", "array-three-reverse",
+				"array", "array-double", "array-embedded", "array-empty", "array-empty-nested", "array-nan", "array-null", "array-three", "array-three-reverse",
 				"binary", "binary-empty",
 				"bool-false", "bool-true",
 				"datetime", "datetime-epoch", "datetime-year-max", "datetime-year-min",

--- a/integration/query_logical_test.go
+++ b/integration/query_logical_test.go
@@ -279,7 +279,7 @@ func TestQueryLogicalNot(t *testing.T) {
 		"Not": {
 			filter: bson.D{{"value", bson.D{{"$not", bson.D{{"$eq", 42}}}}}},
 			expectedIDs: []any{
-				"array-double", "array-embedded", "array-empty", "array-empty-nested", "array-nan", "array-null",
+				"array-embedded", "array-empty", "array-null", "array-two",
 				"binary", "binary-empty",
 				"bool-false", "bool-true",
 				"datetime", "datetime-epoch", "datetime-year-max", "datetime-year-min",
@@ -307,7 +307,7 @@ func TestQueryLogicalNot(t *testing.T) {
 		"NotEqNull": {
 			filter: bson.D{{"value", bson.D{{"$not", bson.D{{"$eq", nil}}}}}},
 			expectedIDs: []any{
-				"array", "array-double", "array-empty", "array-empty-nested", "array-nan",
+				"array", "array-empty", "array-two",
 				"binary", "binary-empty",
 				"bool-false", "bool-true",
 				"datetime", "datetime-epoch", "datetime-year-max", "datetime-year-min",
@@ -325,7 +325,7 @@ func TestQueryLogicalNot(t *testing.T) {
 		"ValueRegex": {
 			filter: bson.D{{"value", bson.D{{"$not", primitive.Regex{Pattern: "^fo"}}}}},
 			expectedIDs: []any{
-				"array", "array-double", "array-embedded", "array-empty", "array-empty-nested", "array-nan", "array-null",
+				"array", "array-embedded", "array-empty", "array-null", "array-two",
 				"binary", "binary-empty",
 				"bool-false", "bool-true",
 				"datetime", "datetime-epoch", "datetime-year-max", "datetime-year-min",
@@ -344,7 +344,7 @@ func TestQueryLogicalNot(t *testing.T) {
 		"NoSuchFieldRegex": {
 			filter: bson.D{{"no-such-field", bson.D{{"$not", primitive.Regex{Pattern: "/someregex/"}}}}},
 			expectedIDs: []any{
-				"array", "array-double", "array-embedded", "array-empty", "array-empty-nested", "array-nan", "array-null", "array-three", "array-three-reverse",
+				"array", "array-embedded", "array-empty", "array-null", "array-three", "array-three-reverse", "array-two",
 				"binary", "binary-empty",
 				"bool-false", "bool-true",
 				"datetime", "datetime-epoch", "datetime-year-max", "datetime-year-min",

--- a/integration/query_test.go
+++ b/integration/query_test.go
@@ -318,7 +318,7 @@ func TestQueryCount(t *testing.T) {
 	}{
 		"CountAllDocuments": {
 			command:  bson.D{{"count", collection.Name()}},
-			response: 52,
+			response: 50,
 		},
 		"CountExactlyOneDocument": {
 			command: bson.D{
@@ -332,7 +332,7 @@ func TestQueryCount(t *testing.T) {
 				{"count", collection.Name()},
 				{"query", bson.D{{"value", bson.D{{"$type", "array"}}}}},
 			},
-			response: 9,
+			response: 7,
 		},
 		"CountNonExistingCollection": {
 			command: bson.D{

--- a/integration/query_test.go
+++ b/integration/query_test.go
@@ -318,7 +318,7 @@ func TestQueryCount(t *testing.T) {
 	}{
 		"CountAllDocuments": {
 			command:  bson.D{{"count", collection.Name()}},
-			response: 49,
+			response: 52,
 		},
 		"CountExactlyOneDocument": {
 			command: bson.D{
@@ -332,7 +332,7 @@ func TestQueryCount(t *testing.T) {
 				{"count", collection.Name()},
 				{"query", bson.D{{"value", bson.D{{"$type", "array"}}}}},
 			},
-			response: 6,
+			response: 9,
 		},
 		"CountNonExistingCollection": {
 			command: bson.D{

--- a/integration/shareddata/composites.go
+++ b/integration/shareddata/composites.go
@@ -38,7 +38,7 @@ var Composites = &Values[string]{
 		"array-embedded":      bson.A{bson.A{int32(42), "foo"}, nil},
 		"array-empty":         bson.A{},
 
-		// TODO: This case demonstrates some bugs.
+		// TODO: This case demonstrates a bug, see https://github.com/FerretDB/FerretDB/issues/732
 		// "array-empty-nested": bson.A{bson.A{}},
 
 		"array-null": bson.A{nil},

--- a/integration/shareddata/composites.go
+++ b/integration/shareddata/composites.go
@@ -32,7 +32,7 @@ var Composites = &Values[string]{
 		"document-empty":             bson.D{},
 
 		"array":               bson.A{int32(42)},
-		"array-two":           bson.A{42.42, math.NaN()},
+		"array-two":           bson.A{42.13, math.NaN()},
 		"array-three":         bson.A{int32(42), "foo", nil},
 		"array-three-reverse": bson.A{nil, "foo", int32(42)},
 		"array-embedded":      bson.A{bson.A{int32(42), "foo"}, nil},

--- a/integration/shareddata/composites.go
+++ b/integration/shareddata/composites.go
@@ -14,7 +14,11 @@
 
 package shareddata
 
-import "go.mongodb.org/mongo-driver/bson"
+import (
+	"math"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
 
 // Composites contain composite values for tests.
 //
@@ -28,10 +32,13 @@ var Composites = &Values[string]{
 		"document-empty":             bson.D{},
 
 		"array":               bson.A{int32(42)},
+		"array-double":        bson.A{42.42},
 		"array-three":         bson.A{int32(42), "foo", nil},
 		"array-three-reverse": bson.A{nil, "foo", int32(42)},
 		"array-embedded":      bson.A{bson.A{int32(42), "foo"}, nil},
 		"array-empty":         bson.A{},
+		"array-empty-nested":  bson.A{bson.A{}},
+		"array-nan":           bson.A{math.NaN()},
 		"array-null":          bson.A{nil},
 	},
 }

--- a/integration/shareddata/composites.go
+++ b/integration/shareddata/composites.go
@@ -32,13 +32,15 @@ var Composites = &Values[string]{
 		"document-empty":             bson.D{},
 
 		"array":               bson.A{int32(42)},
-		"array-double":        bson.A{42.42},
+		"array-two":           bson.A{42.42, math.NaN()},
 		"array-three":         bson.A{int32(42), "foo", nil},
 		"array-three-reverse": bson.A{nil, "foo", int32(42)},
 		"array-embedded":      bson.A{bson.A{int32(42), "foo"}, nil},
 		"array-empty":         bson.A{},
-		"array-empty-nested":  bson.A{bson.A{}},
-		"array-nan":           bson.A{math.NaN()},
-		"array-null":          bson.A{nil},
+
+		// TODO: This case demonstrates some bugs.
+		// "array-empty-nested": bson.A{bson.A{}},
+
+		"array-null": bson.A{nil},
 	},
 }

--- a/integration/shareddata/composites.go
+++ b/integration/shareddata/composites.go
@@ -37,10 +37,9 @@ var Composites = &Values[string]{
 		"array-three-reverse": bson.A{nil, "foo", int32(42)},
 		"array-embedded":      bson.A{bson.A{int32(42), "foo"}, nil},
 		"array-empty":         bson.A{},
+		"array-null":          bson.A{nil},
 
 		// TODO: This case demonstrates a bug, see https://github.com/FerretDB/FerretDB/issues/732
 		// "array-empty-nested": bson.A{bson.A{}},
-
-		"array-null": bson.A{nil},
 	},
 }


### PR DESCRIPTION
This PR provides additional examples for tests' shared data composites. 

These examples will help to cover more test cases. 
For example, they are helpful for #724.
Also, `array-empty-nested` reveals a bug described in #732.

### How to review?
- Take a look at the changes in `integration/shareddata/composites.go`.
- Take a look at the rest of the files. Various tests were rewritten to support new composites.