### PR TITLE
Fix fluky test

### DIFF
--- a/integration/commands_administration_test.go
+++ b/integration/commands_administration_test.go
@@ -792,7 +792,7 @@ func TestCommandsAdministrationServerStatus(t *testing.T) {
 	catalogStats, ok := must.NotFail(doc.Get("catalogStats")).(*types.Document)
 	assert.True(t, ok)
 
-	assert.InDelta(t, float64(1), must.NotFail(catalogStats.Get("collections")), 50)
+	assert.InDelta(t, float64(51), must.NotFail(catalogStats.Get("collections")), 50)
 	assert.InDelta(t, float64(3), must.NotFail(catalogStats.Get("internalCollections")), 3)
 
 	assert.Equal(t, int32(0), must.NotFail(catalogStats.Get("capped")))

--- a/integration/commands_administration_test.go
+++ b/integration/commands_administration_test.go
@@ -781,10 +781,10 @@ func TestCommandsAdministrationServerStatus(t *testing.T) {
 	assert.Regexp(t, `^5\.0\.`, must.NotFail(doc.Get("version")))
 	assert.NotEmpty(t, must.NotFail(doc.Get("process")))
 
-	assert.InDelta(t, float64(1), must.NotFail(doc.Get("pid")), 5_000_000)
-	assert.InDelta(t, float64(0), must.NotFail(doc.Get("uptime")), 600)
-	assert.InDelta(t, float64(0), must.NotFail(doc.Get("uptimeMillis")), 600_000)
-	assert.InDelta(t, float64(0), must.NotFail(doc.Get("uptimeEstimate")), 6000)
+	assert.GreaterOrEqual(t, must.NotFail(doc.Get("pid")), int64(1))
+	assert.GreaterOrEqual(t, must.NotFail(doc.Get("uptime")), float64(0))
+	assert.GreaterOrEqual(t, must.NotFail(doc.Get("uptimeMillis")), int64(0))
+	assert.GreaterOrEqual(t, must.NotFail(doc.Get("uptimeEstimate")), int64(0))
 
 	expectedLocalTime := ConvertDocument(t, bson.D{{"localTime", primitive.NewDateTimeFromTime(time.Now())}})
 	testutil.CompareAndSetByPathTime(t, expectedLocalTime, doc, time.Duration(2*time.Second), types.NewPathFromString("localTime"))


### PR DESCRIPTION
We run a lot of tests in parallel, so the number of collections is in the range between 1 (this test) and many, where "many" is 100 for now.
Uptime can also be as small as 0 seconds on a fast machine but can also be large if the environment wasn't restarted for a long time.

# Checklist

* [x] Tests are added for new functionality or fixed bugs.
* [x] `task all` passes.

See CONTRIBUTING.md for more details.