### PR TITLE
Drop `test_db`

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -47,7 +47,7 @@ tasks:
   env-setup:
     deps: [gen-version]
     cmds:
-      - go run ./cmd/envtool/main.go
+      - go run {{if ne OS "windows"}}-race{{end}} ./cmd/envtool/main.go
 
   env-up-detach:
     cmds:
@@ -90,13 +90,13 @@ tasks:
   test-unit-short:
     desc: "Run short unit tests"
     cmds:
-      - go test -short -count=1 {{if ne OS "windows"}} -race {{end}} -shuffle=on -coverprofile=cover.txt ./...
+      - go test -short -count=1 {{if ne OS "windows"}}-race{{end}} -shuffle=on -coverprofile=cover.txt ./...
 
   test-unit:
     desc: "Run all unit tests"
     cmds:
-      - go test -count=1 {{if ne OS "windows"}} -race {{end}} -shuffle=on -coverprofile=cover.txt -coverpkg=./... ./...
-      - go test -count=1 {{if ne OS "windows"}} -race {{end}} -shuffle=on -bench=. -benchtime=1x ./...
+      - go test -count=1 {{if ne OS "windows"}}-race{{end}} -shuffle=on -coverprofile=cover.txt -coverpkg=./... ./...
+      - go test -count=1 {{if ne OS "windows"}}-race{{end}} -shuffle=on -bench=. -benchtime=1x ./...
 
   test-integration:
     desc: "Run all integration tests in parallel"
@@ -121,7 +121,7 @@ tasks:
   test-integration-db:
     dir: integration
     cmds:
-      - go test -count=1 {{if ne OS "windows"}} -race {{end}} -shuffle=on -coverprofile=integration-{{.DB}}.txt -coverpkg=../... -port={{.DB}}
+      - go test -count=1 {{if ne OS "windows"}}-race{{end}} -shuffle=on -coverprofile=integration-{{.DB}}.txt -coverpkg=../... -port={{.DB}}
 
   bench-short:
     desc: "Benchmark for about 20 seconds (with default BENCHTIME)"
@@ -160,15 +160,15 @@ tasks:
   fuzz-corpus:
     desc: "Sync seed and generated fuzz corpora with FUZZCORPUS"
     cmds:
-      - go run ./cmd/fuzztool/fuzztool.go -dst={{.FUZZCORPUS}} -src=generated
-      - go run ./cmd/fuzztool/fuzztool.go -dst={{.FUZZCORPUS}} -src=seed
-      - go run ./cmd/fuzztool/fuzztool.go -src={{.FUZZCORPUS}} -dst=generated
+      - go run {{if ne OS "windows"}}-race{{end}} ./cmd/fuzztool/fuzztool.go -dst={{.FUZZCORPUS}} -src=generated
+      - go run {{if ne OS "windows"}}-race{{end}} ./cmd/fuzztool/fuzztool.go -dst={{.FUZZCORPUS}} -src=seed
+      - go run {{if ne OS "windows"}}-race{{end}} ./cmd/fuzztool/fuzztool.go -src={{.FUZZCORPUS}} -dst=generated
 
   build-testcover:
     desc: "Build bin/ferretdb-testcover"
     deps: [gen-version]
     cmds:
-      - go test -c -o=bin/ferretdb-testcover -trimpath -tags=testcover,tigris {{if ne OS "windows"}} -race {{end}} -coverpkg=./... ./cmd/ferretdb
+      - go test -c -o=bin/ferretdb-testcover -trimpath -tags=testcover,tigris {{if ne OS "windows"}}-race{{end}} -coverpkg=./... ./cmd/ferretdb
 
   run:
     desc: "Run FerretDB"
@@ -223,14 +223,14 @@ tasks:
     desc: "Run MongoDB shell (`mongosh`)"
     cmds:
       - >
-        docker-compose exec mongodb mongosh mongodb://host.docker.internal:27017/monila?heartbeatFrequencyMS=300000
+        docker-compose exec mongodb mongosh mongodb://host.docker.internal:27017/test?heartbeatFrequencyMS=300000
         --verbose --eval 'disableTelemetry()' --shell
 
   mongo:
     desc: "Run legacy `mongo` shell"
     cmds:
       - >
-        docker-compose exec mongodb mongo mongodb://host.docker.internal:27017/monila?heartbeatFrequencyMS=300000
+        docker-compose exec mongodb mongo mongodb://host.docker.internal:27017/test?heartbeatFrequencyMS=300000
         --verbose
 
   docker-init:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
       context: ./build/deps
       dockerfile: postgres.Dockerfile
     container_name: ferretdb_postgres
-    depends_on: [test_db]
     ports:
       - 5432:5432
     extra_hosts:
@@ -68,7 +67,6 @@ services:
       context: ./build/deps
       dockerfile: mongo.Dockerfile
     container_name: ferretdb_mongodb
-    depends_on: [test_db]
     command: --enableFreeMonitoring off
     ports:
       - 37017:27017
@@ -77,14 +75,6 @@ services:
     environment:
       # Always UTC+05:45. Set to catch timezone problems.
       - TZ=Asia/Kathmandu
-    volumes:
-      - test_db_mongodb:/test_db/:ro
-
-  test_db:
-    image: aleksi/test_db:mongodb-values
-    container_name: ferretdb_test_db
-    volumes:
-      - test_db_mongodb:/test_db/mongodb:ro
 
   markdownlint:
     build:
@@ -95,5 +85,4 @@ services:
       - .:/workdir
 
 volumes:
-  test_db_mongodb:
   tigrisdata:

--- a/integration/commands_administration_test.go
+++ b/integration/commands_administration_test.go
@@ -129,12 +129,12 @@ func TestCommandsAdministrationCreateDropListDatabases(t *testing.T) {
 
 	filter := bson.D{{
 		"name", bson.D{{
-			"$in", bson.A{"monila", "values", "admin", name},
+			"$in", bson.A{name, "admin"},
 		}},
 	}}
 	names, err := client.ListDatabaseNames(ctx, filter)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"admin", "monila", "values"}, names)
+	assert.Equal(t, []string{"admin"}, names)
 
 	actual, err := client.ListDatabases(ctx, filter)
 	require.NoError(t, err)
@@ -142,10 +142,6 @@ func TestCommandsAdministrationCreateDropListDatabases(t *testing.T) {
 	expectedBefore := mongo.ListDatabasesResult{
 		Databases: []mongo.DatabaseSpecification{{
 			Name: "admin",
-		}, {
-			Name: "monila",
-		}, {
-			Name: "values",
 		}},
 	}
 	assertDatabases(t, expectedBefore, actual)
@@ -161,11 +157,7 @@ func TestCommandsAdministrationCreateDropListDatabases(t *testing.T) {
 		Databases: []mongo.DatabaseSpecification{{
 			Name: "admin",
 		}, {
-			Name: "monila",
-		}, {
 			Name: name,
-		}, {
-			Name: "values",
 		}},
 	}
 	assertDatabases(t, expectedAfter, actual)

--- a/internal/handlers/pg/pgdb/pool_test.go
+++ b/internal/handlers/pg/pgdb/pool_test.go
@@ -55,38 +55,6 @@ func TestValidUTF8Locale(t *testing.T) {
 	}
 }
 
-func TestTables(t *testing.T) {
-	t.Parallel()
-
-	ctx := testutil.Ctx(t)
-	pool := testutil.Pool(ctx, t, nil, zaptest.NewLogger(t))
-
-	tables, err := pool.Tables(ctx, "monila")
-	require.NoError(t, err)
-
-	expectedTables := []string{
-		"actor",
-		"address",
-		"category",
-		"city",
-		"country",
-		"customer",
-		"film",
-		"film_actor",
-		"film_category",
-		"inventory",
-		"language",
-		"rental",
-		"staff",
-		"store",
-	}
-	assert.Equal(t, expectedTables, tables)
-
-	tables, err = pool.Tables(ctx, "pagila")
-	require.NoError(t, err)
-	assert.Empty(t, tables)
-}
-
 func TestCreateDrop(t *testing.T) {
 	t.Parallel()
 
@@ -107,7 +75,7 @@ func TestCreateDrop(t *testing.T) {
 		// - table drop is not possible
 		// - schema drop is not possible
 		// - table creation is not possible
-		// - shema creation is possible
+		// - schema creation is possible
 
 		err := pool.DropTable(ctx, schemaName, tableName)
 		require.Equal(t, pgdb.ErrNotExist, err)
@@ -120,6 +88,10 @@ func TestCreateDrop(t *testing.T) {
 
 		err = pool.CreateSchema(ctx, schemaName)
 		require.NoError(t, err)
+
+		tables, err := pool.Tables(ctx, schemaName)
+		require.NoError(t, err)
+		assert.Empty(t, tables)
 	})
 
 	t.Run("SchemaExistsTableDoesNotExist", func(t *testing.T) {
@@ -150,6 +122,10 @@ func TestCreateDrop(t *testing.T) {
 		err = pool.CreateTable(ctx, schemaName, tableName)
 		require.NoError(t, err)
 
+		tables, err := pool.Tables(ctx, schemaName)
+		require.NoError(t, err)
+		assert.Equal(t, []string{tableName}, tables)
+
 		err = pool.DropSchema(ctx, schemaName)
 		require.NoError(t, err)
 
@@ -172,6 +148,10 @@ func TestCreateDrop(t *testing.T) {
 
 		err = pool.CreateTable(ctx, schemaName, tableName)
 		require.NoError(t, err)
+
+		tables, err := pool.Tables(ctx, schemaName)
+		require.NoError(t, err)
+		assert.Equal(t, []string{tableName}, tables)
 
 		// Table exists ->
 		// - table creation is not possible


### PR DESCRIPTION
We are not using it much now, but it makes `task env-up` much slower.

# Checklist

* [x] Tests are added for new functionality or fixed bugs.
* [x] `task all` passes.

See CONTRIBUTING.md for more details.