### PR TITLE
Tweak schedule of daily builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,7 +41,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "42 4 * * *"
+    - cron: "42 2 * * *" # after Go workflow
 
 env:
   GOPATH: /home/runner/go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "42 2 * * *"
+    - cron: "12 2 * * *"
 
 env:
   GOPATH: /home/runner/go

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "42 3 * * *"
+    - cron: "12 3 * * *" # after Docker workflow
 
 env:
   GOPATH: /home/runner/go


### PR DESCRIPTION
Sync FerretDB's and dance's build times, so dance tests run after the new Docker image is built.

See FerretDB/dance#146.