### PR TITLE
Fix `task env-pull` target

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -71,7 +71,7 @@ tasks:
   env-pull:
     desc: "Pull development environment's Docker images"
     cmds:
-      - docker-compose pull --include-deps
+      - docker-compose build --pull
 
   env-down:
     desc: "Stop development environment"


### PR DESCRIPTION
After the switch from `image` to `build` in `docker-compose.yml`,
the previous command did nothing useful.
