### PR TITLE
Make it easier to trigger rebuilds

### DIFF
--- a/.github/workflows/conform-pr.yml
+++ b/.github/workflows/conform-pr.yml
@@ -23,7 +23,7 @@ on:
       # - unlocked
       # - review_requested
       # - review_request_removed
-      # - auto_merge_enabled
+      - auto_merge_enabled # if GitHub Actions stuck, re-enable auto merge to force rebuild
       # - auto_merge_disabled
 
 # Stop pending and in-progress jobs of this workflow.

--- a/.github/workflows/conform-pr.yml
+++ b/.github/workflows/conform-pr.yml
@@ -23,7 +23,7 @@ on:
       # - unlocked
       # - review_requested
       # - review_request_removed
-      - auto_merge_enabled # if GitHub Actions stuck, re-enable auto merge to force rebuild
+      - auto_merge_enabled # if GitHub Actions stuck, re-enable auto-merge to force rebuild
       # - auto_merge_disabled
 
 # Stop pending and in-progress jobs of this workflow.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,6 +37,7 @@ on:
       - opened
       - reopened
       - synchronize
+      - auto_merge_enabled # if GitHub Actions stuck, re-enable auto merge to force rebuild
   push:
     branches:
       - main

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,7 @@ on:
       - opened
       - reopened
       - synchronize
-      - auto_merge_enabled # if GitHub Actions stuck, re-enable auto merge to force rebuild
+      - auto_merge_enabled # if GitHub Actions stuck, re-enable auto-merge to force rebuild
   push:
     branches:
       - main

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ on:
       - opened
       - reopened
       - synchronize
-      - auto_merge_enabled # if GitHub Actions stuck, re-enable auto merge to force rebuild
+      - auto_merge_enabled # if GitHub Actions stuck, re-enable auto-merge to force rebuild
   push:
     branches:
       - main

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - reopened
       - synchronize
+      - auto_merge_enabled # if GitHub Actions stuck, re-enable auto merge to force rebuild
   push:
     branches:
       - main

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,7 +6,7 @@ on:
       - opened
       - reopened
       - synchronize
-      - auto_merge_enabled # if GitHub Actions stuck, re-enable auto merge to force rebuild
+      - auto_merge_enabled # if GitHub Actions stuck, re-enable auto-merge to force rebuild
   push:
     branches:
       - main

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - reopened
       - synchronize
+      - auto_merge_enabled # if GitHub Actions stuck, re-enable auto merge to force rebuild
   push:
     branches:
       - main


### PR DESCRIPTION
This makes it easier to solve problems like this one:

![image](https://user-images.githubusercontent.com/11512/176763482-5222cda5-5617-4daf-aaa5-70d713bda873.png)

![image](https://user-images.githubusercontent.com/11512/176763541-4064220b-acba-4e61-b375-4f18549ea2c4.png)

To trigger rebuild, re-enable auto-merge.