### PR TITLE
Add `ferretdb_` prefix to our custom build tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ ENV CGO_ENABLED=1
 
 # split into several commands for better logging on GitHub Actions
 RUN go mod download
-RUN go build -v -o=bin/ferretdb -trimpath -tags=testcover,tigris -race                 ./cmd/ferretdb
-RUN go test  -c -o=bin/ferretdb -trimpath -tags=testcover,tigris -race -coverpkg=./... ./cmd/ferretdb
+RUN go build -v -o=bin/ferretdb -trimpath -tags=ferretdb_testcover,ferretdb_tigris -race                 ./cmd/ferretdb
+RUN go test  -c -o=bin/ferretdb -trimpath -tags=ferretdb_testcover,ferretdb_tigris -race -coverpkg=./... ./cmd/ferretdb
 
 FROM golang:1.18.3
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -84,7 +84,7 @@ tasks:
     cmds:
       - go test -count=1 {{if ne OS "windows"}}-race{{end}} -run=TestEnvData . -port=37017
       - go test -count=1 {{if ne OS "windows"}}-race{{end}} -run=TestEnvData . -handler=pg
-      - go test -count=1 {{if ne OS "windows"}}-race{{end}} -run=TestEnvData -tags=tigris ./tigris -handler=tigris
+      - go test -count=1 {{if ne OS "windows"}}-race{{end}} -run=TestEnvData -tags=ferretdb_tigris ./tigris -handler=tigris
 
   gen:
     desc: "Generate (and format) code"
@@ -130,7 +130,7 @@ tasks:
     desc: "Run integration tests for Tigris handler"
     dir: integration/tigris
     cmds:
-      - go test -count=1 {{if ne OS "windows"}}-race{{end}} -tags=tigris -shuffle=on -coverprofile=integration-tigris.txt -coverpkg=../... -handler=tigris
+      - go test -count=1 {{if ne OS "windows"}}-race{{end}} -tags=ferretdb_tigris -shuffle=on -coverprofile=integration-tigris.txt -coverpkg=../... -handler=tigris
 
   test-integration-mongodb:
     desc: "Run integration tests for MongoDB"
@@ -183,7 +183,7 @@ tasks:
     desc: "Build bin/ferretdb-testcover"
     deps: [gen-version]
     cmds:
-      - go test -c -o=bin/ferretdb-testcover{{exeExt}} -trimpath -tags=testcover,tigris {{if ne OS "windows"}}-race{{end}} -coverpkg=./... ./cmd/ferretdb
+      - go test -c -o=bin/ferretdb-testcover{{exeExt}} -trimpath -tags=ferretdb_testcover,ferretdb_tigris {{if ne OS "windows"}}-race{{end}} -coverpkg=./... ./cmd/ferretdb
 
   run:
     desc: "Run FerretDB"

--- a/cmd/ferretdb/main_test.go
+++ b/cmd/ferretdb/main_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build testcover
+//go:build ferretdb_testcover
 
 package main
 

--- a/cmd/ferretdb/main_tigris.go
+++ b/cmd/ferretdb/main_tigris.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build tigris
+//go:build ferretdb_tigris
 
 package main
 
@@ -20,7 +20,7 @@ import (
 	"flag"
 )
 
-// init adds `tigris` handler flags when `tigris` build tag is provided.
+// init adds "tigris" handler flags when "ferretdb_tigris" build tag is provided.
 func init() {
 	flag.StringVar(&tigrisURL, "tigris-url", "127.0.0.1:8081", "Tigris URL")
 }

--- a/internal/handlers/registry/tigris.go
+++ b/internal/handlers/registry/tigris.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build tigris
+//go:build ferretdb_tigris
 
 package registry
 
@@ -21,7 +21,7 @@ import (
 	"github.com/FerretDB/FerretDB/internal/handlers/tigris"
 )
 
-// init registers `tigris` handler for Tigris when `tigris` build tag is provided.
+// init registers "tigris" handler for Tigris when "ferretdb_tigris" build tag is provided.
 func init() {
 	registry["tigris"] = func(opts *NewHandlerOpts) (handlers.Interface, error) {
 		handlerOpts := &tigris.NewOpts{

--- a/internal/util/version/version.go
+++ b/internal/util/version/version.go
@@ -43,7 +43,7 @@ type Info struct {
 	Commit           string
 	Branch           string
 	Dirty            bool
-	Debug            bool // testcover or -race
+	Debug            bool // -tags=ferretdb_testcover or -race
 	BuildEnvironment *types.Document
 }
 
@@ -124,7 +124,7 @@ func init() {
 				info.Debug = true
 			}
 		case "-tags":
-			if slices.Contains(strings.Split(s.Value, ","), "testcover") {
+			if slices.Contains(strings.Split(s.Value, ","), "ferretdb_testcover") {
 				info.Debug = true
 			}
 		}


### PR DESCRIPTION
To avoid possible conflicts.

## Readiness checklist

* [ ] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [x] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [x] I checked comments rendering with `task godocs`.
* [x] (for maintainers only) I set Reviewers, Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
