### PR TITLE
Fix edge cases in `drop` and `dropDatabase` handlers

### DIFF
--- a/integration/commands_administration_test.go
+++ b/integration/commands_administration_test.go
@@ -35,36 +35,29 @@ import (
 
 func TestCommandsAdministrationCreateDropList(t *testing.T) {
 	t.Parallel()
-	ctx, collection := Setup(t)
+	ctx, collection := Setup(t) // no providers there
 	db := collection.Database()
 	name := collection.Name()
 
 	names, err := db.ListCollectionNames(ctx, bson.D{})
 	require.NoError(t, err)
-	assert.Contains(t, names, name)
+	require.Empty(t, names, "setup should not create collection if no providers are given")
 
-	err = collection.Drop(ctx)
-	require.NoError(t, err)
-
-	// error is consumed by the driver
+	// drop non-existing collection in non-existing database; error is consumed by the driver
 	err = collection.Drop(ctx)
 	require.NoError(t, err)
 	err = db.Collection(name).Drop(ctx)
 	require.NoError(t, err)
 
 	// drop manually to check error
-	var actual bson.D
-	err = db.RunCommand(ctx, bson.D{{"drop", name}}).Decode(&actual)
+	var res bson.D
+	err = db.RunCommand(ctx, bson.D{{"drop", name}}).Decode(&res)
 	expectedErr := mongo.CommandError{
 		Code:    26,
 		Name:    "NamespaceNotFound",
 		Message: `ns not found`,
 	}
 	AssertEqualError(t, expectedErr, err)
-
-	names, err = db.ListCollectionNames(ctx, bson.D{})
-	require.NoError(t, err)
-	assert.NotContains(t, names, name)
 
 	err = db.CreateCollection(ctx, name)
 	require.NoError(t, err)
@@ -81,99 +74,62 @@ func TestCommandsAdministrationCreateDropList(t *testing.T) {
 	names, err = db.ListCollectionNames(ctx, bson.D{})
 	require.NoError(t, err)
 	assert.Contains(t, names, name)
-}
 
-// assertDatabases checks that expected and actual listDatabases results are similar.
-func assertDatabases(t *testing.T, expected, actual mongo.ListDatabasesResult) {
-	t.Helper()
+	// drop existing collection
+	err = collection.Drop(ctx)
+	require.NoError(t, err)
 
-	var sizeSum int64
-	assert.NotZero(t, actual.TotalSize)
-
-	require.Len(t, actual.Databases, len(expected.Databases), "%+v", actual)
-	for i, a := range actual.Databases {
-		e := expected.Databases[i]
-		require.Equal(t, e.Name, a.Name)
-
-		assert.Zero(t, e.SizeOnDisk)
-
-		if a.Empty {
-			assert.Zero(t, a.SizeOnDisk, "%+v", a)
-			continue
-		}
-
-		// to make comparison easier
-		assert.NotZero(t, a.SizeOnDisk, "%+v", a)
-		sizeSum += a.SizeOnDisk
-		actual.Databases[i].SizeOnDisk = 0
+	// drop manually to check error
+	err = db.RunCommand(ctx, bson.D{{"drop", name}}).Decode(&res)
+	expectedErr = mongo.CommandError{
+		Code:    26,
+		Name:    "NamespaceNotFound",
+		Message: `ns not found`,
 	}
-
-	// That's not true for PostgreSQL, where a sum of `pg_total_relation_size` result for all schemas
-	// is not equal to `pg_database_size` for the whole database.
-	// assert.Equal(t, sizeSum, actual.TotalSize)
-	actual.TotalSize = sizeSum
-
-	expected.TotalSize = sizeSum
-	assert.Equal(t, expected, actual)
+	AssertEqualError(t, expectedErr, err)
 }
 
-//nolint:paralleltest // we test a global list of databases
 func TestCommandsAdministrationCreateDropListDatabases(t *testing.T) {
-	ctx, collection, _ := SetupWithOpts(t, &SetupOpts{
-		DatabaseName: "admin",
-	})
-	client := collection.Database().Client()
-	name := collection.Name()
-
-	// drop remnants of the previous failed run
-	_ = client.Database(name).Drop(ctx)
+	t.Parallel()
+	ctx, collection := Setup(t) // no providers there
+	db := collection.Database()
+	name := db.Name()
 
 	filter := bson.D{{
 		"name", bson.D{{
-			"$in", bson.A{name, "admin"},
+			"$in", bson.A{name}, // skip admin, other tests databases, etc
 		}},
 	}}
-	names, err := client.ListDatabaseNames(ctx, filter)
+	names, err := db.Client().ListDatabaseNames(ctx, filter)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"admin"}, names)
+	require.Empty(t, names, "setup should not create database if no providers are given")
 
-	actual, err := client.ListDatabases(ctx, filter)
-	require.NoError(t, err)
-
-	expectedBefore := mongo.ListDatabasesResult{
-		Databases: []mongo.DatabaseSpecification{{
-			Name: "admin",
-		}},
-	}
-	assertDatabases(t, expectedBefore, actual)
-
-	// there is no explicit command to create database, so create collection instead
-	err = client.Database(name).CreateCollection(ctx, name)
-	require.NoError(t, err)
-
-	actual, err = client.ListDatabases(ctx, filter)
-	require.NoError(t, err)
-
-	expectedAfter := mongo.ListDatabasesResult{
-		Databases: []mongo.DatabaseSpecification{{
-			Name: "admin",
-		}, {
-			Name: name,
-		}},
-	}
-	assertDatabases(t, expectedAfter, actual)
-
-	err = client.Database(name).Drop(ctx)
+	// drop non-existing database; error is consumed by the driver
+	err = db.Drop(ctx)
 	require.NoError(t, err)
 
 	// drop manually to check error
 	var res bson.D
-	err = client.Database(name).RunCommand(ctx, bson.D{{"dropDatabase", 1}}).Decode(&res)
+	err = db.RunCommand(ctx, bson.D{{"dropDatabase", 1}}).Decode(&res)
+	require.NoError(t, err)
+	assert.Equal(t, bson.D{{"ok", 1.0}}, res)
+
+	// there is no explicit command to create database, so create collection instead
+	err = db.Client().Database(name).CreateCollection(ctx, testutil.CollectionName(t))
 	require.NoError(t, err)
 
-	actual, err = client.ListDatabases(ctx, filter)
+	names, err = db.Client().ListDatabaseNames(ctx, filter)
 	require.NoError(t, err)
-	assertDatabases(t, expectedBefore, actual)
+	assert.Equal(t, []string{name}, names)
+
+	// drop existing database
+	err = db.Drop(ctx)
+	require.NoError(t, err)
+
+	// drop manually to check error
+	err = db.RunCommand(ctx, bson.D{{"dropDatabase", 1}}).Decode(&res)
+	require.NoError(t, err)
+	assert.Equal(t, bson.D{{"ok", 1.0}}, res)
 }
 
 func TestCommandsAdministrationGetParameter(t *testing.T) {

--- a/integration/setup.go
+++ b/integration/setup.go
@@ -103,10 +103,6 @@ func SetupWithOpts(t *testing.T, opts *SetupOpts) (context.Context, *mongo.Colle
 		_ = db.Drop(ctx)
 	}
 
-	// create collection explicitly in case there are no docs to insert
-	err := db.CreateCollection(ctx, collectionName)
-	require.NoError(t, err)
-
 	// delete collection and (possibly) database unless test failed
 	t.Cleanup(func() {
 		if t.Failed() {
@@ -114,7 +110,7 @@ func SetupWithOpts(t *testing.T, opts *SetupOpts) (context.Context, *mongo.Colle
 			return
 		}
 
-		err = collection.Drop(ctx)
+		err := collection.Drop(ctx)
 		require.NoError(t, err)
 
 		if ownDatabase {

--- a/internal/clientconn/conn.go
+++ b/internal/clientconn/conn.go
@@ -86,9 +86,6 @@ func newConn(opts *newConnOpts) (*conn, error) {
 		panic("handler required")
 	}
 
-	prefix := fmt.Sprintf("// %s -> %s ", opts.netConn.RemoteAddr(), opts.netConn.LocalAddr())
-	l := opts.l.Named(prefix)
-
 	var p *proxy.Router
 	if opts.mode != NormalMode {
 		var err error
@@ -100,7 +97,7 @@ func newConn(opts *newConnOpts) (*conn, error) {
 	return &conn{
 		netConn: opts.netConn,
 		mode:    opts.mode,
-		l:       l.Sugar(),
+		l:       opts.l.Sugar(),
 		h:       opts.handler,
 		m:       opts.connMetrics,
 		proxy:   p,

--- a/internal/clientconn/listener.go
+++ b/internal/clientconn/listener.go
@@ -140,15 +140,17 @@ func (l *Listener) Run(ctx context.Context) error {
 			}
 			conn, e := newConn(opts)
 			if e != nil {
-				logger.Warn("Failed to create connection", zap.Error(e))
+				logger.Warn("Failed to create connection", zap.String("conn", connID), zap.Error(e))
 				return
 			}
 
+			logger.Info("Connection started", zap.String("conn", connID))
+
 			e = conn.run(runCtx)
 			if e == io.EOF {
-				logger.Info("Connection stopped")
+				logger.Info("Connection stopped", zap.String("conn", connID))
 			} else {
-				logger.Warn("Connection stopped", zap.Error(e))
+				logger.Warn("Connection stopped", zap.String("conn", connID), zap.Error(e))
 			}
 		}()
 	}

--- a/internal/handlers/pg/msg_drop.go
+++ b/internal/handlers/pg/msg_drop.go
@@ -46,10 +46,12 @@ func (h *Handler) MsgDrop(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, er
 	}
 
 	err = h.pgPool.DropCollection(ctx, db, collection)
-	if err != nil && !errors.Is(err, pgdb.ErrSchemaNotExist) {
-		if errors.Is(err, pgdb.ErrTableNotExist) {
-			return nil, common.NewErrorMsg(common.ErrNamespaceNotFound, "ns not found")
-		}
+	switch {
+	case err == nil:
+		// nothing
+	case errors.Is(err, pgdb.ErrSchemaNotExist), errors.Is(err, pgdb.ErrTableNotExist):
+		return nil, common.NewErrorMsg(common.ErrNamespaceNotFound, "ns not found")
+	default:
 		return nil, lazyerrors.Error(err)
 	}
 

--- a/internal/handlers/pg/msg_listcollections.go
+++ b/internal/handlers/pg/msg_listcollections.go
@@ -16,8 +16,10 @@ package pg
 
 import (
 	"context"
+	"errors"
 
 	"github.com/FerretDB/FerretDB/internal/handlers/common"
+	"github.com/FerretDB/FerretDB/internal/handlers/pg/pgdb"
 	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
 	"github.com/FerretDB/FerretDB/internal/util/must"
@@ -54,7 +56,7 @@ func (h *Handler) MsgListCollections(ctx context.Context, msg *wire.OpMsg) (*wir
 	}
 
 	names, err := h.pgPool.Collections(ctx, db)
-	if err != nil {
+	if err != nil && !errors.Is(err, pgdb.ErrSchemaNotExist) {
 		return nil, lazyerrors.Error(err)
 	}
 

--- a/internal/handlers/tigris/msg_insert.go
+++ b/internal/handlers/tigris/msg_insert.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"github.com/tigrisdata/tigris-client-go/driver"
-	"go.uber.org/zap"
 
 	"github.com/FerretDB/FerretDB/internal/handlers/common"
 	"github.com/FerretDB/FerretDB/internal/tjson"
@@ -89,7 +88,7 @@ func (h *Handler) insert(ctx context.Context, fp fetchParam, doc *types.Document
 	// TODO https://github.com/FerretDB/FerretDB/issues/787
 	err := h.driver.CreateDatabase(ctx, fp.db)
 	if err != nil {
-		h.L.Warn("CreateDatabase", zap.Error(err))
+		h.L.Sugar().Warnf("Failed to CreateDatabase: %+v", err)
 	}
 
 	schema, err := tjson.DocumentSchema(doc)
@@ -103,7 +102,7 @@ func (h *Handler) insert(ctx context.Context, fp fetchParam, doc *types.Document
 
 	err = h.driver.UseDatabase(fp.db).CreateOrUpdateCollection(ctx, fp.collection, b)
 	if err != nil {
-		h.L.Warn("CreateOrUpdateCollection", zap.Error(err))
+		h.L.Sugar().Warnf("Failed to CreateOrUpdateCollection: %+v", err)
 	}
 
 	b, err = tjson.Marshal(doc)


### PR DESCRIPTION
# Description

Errors are different when dropping non-existing collections in existing vs non-existing databases, etc.

## Readiness checklist

* [x] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] (for maintainers only) I set Reviewers, Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
