### PR TITLE
Wait for `Tigris` backend to be ready

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -48,7 +48,7 @@ tasks:
       - go mod verify
 
   init-clean:
-    desc: "Clean all caches and re-install development tools"
+    desc: "Clean all caches, including docker buildx and docker system volumes, and re-installs development tools"
     cmds:
       - docker buildx prune --all
       - docker system prune --all --volumes

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -48,7 +48,7 @@ tasks:
       - go mod verify
 
   init-clean:
-    desc: "Clean all caches, including docker buildx and docker system volumes, and re-installs development tools"
+    desc: "Clean all caches, including docker buildx and docker system volumes, and re-install development tools"
     cmds:
       - docker buildx prune --all
       - docker system prune --all --volumes

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -50,6 +50,8 @@ tasks:
   init-clean:
     desc: "Clean all caches and re-install development tools"
     cmds:
+      - docker buildx prune --all
+      - docker system prune --all --volumes
       - bin/golangci-lint cache clean
       - go clean -cache -testcache -modcache -fuzzcache
       - task: init

--- a/cmd/envtool/main.go
+++ b/cmd/envtool/main.go
@@ -109,7 +109,7 @@ func waitForTigrisPort(ctx context.Context, logger *zap.SugaredLogger, port uint
 	for ctx.Err() == nil {
 		driver, err := driver.NewDriver(ctx, cfg)
 		if err == nil {
-			_, err := driver.Info(ctx)
+			_, err = driver.Info(ctx)
 			driver.Close()
 			if err == nil {
 				return nil

--- a/cmd/envtool/main.go
+++ b/cmd/envtool/main.go
@@ -110,6 +110,7 @@ func waitForTigrisPort(ctx context.Context, logger *zap.SugaredLogger, port uint
 		driver, err := driver.NewDriver(ctx, cfg)
 		if err == nil {
 			if _, err := driver.Info(ctx); err == nil {
+				driver.Close()
 				return nil
 			}
 			driver.Close()

--- a/cmd/envtool/main.go
+++ b/cmd/envtool/main.go
@@ -105,16 +105,15 @@ func waitForTigrisPort(ctx context.Context, logger *zap.SugaredLogger, port uint
 	cfg := &config.Driver{
 		URL: fmt.Sprintf("127.0.0.1:%d", port),
 	}
-	driver, err := driver.NewDriver(ctx, cfg)
-	if err != nil {
-		return err
-	}
-	defer driver.Close()
 
 	for ctx.Err() == nil {
-		_, err := driver.Info(ctx)
+		driver, err := driver.NewDriver(ctx, cfg)
 		if err == nil {
-			return nil
+			_, err := driver.Info(ctx)
+			if err == nil {
+				return nil
+			}
+			driver.Close()
 		}
 
 		time.Sleep(time.Second)

--- a/cmd/envtool/main.go
+++ b/cmd/envtool/main.go
@@ -109,8 +109,7 @@ func waitForTigrisPort(ctx context.Context, logger *zap.SugaredLogger, port uint
 	for ctx.Err() == nil {
 		driver, err := driver.NewDriver(ctx, cfg)
 		if err == nil {
-			_, err := driver.Info(ctx)
-			if err == nil {
+			if _, err := driver.Info(ctx); err == nil {
 				return nil
 			}
 			driver.Close()

--- a/cmd/envtool/main.go
+++ b/cmd/envtool/main.go
@@ -109,11 +109,11 @@ func waitForTigrisPort(ctx context.Context, logger *zap.SugaredLogger, port uint
 	for ctx.Err() == nil {
 		driver, err := driver.NewDriver(ctx, cfg)
 		if err == nil {
-			if _, err := driver.Info(ctx); err == nil {
-				driver.Close()
+			_, err := driver.Info(ctx)
+			driver.Close()
+			if err == nil {
 				return nil
 			}
-			driver.Close()
 		}
 
 		time.Sleep(time.Second)


### PR DESCRIPTION
# Description

## This PR

* adds wait for Tigris backend in envtool.
* adds `docker buildx prune` in `init-clean`
* adds `docker system prune` including volume in `init-clean`

## About `docker system prune` and `docker buildx prune` 

It might seem too much for one.
If you don't want to prune all docker volumes, feel free to say `No` to that when it asks. 
Task continues to run without pruning docker volumes.


## Checklist:
* [ ] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [x] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [x] I checked comments rendering with `task godocs`.
* [x] (for maintainers only) I set Reviewers, Assignee, Labels, Project and project's Sprint fields.
* [ ] I marked all done items in this checklist.
