### PR TITLE
Extract parameter list into one variable in `QueryDocuments`

### DIFF
--- a/internal/handlers/pg/msg_count.go
+++ b/internal/handlers/pg/msg_count.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jackc/pgx/v4"
 
 	"github.com/FerretDB/FerretDB/internal/handlers/common"
+	"github.com/FerretDB/FerretDB/internal/handlers/pg/pgdb"
 	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
 	"github.com/FerretDB/FerretDB/internal/util/must"
@@ -60,8 +61,8 @@ func (h *Handler) MsgCount(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, e
 		}
 	}
 
-	var sp sqlParam
-	if sp.db, err = common.GetRequiredParam[string](document, "$db"); err != nil {
+	var sp pgdb.SQLParam
+	if sp.DB, err = common.GetRequiredParam[string](document, "$db"); err != nil {
 		return nil, err
 	}
 	collectionParam, err := document.Get(document.Command())
@@ -69,7 +70,7 @@ func (h *Handler) MsgCount(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, e
 		return nil, err
 	}
 	var ok bool
-	if sp.collection, ok = collectionParam.(string); !ok {
+	if sp.Collection, ok = collectionParam.(string); !ok {
 		return nil, common.NewErrorMsg(
 			common.ErrBadValue,
 			fmt.Sprintf("collection name has invalid type %s", common.AliasFromType(collectionParam)),
@@ -78,7 +79,7 @@ func (h *Handler) MsgCount(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, e
 
 	resDocs := make([]*types.Document, 0, 16)
 	err = h.pgPool.InTransaction(ctx, func(tx pgx.Tx) error {
-		fetchedChan, err := h.pgPool.QueryDocuments(ctx, tx, sp.db, sp.collection, sp.comment)
+		fetchedChan, err := h.pgPool.QueryDocuments(ctx, tx, sp)
 		if err != nil {
 			return err
 		}

--- a/internal/handlers/pg/msg_dbstats.go
+++ b/internal/handlers/pg/msg_dbstats.go
@@ -31,8 +31,8 @@ func (h *Handler) MsgDBStats(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg,
 		return nil, lazyerrors.Error(err)
 	}
 
-	var sp sqlParam
-	if sp.db, err = common.GetRequiredParam[string](document, "$db"); err != nil {
+	var db string
+	if db, err = common.GetRequiredParam[string](document, "$db"); err != nil {
 		return nil, err
 	}
 
@@ -42,7 +42,7 @@ func (h *Handler) MsgDBStats(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg,
 		scale = 1
 	}
 
-	stats, err := h.pgPool.SchemaStats(ctx, sp.db, "")
+	stats, err := h.pgPool.SchemaStats(ctx, db, "")
 	if err != nil {
 		return nil, lazyerrors.Error(err)
 	}
@@ -55,7 +55,7 @@ func (h *Handler) MsgDBStats(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg,
 	var reply wire.OpMsg
 	err = reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{must.NotFail(types.NewDocument(
-			"db", sp.db,
+			"db", db,
 			"collections", stats.CountTables,
 			// TODO https://github.com/FerretDB/FerretDB/issues/176
 			"views", int32(0),

--- a/internal/handlers/pg/msg_update.go
+++ b/internal/handlers/pg/msg_update.go
@@ -22,6 +22,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/FerretDB/FerretDB/internal/handlers/common"
+	"github.com/FerretDB/FerretDB/internal/handlers/pg/pgdb"
 	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
 	"github.com/FerretDB/FerretDB/internal/util/must"
@@ -40,8 +41,8 @@ func (h *Handler) MsgUpdate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 	}
 	common.Ignored(document, h.l, "ordered", "writeConcern", "bypassDocumentValidation", "comment")
 
-	var sp sqlParam
-	if sp.db, err = common.GetRequiredParam[string](document, "$db"); err != nil {
+	var sp pgdb.SQLParam
+	if sp.DB, err = common.GetRequiredParam[string](document, "$db"); err != nil {
 		return nil, err
 	}
 	collectionParam, err := document.Get(document.Command())
@@ -49,7 +50,7 @@ func (h *Handler) MsgUpdate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 		return nil, err
 	}
 	var ok bool
-	if sp.collection, ok = collectionParam.(string); !ok {
+	if sp.Collection, ok = collectionParam.(string); !ok {
 		return nil, common.NewErrorMsg(
 			common.ErrBadValue,
 			fmt.Sprintf("collection name has invalid type %s", common.AliasFromType(collectionParam)),
@@ -61,12 +62,12 @@ func (h *Handler) MsgUpdate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 		return nil, err
 	}
 
-	created, err := h.pgPool.CreateTableIfNotExist(ctx, sp.db, sp.collection)
+	created, err := h.pgPool.CreateTableIfNotExist(ctx, sp.DB, sp.Collection)
 	if err != nil {
 		return nil, err
 	}
 	if created {
-		h.l.Info("Created table.", zap.String("schema", sp.db), zap.String("table", sp.collection))
+		h.l.Info("Created table.", zap.String("schema", sp.DB), zap.String("table", sp.Collection))
 	}
 
 	var matched, modified int32
@@ -108,7 +109,7 @@ func (h *Handler) MsgUpdate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 
 		resDocs := make([]*types.Document, 0, 16)
 		err = h.pgPool.InTransaction(ctx, func(tx pgx.Tx) error {
-			fetchedChan, err := h.pgPool.QueryDocuments(ctx, tx, sp.db, sp.collection, sp.comment)
+			fetchedChan, err := h.pgPool.QueryDocuments(ctx, tx, sp)
 			if err != nil {
 				return err
 			}
@@ -213,10 +214,10 @@ func (h *Handler) MsgUpdate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 }
 
 // update updates documents by _id.
-func (h *Handler) update(ctx context.Context, sp sqlParam, doc *types.Document) (int64, error) {
+func (h *Handler) update(ctx context.Context, sp pgdb.SQLParam, doc *types.Document) (int64, error) {
 	id := must.NotFail(doc.Get("_id"))
 
-	rowsUpdated, err := h.pgPool.SetDocumentByID(ctx, sp.db, sp.collection, id, doc)
+	rowsUpdated, err := h.pgPool.SetDocumentByID(ctx, sp.DB, sp.Collection, id, doc)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/handlers/pg/pg.go
+++ b/internal/handlers/pg/pg.go
@@ -24,13 +24,6 @@ import (
 	"github.com/FerretDB/FerretDB/internal/handlers/pg/pgdb"
 )
 
-// sqlParam represents options/parameters used for sql query.
-type sqlParam struct {
-	db         string
-	collection string
-	comment    string
-}
-
 // Handler implements handlers.Interface on top of PostgreSQL.
 type Handler struct {
 	// TODO replace those fields with embedded *NewOpts to sync with Tigris handler

--- a/internal/handlers/pg/pgdb/query_documents.go
+++ b/internal/handlers/pg/pgdb/query_documents.go
@@ -43,6 +43,13 @@ type FetchedDocs struct {
 	Err  error
 }
 
+// SQLParam represents options/parameters used for sql query.
+type SQLParam struct {
+	DB         string
+	Collection string
+	Comment    string
+}
+
 // QueryDocuments returns a channel with buffer FetchedChannelBufSize
 // to fetch list of documents for given FerretDB database and collection.
 //
@@ -54,10 +61,12 @@ type FetchedDocs struct {
 // Context cancellation is not considered an error.
 //
 // If the collection doesn't exist, fetch returns a closed channel and no error.
-func (pgPool *Pool) QueryDocuments(
-	ctx context.Context, querier pgxtype.Querier, db, collection, comment string,
+func (pgPool *Pool) QueryDocuments(ctx context.Context, querier pgxtype.Querier, sp SQLParam,
 ) (<-chan FetchedDocs, error) {
 	fetchedChan := make(chan FetchedDocs, FetchedChannelBufSize)
+	db := sp.DB
+	collection := sp.Collection
+	comment := sp.Comment
 
 	// Special case: check if collection exists at all
 	collectionExists, err := CollectionExists(ctx, querier, db, collection)

--- a/internal/handlers/pg/pgdb/query_documents_test.go
+++ b/internal/handlers/pg/pgdb/query_documents_test.go
@@ -100,7 +100,8 @@ func TestQueryDocuments(t *testing.T) {
 				require.NoError(t, pgdb.InsertDocument(ctx, tx, dbName, tc.collection, doc))
 			}
 
-			fetchedChan, err := pool.QueryDocuments(ctx, tx, dbName, tc.collection, "")
+			sp := pgdb.SQLParam{DB: dbName, Collection: tc.collection}
+			fetchedChan, err := pool.QueryDocuments(ctx, tx, sp)
 			require.NoError(t, err)
 
 			iter := 0
@@ -131,8 +132,9 @@ func TestQueryDocuments(t *testing.T) {
 			))
 		}
 
+		sp := pgdb.SQLParam{DB: dbName, Collection: collectionName + "_cancel"}
 		ctx, cancel := context.WithCancel(context.Background())
-		fetchedChan, err := pool.QueryDocuments(ctx, pool, dbName, collectionName+"_cancel", "")
+		fetchedChan, err := pool.QueryDocuments(ctx, pool, sp)
 		cancel()
 		require.NoError(t, err)
 
@@ -156,7 +158,8 @@ func TestQueryDocuments(t *testing.T) {
 		tx, err := pool.Begin(ctx)
 		require.NoError(t, err)
 
-		fetchedChan, err := pool.QueryDocuments(context.Background(), tx, dbName, collectionName+"_non-existing", "")
+		sp := pgdb.SQLParam{DB: dbName, Collection: collectionName + "_non-existing"}
+		fetchedChan, err := pool.QueryDocuments(context.Background(), tx, sp)
 		require.NoError(t, err)
 		res, ok := <-fetchedChan
 		require.False(t, ok)


### PR DESCRIPTION
# Description

This PR is a part of #167.

Explain command will add yet another parameter to the `QueryDocuments`, so this PR gathers `QueryDocuments` parameters at one variable.

* [x] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [x] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [x] I checked comments rendering with `task godocs`.
* [x] (for maintainers only) I set Reviewers, Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
