### PR TITLE
Use `v` instead of `value` in tests

### DIFF
--- a/integration/findandmodify_test.go
+++ b/integration/findandmodify_test.go
@@ -45,7 +45,7 @@ func TestFindAndModifySimple(t *testing.T) {
 					"value",
 					bson.D{
 						{"_id", "binary"},
-						{"value", primitive.Binary{Subtype: 0x80, Data: []byte{42, 0, 13}}},
+						{"v", primitive.Binary{Subtype: 0x80, Data: []byte{42, 0, 13}}},
 					},
 				},
 				{"ok", float64(1)},
@@ -54,84 +54,84 @@ func TestFindAndModifySimple(t *testing.T) {
 		"NewDoubleNonZero": {
 			command: bson.D{
 				{"query", bson.D{{"_id", "double-smallest"}}},
-				{"update", bson.D{{"_id", "double-smallest"}, {"value", int32(43)}}},
+				{"update", bson.D{{"_id", "double-smallest"}, {"v", int32(43)}}},
 				{"new", float64(42)},
 			},
 			response: bson.D{
 				{"lastErrorObject", bson.D{{"n", int32(1)}, {"updatedExisting", true}}},
-				{"value", bson.D{{"_id", "double-smallest"}, {"value", int32(43)}}},
+				{"value", bson.D{{"_id", "double-smallest"}, {"v", int32(43)}}},
 				{"ok", float64(1)},
 			},
 		},
 		"NewDoubleZero": {
 			command: bson.D{
 				{"query", bson.D{{"_id", "double-zero"}}},
-				{"update", bson.D{{"_id", "double-zero"}, {"value", 43.0}}},
+				{"update", bson.D{{"_id", "double-zero"}, {"v", 43.0}}},
 				{"new", float64(0)},
 			},
 			response: bson.D{
 				{"lastErrorObject", bson.D{{"n", int32(1)}, {"updatedExisting", true}}},
-				{"value", bson.D{{"_id", "double-zero"}, {"value", 0.0}}},
+				{"value", bson.D{{"_id", "double-zero"}, {"v", 0.0}}},
 				{"ok", float64(1)},
 			},
 		},
 		"NewDoubleNaN": {
 			command: bson.D{
 				{"query", bson.D{{"_id", "double-zero"}}},
-				{"update", bson.D{{"_id", "double-zero"}, {"value", 43.0}}},
+				{"update", bson.D{{"_id", "double-zero"}, {"v", 43.0}}},
 				{"new", math.NaN()},
 			},
 			response: bson.D{
 				{"lastErrorObject", bson.D{{"n", int32(1)}, {"updatedExisting", true}}},
-				{"value", bson.D{{"_id", "double-zero"}, {"value", float64(43)}}},
+				{"value", bson.D{{"_id", "double-zero"}, {"v", float64(43)}}},
 				{"ok", float64(1)},
 			},
 		},
 		"NewIntNonZero": {
 			command: bson.D{
 				{"query", bson.D{{"_id", "int32"}}},
-				{"update", bson.D{{"_id", "int32"}, {"value", int32(43)}}},
+				{"update", bson.D{{"_id", "int32"}, {"v", int32(43)}}},
 				{"new", int32(11)},
 			},
 			response: bson.D{
 				{"lastErrorObject", bson.D{{"n", int32(1)}, {"updatedExisting", true}}},
-				{"value", bson.D{{"_id", "int32"}, {"value", int32(43)}}},
+				{"value", bson.D{{"_id", "int32"}, {"v", int32(43)}}},
 				{"ok", float64(1)},
 			},
 		},
 		"NewIntZero": {
 			command: bson.D{
 				{"query", bson.D{{"_id", "int32-zero"}}},
-				{"update", bson.D{{"_id", "int32-zero"}, {"value", int32(43)}}},
+				{"update", bson.D{{"_id", "int32-zero"}, {"v", int32(43)}}},
 				{"new", int32(0)},
 			},
 			response: bson.D{
 				{"lastErrorObject", bson.D{{"n", int32(1)}, {"updatedExisting", true}}},
-				{"value", bson.D{{"_id", "int32-zero"}, {"value", int32(0)}}},
+				{"value", bson.D{{"_id", "int32-zero"}, {"v", int32(0)}}},
 				{"ok", float64(1)},
 			},
 		},
 		"NewLongNonZero": {
 			command: bson.D{
 				{"query", bson.D{{"_id", "int64"}}},
-				{"update", bson.D{{"_id", "int64"}, {"value", int64(43)}}},
+				{"update", bson.D{{"_id", "int64"}, {"v", int64(43)}}},
 				{"new", int64(11)},
 			},
 			response: bson.D{
 				{"lastErrorObject", bson.D{{"n", int32(1)}, {"updatedExisting", true}}},
-				{"value", bson.D{{"_id", "int64"}, {"value", int64(43)}}},
+				{"value", bson.D{{"_id", "int64"}, {"v", int64(43)}}},
 				{"ok", float64(1)},
 			},
 		},
 		"NewLongZero": {
 			command: bson.D{
 				{"query", bson.D{{"_id", "int64-zero"}}},
-				{"update", bson.D{{"_id", "int64-zero"}, {"value", int64(43)}}},
+				{"update", bson.D{{"_id", "int64-zero"}, {"v", int64(43)}}},
 				{"new", int64(0)},
 			},
 			response: bson.D{
 				{"lastErrorObject", bson.D{{"n", int32(1)}, {"updatedExisting", true}}},
-				{"value", bson.D{{"_id", "int64-zero"}, {"value", int64(0)}}},
+				{"value", bson.D{{"_id", "int64-zero"}, {"v", int64(0)}}},
 				{"ok", float64(1)},
 			},
 		},
@@ -319,44 +319,44 @@ func TestFindAndModifyUpdate(t *testing.T) {
 		"Replace": {
 			query: bson.D{{"_id", "int64"}},
 			command: bson.D{
-				{"update", bson.D{{"_id", "int64"}, {"value", int64(43)}}},
+				{"update", bson.D{{"_id", "int64"}, {"v", int64(43)}}},
 			},
-			update: bson.D{{"_id", "int64"}, {"value", int64(43)}},
+			update: bson.D{{"_id", "int64"}, {"v", int64(43)}},
 			response: bson.D{
 				{"lastErrorObject", bson.D{{"n", int32(1)}, {"updatedExisting", true}}},
-				{"value", bson.D{{"_id", "int64"}, {"value", int64(42)}}},
+				{"value", bson.D{{"_id", "int64"}, {"v", int64(42)}}},
 				{"ok", float64(1)},
 			},
 		},
 		"ReplaceWithoutID": {
 			query: bson.D{{"_id", "int64"}},
 			command: bson.D{
-				{"update", bson.D{{"value", int64(43)}}},
+				{"update", bson.D{{"v", int64(43)}}},
 			},
-			update: bson.D{{"_id", "int64"}, {"value", int64(43)}},
+			update: bson.D{{"_id", "int64"}, {"v", int64(43)}},
 			response: bson.D{
 				{"lastErrorObject", bson.D{{"n", int32(1)}, {"updatedExisting", true}}},
-				{"value", bson.D{{"_id", "int64"}, {"value", int64(42)}}},
+				{"value", bson.D{{"_id", "int64"}, {"v", int64(42)}}},
 				{"ok", float64(1)},
 			},
 		},
 		"ReplaceReturnNew": {
 			query: bson.D{{"_id", "int32"}},
 			command: bson.D{
-				{"update", bson.D{{"_id", "int32"}, {"value", int32(43)}}},
+				{"update", bson.D{{"_id", "int32"}, {"v", int32(43)}}},
 				{"new", true},
 			},
-			update: bson.D{{"_id", "int32"}, {"value", int32(43)}},
+			update: bson.D{{"_id", "int32"}, {"v", int32(43)}},
 			response: bson.D{
 				{"lastErrorObject", bson.D{{"n", int32(1)}, {"updatedExisting", true}}},
-				{"value", bson.D{{"_id", "int32"}, {"value", int32(43)}}},
+				{"value", bson.D{{"_id", "int32"}, {"v", int32(43)}}},
 				{"ok", float64(1)},
 			},
 		},
 		"UpdateNotExistedIdInQuery": {
 			query: bson.D{{"_id", "no-such-id"}},
 			command: bson.D{
-				{"update", bson.D{{"value", int32(43)}}},
+				{"update", bson.D{{"v", int32(43)}}},
 			},
 			response: bson.D{
 				{"lastErrorObject", bson.D{{"n", int32(0)}, {"updatedExisting", false}}},
@@ -365,11 +365,11 @@ func TestFindAndModifyUpdate(t *testing.T) {
 		},
 		"UpdateNotExistedIdNotInQuery": {
 			query: bson.D{{"$and", bson.A{
-				bson.D{{"value", bson.D{{"$gt", 0}}}},
-				bson.D{{"value", bson.D{{"$lt", 0}}}},
+				bson.D{{"v", bson.D{{"$gt", 0}}}},
+				bson.D{{"v", bson.D{{"$lt", 0}}}},
 			}}},
 			command: bson.D{
-				{"update", bson.D{{"value", int32(43)}}},
+				{"update", bson.D{{"v", int32(43)}}},
 			},
 			response: bson.D{
 				{"lastErrorObject", bson.D{{"n", int32(0)}, {"updatedExisting", false}}},
@@ -379,25 +379,25 @@ func TestFindAndModifyUpdate(t *testing.T) {
 		"UpdateOperatorSet": {
 			query: bson.D{{"_id", "int64"}},
 			command: bson.D{
-				{"update", bson.D{{"$set", bson.D{{"value", int64(43)}}}}},
+				{"update", bson.D{{"$set", bson.D{{"v", int64(43)}}}}},
 			},
-			update: bson.D{{"_id", "int64"}, {"value", int64(43)}},
+			update: bson.D{{"_id", "int64"}, {"v", int64(43)}},
 			response: bson.D{
 				{"lastErrorObject", bson.D{{"n", int32(1)}, {"updatedExisting", true}}},
-				{"value", bson.D{{"_id", "int64"}, {"value", int64(42)}}},
+				{"value", bson.D{{"_id", "int64"}, {"v", int64(42)}}},
 				{"ok", float64(1)},
 			},
 		},
 		"UpdateOperatorSetReturnNew": {
 			query: bson.D{{"_id", "int64"}},
 			command: bson.D{
-				{"update", bson.D{{"$set", bson.D{{"value", int64(43)}}}}},
+				{"update", bson.D{{"$set", bson.D{{"v", int64(43)}}}}},
 				{"new", true},
 			},
-			update: bson.D{{"_id", "int64"}, {"value", int64(43)}},
+			update: bson.D{{"_id", "int64"}, {"v", int64(43)}},
 			response: bson.D{
 				{"lastErrorObject", bson.D{{"n", int32(1)}, {"updatedExisting", true}}},
-				{"value", bson.D{{"_id", "int64"}, {"value", int64(43)}}},
+				{"value", bson.D{{"_id", "int64"}, {"v", int64(43)}}},
 				{"ok", float64(1)},
 			},
 		},
@@ -447,7 +447,7 @@ func TestFindAndModifyUpsert(t *testing.T) {
 		"Upsert": {
 			command: bson.D{
 				{"query", bson.D{{"_id", "double"}}},
-				{"update", bson.D{{"$set", bson.D{{"value", 43.13}}}}},
+				{"update", bson.D{{"$set", bson.D{{"v", 43.13}}}}},
 				{"upsert", true},
 			},
 			response: bson.D{
@@ -455,14 +455,14 @@ func TestFindAndModifyUpsert(t *testing.T) {
 					{"n", int32(1)},
 					{"updatedExisting", true},
 				}},
-				{"value", bson.D{{"_id", "double"}, {"value", 42.13}}},
+				{"value", bson.D{{"_id", "double"}, {"v", 42.13}}},
 				{"ok", float64(1)},
 			},
 		},
 		"UpsertNew": {
 			command: bson.D{
 				{"query", bson.D{{"_id", "double"}}},
-				{"update", bson.D{{"$set", bson.D{{"value", 43.13}}}}},
+				{"update", bson.D{{"$set", bson.D{{"v", 43.13}}}}},
 				{"upsert", true},
 				{"new", true},
 			},
@@ -471,14 +471,14 @@ func TestFindAndModifyUpsert(t *testing.T) {
 					{"n", int32(1)},
 					{"updatedExisting", true},
 				}},
-				{"value", bson.D{{"_id", "double"}, {"value", 43.13}}},
+				{"value", bson.D{{"_id", "double"}, {"v", 43.13}}},
 				{"ok", float64(1)},
 			},
 		},
 		"UpsertNoSuchDocument": {
 			command: bson.D{
 				{"query", bson.D{{"_id", "no-such-doc"}}},
-				{"update", bson.D{{"$set", bson.D{{"value", 43.13}}}}},
+				{"update", bson.D{{"$set", bson.D{{"v", 43.13}}}}},
 				{"upsert", true},
 				{"new", true},
 			},
@@ -488,14 +488,14 @@ func TestFindAndModifyUpsert(t *testing.T) {
 					{"updatedExisting", false},
 					{"upserted", "no-such-doc"},
 				}},
-				{"value", bson.D{{"_id", "no-such-doc"}, {"value", 43.13}}},
+				{"value", bson.D{{"_id", "no-such-doc"}, {"v", 43.13}}},
 				{"ok", float64(1)},
 			},
 		},
 		"UpsertNoSuchReplaceDocument": {
 			command: bson.D{
 				{"query", bson.D{{"_id", "no-such-doc"}}},
-				{"update", bson.D{{"value", 43.13}}},
+				{"update", bson.D{{"v", 43.13}}},
 				{"upsert", true},
 				{"new", true},
 			},
@@ -505,14 +505,14 @@ func TestFindAndModifyUpsert(t *testing.T) {
 					{"updatedExisting", false},
 					{"upserted", "no-such-doc"},
 				}},
-				{"value", bson.D{{"_id", "no-such-doc"}, {"value", 43.13}}},
+				{"value", bson.D{{"_id", "no-such-doc"}, {"v", 43.13}}},
 				{"ok", float64(1)},
 			},
 		},
 		"UpsertReplace": {
 			command: bson.D{
 				{"query", bson.D{{"_id", "double"}}},
-				{"update", bson.D{{"value", 43.13}}},
+				{"update", bson.D{{"v", 43.13}}},
 				{"upsert", true},
 			},
 			response: bson.D{
@@ -520,14 +520,14 @@ func TestFindAndModifyUpsert(t *testing.T) {
 					{"n", int32(1)},
 					{"updatedExisting", true},
 				}},
-				{"value", bson.D{{"_id", "double"}, {"value", 42.13}}},
+				{"value", bson.D{{"_id", "double"}, {"v", 42.13}}},
 				{"ok", float64(1)},
 			},
 		},
 		"UpsertReplaceReturnNew": {
 			command: bson.D{
 				{"query", bson.D{{"_id", "double"}}},
-				{"update", bson.D{{"value", 43.13}}},
+				{"update", bson.D{{"v", 43.13}}},
 				{"upsert", true},
 				{"new", true},
 			},
@@ -536,7 +536,7 @@ func TestFindAndModifyUpsert(t *testing.T) {
 					{"n", int32(1)},
 					{"updatedExisting", true},
 				}},
-				{"value", bson.D{{"_id", "double"}, {"value", 43.13}}},
+				{"value", bson.D{{"_id", "double"}, {"v", 43.13}}},
 				{"ok", float64(1)},
 			},
 		},
@@ -566,18 +566,17 @@ func TestFindAndModifyUpsertComplex(t *testing.T) {
 	for name, tc := range map[string]struct {
 		command         bson.D
 		lastErrorObject bson.D
-		value           bson.D
 	}{
 		"UpsertNoSuchDocumentNoIdInQuery": {
 			command: bson.D{
 				{"query", bson.D{{
 					"$and",
 					bson.A{
-						bson.D{{"value", bson.D{{"$gt", 0}}}},
-						bson.D{{"value", bson.D{{"$lt", 0}}}},
+						bson.D{{"v", bson.D{{"$gt", 0}}}},
+						bson.D{{"v", bson.D{{"$lt", 0}}}},
 					},
 				}}},
-				{"update", bson.D{{"$set", bson.D{{"value", 43.13}}}}},
+				{"update", bson.D{{"$set", bson.D{{"v", 43.13}}}}},
 				{"upsert", true},
 			},
 			lastErrorObject: bson.D{
@@ -631,7 +630,7 @@ func TestFindAndModifyRemove(t *testing.T) {
 				{"lastErrorObject", bson.D{
 					{"n", int32(1)},
 				}},
-				{"value", bson.D{{"_id", "double"}, {"value", 42.13}}},
+				{"value", bson.D{{"_id", "double"}, {"v", 42.13}}},
 				{"ok", float64(1)},
 			},
 		},
@@ -642,8 +641,8 @@ func TestFindAndModifyRemove(t *testing.T) {
 					bson.D{{
 						"$and",
 						bson.A{
-							bson.D{{"value", bson.D{{"$gt", 0}}}},
-							bson.D{{"value", bson.D{{"$lt", 0}}}},
+							bson.D{{"v", bson.D{{"$gt", 0}}}},
+							bson.D{{"v", bson.D{{"$lt", 0}}}},
 						},
 					}},
 				},

--- a/integration/query_array_test.go
+++ b/integration/query_array_test.go
@@ -33,12 +33,12 @@ func TestQueryArraySize(t *testing.T) {
 	ctx, collection := Setup(t)
 
 	_, err := collection.InsertMany(ctx, []any{
-		bson.D{{"_id", "array-empty"}, {"value", bson.A{}}},
-		bson.D{{"_id", "array-one"}, {"value", bson.A{"1"}}},
-		bson.D{{"_id", "array-two"}, {"value", bson.A{"1", nil}}},
-		bson.D{{"_id", "array-three"}, {"value", bson.A{"1", "2", math.NaN()}}},
-		bson.D{{"_id", "string"}, {"value", "12"}},
-		bson.D{{"_id", "document"}, {"value", bson.D{{"value", bson.A{"1", "2"}}}}},
+		bson.D{{"_id", "array-empty"}, {"v", bson.A{}}},
+		bson.D{{"_id", "array-one"}, {"v", bson.A{"1"}}},
+		bson.D{{"_id", "array-two"}, {"v", bson.A{"1", nil}}},
+		bson.D{{"_id", "array-three"}, {"v", bson.A{"1", "2", math.NaN()}}},
+		bson.D{{"_id", "string"}, {"v", "12"}},
+		bson.D{{"_id", "document"}, {"v", bson.D{{"v", bson.A{"1", "2"}}}}},
 	})
 	require.NoError(t, err)
 
@@ -48,31 +48,31 @@ func TestQueryArraySize(t *testing.T) {
 		err         *mongo.CommandError
 	}{
 		"int32": {
-			filter:      bson.D{{"value", bson.D{{"$size", int32(2)}}}},
+			filter:      bson.D{{"v", bson.D{{"$size", int32(2)}}}},
 			expectedIDs: []any{"array-two"},
 		},
 		"int64": {
-			filter:      bson.D{{"value", bson.D{{"$size", int64(2)}}}},
+			filter:      bson.D{{"v", bson.D{{"$size", int64(2)}}}},
 			expectedIDs: []any{"array-two"},
 		},
 		"float64": {
-			filter:      bson.D{{"value", bson.D{{"$size", float64(2)}}}},
+			filter:      bson.D{{"v", bson.D{{"$size", float64(2)}}}},
 			expectedIDs: []any{"array-two"},
 		},
 		"Zero": {
-			filter:      bson.D{{"value", bson.D{{"$size", 0}}}},
+			filter:      bson.D{{"v", bson.D{{"$size", 0}}}},
 			expectedIDs: []any{"array-empty"},
 		},
 		"NegativeZero": {
-			filter:      bson.D{{"value", bson.D{{"$size", math.Copysign(0, -1)}}}},
+			filter:      bson.D{{"v", bson.D{{"$size", math.Copysign(0, -1)}}}},
 			expectedIDs: []any{"array-empty"},
 		},
 		"NotFound": {
-			filter:      bson.D{{"value", bson.D{{"$size", 4}}}},
+			filter:      bson.D{{"v", bson.D{{"$size", 4}}}},
 			expectedIDs: []any{},
 		},
 		"InvalidType": {
-			filter: bson.D{{"value", bson.D{{"$size", bson.D{{"$gt", 1}}}}}},
+			filter: bson.D{{"v", bson.D{{"$size", bson.D{{"$gt", 1}}}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
@@ -80,7 +80,7 @@ func TestQueryArraySize(t *testing.T) {
 			},
 		},
 		"NotWhole": {
-			filter: bson.D{{"value", bson.D{{"$size", 2.1}}}},
+			filter: bson.D{{"v", bson.D{{"$size", 2.1}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
@@ -88,7 +88,7 @@ func TestQueryArraySize(t *testing.T) {
 			},
 		},
 		"NaN": {
-			filter: bson.D{{"value", bson.D{{"$size", math.NaN()}}}},
+			filter: bson.D{{"v", bson.D{{"$size", math.NaN()}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
@@ -96,7 +96,7 @@ func TestQueryArraySize(t *testing.T) {
 			},
 		},
 		"Infinity": {
-			filter: bson.D{{"value", bson.D{{"$size", math.Inf(+1)}}}},
+			filter: bson.D{{"v", bson.D{{"$size", math.Inf(+1)}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
@@ -104,7 +104,7 @@ func TestQueryArraySize(t *testing.T) {
 			},
 		},
 		"Negative": {
-			filter: bson.D{{"value", bson.D{{"$size", -1}}}},
+			filter: bson.D{{"v", bson.D{{"$size", -1}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
@@ -151,62 +151,62 @@ func TestQueryArrayDotNotation(t *testing.T) {
 		err         *mongo.CommandError
 	}{
 		"PositionIndexGreaterThanArrayLength": {
-			filter:      bson.D{{"value.5", bson.D{{"$type", "double"}}}},
+			filter:      bson.D{{"v.5", bson.D{{"$type", "double"}}}},
 			expectedIDs: []any{},
 		},
 		"PositionIndexAtTheEndOfArray": {
-			filter:      bson.D{{"value.1", bson.D{{"$type", "double"}}}},
+			filter:      bson.D{{"v.1", bson.D{{"$type", "double"}}}},
 			expectedIDs: []any{"array-two"},
 		},
 
 		"PositionTypeNull": {
-			filter:      bson.D{{"value.0", bson.D{{"$type", "null"}}}},
+			filter:      bson.D{{"v.0", bson.D{{"$type", "null"}}}},
 			expectedIDs: []any{"array-last-embedded", "array-middle-embedded", "array-null", "array-three-reverse"},
 		},
 		"PositionRegex": {
-			filter:      bson.D{{"value.1", primitive.Regex{Pattern: "foo"}}},
+			filter:      bson.D{{"v.1", primitive.Regex{Pattern: "foo"}}},
 			expectedIDs: []any{"array-three", "array-three-reverse"},
 		},
 		"PositionArray": {
-			filter:      bson.D{{"value.0", bson.A{"42", "foo"}}},
+			filter:      bson.D{{"v.0", bson.A{"42", "foo"}}},
 			expectedIDs: []any{"array-embedded"},
 		},
 		"PositionArrayEmpty": {
-			filter:      bson.D{{"value.0", bson.A{}}},
+			filter:      bson.D{{"v.0", bson.A{}}},
 			expectedIDs: []any{"array-empty-nested"},
 		},
 
 		"NoSuchFieldPosition": {
-			filter:      bson.D{{"value.some.0", bson.A{42}}},
+			filter:      bson.D{{"v.some.0", bson.A{42}}},
 			expectedIDs: []any{},
 		},
 		"Field": {
-			filter:      bson.D{{"value.array", int32(42)}},
+			filter:      bson.D{{"v.array", int32(42)}},
 			expectedIDs: []any{"document-composite", "document-composite-reverse"},
 		},
 		"FieldPosition": {
-			filter:      bson.D{{"value.array.0", int32(42)}},
+			filter:      bson.D{{"v.array.0", int32(42)}},
 			expectedIDs: []any{"document-composite", "document-composite-reverse"},
 		},
 		"FieldPositionQuery": {
-			filter:      bson.D{{"value.array.0", bson.D{{"$gte", int32(42)}}}},
+			filter:      bson.D{{"v.array.0", bson.D{{"$gte", int32(42)}}}},
 			expectedIDs: []any{"document-composite", "document-composite-reverse"},
 		},
 		"FieldPositionQueryNonArray": {
-			filter:      bson.D{{"value.document.0", bson.D{{"$lt", int32(42)}}}},
+			filter:      bson.D{{"v.document.0", bson.D{{"$lt", int32(42)}}}},
 			expectedIDs: []any{},
 		},
 		"FieldPositionField": {
-			filter:      bson.D{{"value.array.2.foo", "bar"}},
+			filter:      bson.D{{"v.array.2.foo", "bar"}},
 			expectedIDs: []any{},
 		},
 
 		"FieldPositionQueryRegex": {
-			filter: bson.D{{"value.array.0", bson.D{{"$lt", primitive.Regex{Pattern: "^$"}}}}},
+			filter: bson.D{{"v.array.0", bson.D{{"$lt", primitive.Regex{Pattern: "^$"}}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
-				Message: "Can't have RegEx as arg to predicate over field 'value.array.0'.",
+				Message: "Can't have RegEx as arg to predicate over field 'v.array.0'.",
 			},
 		},
 	} {
@@ -242,17 +242,17 @@ func TestQueryElemMatchOperator(t *testing.T) {
 		"DoubleTarget": {
 			filter: bson.D{
 				{"_id", "double"},
-				{"value", bson.D{{"$elemMatch", bson.D{{"$gt", int32(0)}}}}},
+				{"v", bson.D{{"$elemMatch", bson.D{{"$gt", int32(0)}}}}},
 			},
 			expectedIDs: []any{},
 		},
 		"GtZero": {
-			filter:      bson.D{{"value", bson.D{{"$elemMatch", bson.D{{"$gt", int32(0)}}}}}},
+			filter:      bson.D{{"v", bson.D{{"$elemMatch", bson.D{{"$gt", int32(0)}}}}}},
 			expectedIDs: []any{"array", "array-three", "array-three-reverse", "array-two"},
 		},
 		"GtZeroWithTypeArray": {
 			filter: bson.D{
-				{"value", bson.D{
+				{"v", bson.D{
 					{"$elemMatch", bson.D{
 						{"$gt", int32(0)},
 					}},
@@ -263,7 +263,7 @@ func TestQueryElemMatchOperator(t *testing.T) {
 		},
 		"GtZeroWithTypeString": {
 			filter: bson.D{
-				{"value", bson.D{
+				{"v", bson.D{
 					{"$elemMatch", bson.D{
 						{"$gt", int32(0)},
 					}},
@@ -274,7 +274,7 @@ func TestQueryElemMatchOperator(t *testing.T) {
 		},
 		"GtLt": {
 			filter: bson.D{
-				{"value", bson.D{
+				{"v", bson.D{
 					{"$elemMatch", bson.D{
 						{"$gt", int32(0)},
 						{"$lt", int32(43)},
@@ -285,7 +285,7 @@ func TestQueryElemMatchOperator(t *testing.T) {
 		},
 
 		"UnexpectedFilterString": {
-			filter: bson.D{{"value", bson.D{{"$elemMatch", "foo"}}}},
+			filter: bson.D{{"v", bson.D{{"$elemMatch", "foo"}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
@@ -293,7 +293,7 @@ func TestQueryElemMatchOperator(t *testing.T) {
 			},
 		},
 		"WhereInsideElemMatch": {
-			filter: bson.D{{"value", bson.D{{"$elemMatch", bson.D{{"$where", "123"}}}}}},
+			filter: bson.D{{"v", bson.D{{"$elemMatch", bson.D{{"$where", "123"}}}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
@@ -301,7 +301,7 @@ func TestQueryElemMatchOperator(t *testing.T) {
 			},
 		},
 		"TextInsideElemMatch": {
-			filter: bson.D{{"value", bson.D{{"$elemMatch", bson.D{{"$text", "123"}}}}}},
+			filter: bson.D{{"v", bson.D{{"$elemMatch", bson.D{{"$text", "123"}}}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
@@ -309,7 +309,7 @@ func TestQueryElemMatchOperator(t *testing.T) {
 			},
 		},
 		"GtField": {
-			filter: bson.D{{"value", bson.D{
+			filter: bson.D{{"v", bson.D{
 				{
 					"$elemMatch",
 					bson.D{
@@ -402,7 +402,7 @@ func TestArrayEquality(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			filter := bson.D{{"value", tc.array}}
+			filter := bson.D{{"v", tc.array}}
 			cursor, err := collection.Find(ctx, filter, options.Find().SetSort(bson.D{{"_id", 1}}))
 			require.NoError(t, err)
 

--- a/integration/query_bitwise_test.go
+++ b/integration/query_bitwise_test.go
@@ -42,6 +42,7 @@ func TestQueryBitwiseAllClear(t *testing.T) {
 		value       any
 		expectedIDs []any
 		err         *mongo.CommandError
+		altMessage  string
 	}{
 		"Array": {
 			value: primitive.A{1, 5},
@@ -98,8 +99,9 @@ func TestQueryBitwiseAllClear(t *testing.T) {
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
-				Message: "value takes an Array, a number, or a BinData but received: $bitsAllClear: \"123\"",
+				Message: `v takes an Array, a number, or a BinData but received: $bitsAllClear: "123"`,
 			},
+			altMessage: `value takes an Array, a number, or a BinData but received: $bitsAllClear: "123"`,
 		},
 
 		"Binary": {
@@ -165,11 +167,11 @@ func TestQueryBitwiseAllClear(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			filter := bson.D{{"value", bson.D{{"$bitsAllClear", tc.value}}}}
+			filter := bson.D{{"v", bson.D{{"$bitsAllClear", tc.value}}}}
 			cursor, err := collection.Find(ctx, filter, options.Find().SetSort(bson.D{{"_id", 1}}))
 			if tc.err != nil {
 				require.Nil(t, tc.expectedIDs)
-				AssertEqualError(t, *tc.err, err)
+				AssertEqualAltError(t, *tc.err, tc.altMessage, err)
 				return
 			}
 			require.NoError(t, err)
@@ -196,6 +198,7 @@ func TestQueryBitwiseAllSet(t *testing.T) {
 		value       any
 		expectedIDs []any
 		err         *mongo.CommandError
+		altMessage  string
 	}{
 		"Array": {
 			value:       primitive.A{1, 5},
@@ -244,8 +247,9 @@ func TestQueryBitwiseAllSet(t *testing.T) {
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
-				Message: "value takes an Array, a number, or a BinData but received: $bitsAllSet: \"123\"",
+				Message: `v takes an Array, a number, or a BinData but received: $bitsAllSet: "123"`,
 			},
+			altMessage: `value takes an Array, a number, or a BinData but received: $bitsAllSet: "123"`,
 		},
 
 		"Binary": {
@@ -287,11 +291,11 @@ func TestQueryBitwiseAllSet(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			filter := bson.D{{"value", bson.D{{"$bitsAllSet", tc.value}}}}
+			filter := bson.D{{"v", bson.D{{"$bitsAllSet", tc.value}}}}
 			cursor, err := collection.Find(ctx, filter, options.Find().SetSort(bson.D{{"_id", 1}}))
 			if tc.err != nil {
 				require.Nil(t, tc.expectedIDs)
-				AssertEqualError(t, *tc.err, err)
+				AssertEqualAltError(t, *tc.err, tc.altMessage, err)
 				return
 			}
 			require.NoError(t, err)
@@ -318,6 +322,7 @@ func TestQueryBitwiseAnyClear(t *testing.T) {
 		value       any
 		expectedIDs []any
 		err         *mongo.CommandError
+		altMessage  string
 	}{
 		"Array": {
 			value: primitive.A{1, 5},
@@ -374,8 +379,9 @@ func TestQueryBitwiseAnyClear(t *testing.T) {
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
-				Message: "value takes an Array, a number, or a BinData but received: $bitsAnyClear: \"123\"",
+				Message: `v takes an Array, a number, or a BinData but received: $bitsAnyClear: "123"`,
 			},
+			altMessage: `value takes an Array, a number, or a BinData but received: $bitsAnyClear: "123"`,
 		},
 
 		"Binary": {
@@ -433,11 +439,11 @@ func TestQueryBitwiseAnyClear(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			filter := bson.D{{"value", bson.D{{"$bitsAnyClear", tc.value}}}}
+			filter := bson.D{{"v", bson.D{{"$bitsAnyClear", tc.value}}}}
 			cursor, err := collection.Find(ctx, filter, options.Find().SetSort(bson.D{{"_id", 1}}))
 			if tc.err != nil {
 				require.Nil(t, tc.expectedIDs)
-				AssertEqualError(t, *tc.err, err)
+				AssertEqualAltError(t, *tc.err, tc.altMessage, err)
 				return
 			}
 			require.NoError(t, err)
@@ -464,6 +470,7 @@ func TestQueryBitwiseAnySet(t *testing.T) {
 		value       any
 		expectedIDs []any
 		err         *mongo.CommandError
+		altMessage  string
 	}{
 		"Array": {
 			value: primitive.A{1, 5},
@@ -520,8 +527,9 @@ func TestQueryBitwiseAnySet(t *testing.T) {
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
-				Message: "value takes an Array, a number, or a BinData but received: $bitsAnySet: \"123\"",
+				Message: `v takes an Array, a number, or a BinData but received: $bitsAnySet: "123"`,
 			},
+			altMessage: `value takes an Array, a number, or a BinData but received: $bitsAnySet: "123"`,
 		},
 
 		"Binary": {
@@ -571,11 +579,11 @@ func TestQueryBitwiseAnySet(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			filter := bson.D{{"value", bson.D{{"$bitsAnySet", tc.value}}}}
+			filter := bson.D{{"v", bson.D{{"$bitsAnySet", tc.value}}}}
 			cursor, err := collection.Find(ctx, filter, options.Find().SetSort(bson.D{{"_id", 1}}))
 			if tc.err != nil {
 				require.Nil(t, tc.expectedIDs)
-				AssertEqualError(t, *tc.err, err)
+				AssertEqualAltError(t, *tc.err, tc.altMessage, err)
 				return
 			}
 			require.NoError(t, err)

--- a/integration/query_comparison_test.go
+++ b/integration/query_comparison_test.go
@@ -40,27 +40,27 @@ func TestQueryComparisonImplicit(t *testing.T) {
 		expectedIDs []any
 	}{
 		"Document": {
-			filter:      bson.D{{"value", bson.D{{"foo", int32(42)}, {"42", "foo"}, {"array", bson.A{int32(42), "foo", nil}}}}},
+			filter:      bson.D{{"v", bson.D{{"foo", int32(42)}, {"42", "foo"}, {"array", bson.A{int32(42), "foo", nil}}}}},
 			expectedIDs: []any{"document-composite"},
 		},
 		"DocumentReverse": {
-			filter:      bson.D{{"value", bson.D{{"array", bson.A{int32(42), "foo", nil}}, {"42", "foo"}, {"foo", int32(42)}}}},
+			filter:      bson.D{{"v", bson.D{{"array", bson.A{int32(42), "foo", nil}}, {"42", "foo"}, {"foo", int32(42)}}}},
 			expectedIDs: []any{"document-composite-reverse"},
 		},
 		"DocumentNull": {
-			filter:      bson.D{{"value", bson.D{{"foo", nil}}}},
+			filter:      bson.D{{"v", bson.D{{"foo", nil}}}},
 			expectedIDs: []any{"document-null"},
 		},
 		"DocumentEmpty": {
-			filter:      bson.D{{"value", bson.D{}}},
+			filter:      bson.D{{"v", bson.D{}}},
 			expectedIDs: []any{"document-empty"},
 		},
 		"DocumentShuffledKeys": {
-			filter:      bson.D{{"value", bson.D{{"42", "foo"}, {"array", bson.A{int32(42), "foo", nil}}, {"foo", int32(42)}}}},
+			filter:      bson.D{{"v", bson.D{{"42", "foo"}, {"array", bson.A{int32(42), "foo", nil}}, {"foo", int32(42)}}}},
 			expectedIDs: []any{},
 		},
 		"DocumentDotNotation": {
-			filter:      bson.D{{"value.foo", int32(42)}},
+			filter:      bson.D{{"v.foo", int32(42)}},
 			expectedIDs: []any{"document", "document-composite", "document-composite-reverse"},
 		},
 		"DocumentDotNotationNoSuchField": {
@@ -69,19 +69,19 @@ func TestQueryComparisonImplicit(t *testing.T) {
 		},
 
 		"Array": {
-			filter:      bson.D{{"value", bson.A{int32(42), "foo", nil}}},
+			filter:      bson.D{{"v", bson.A{int32(42), "foo", nil}}},
 			expectedIDs: []any{"array-three"},
 		},
 		"ArrayReverse": {
-			filter:      bson.D{{"value", bson.A{nil, "foo", int32(42)}}},
+			filter:      bson.D{{"v", bson.A{nil, "foo", int32(42)}}},
 			expectedIDs: []any{"array-three-reverse"},
 		},
 		"ArrayNull": {
-			filter:      bson.D{{"value", bson.A{nil}}},
+			filter:      bson.D{{"v", bson.A{nil}}},
 			expectedIDs: []any{"array-null"},
 		},
 		"ArrayEmpty": {
-			filter:      bson.D{{"value", bson.A{}}},
+			filter:      bson.D{{"v", bson.A{}}},
 			expectedIDs: []any{"array-empty", "array-empty-nested"},
 		},
 		"ArrayNoSuchField": {
@@ -89,79 +89,79 @@ func TestQueryComparisonImplicit(t *testing.T) {
 			expectedIDs: []any{},
 		},
 		"ArrayEmbedded": {
-			filter:      bson.D{{"value", bson.A{bson.A{int32(42), "foo"}, nil}}},
+			filter:      bson.D{{"v", bson.A{bson.A{int32(42), "foo"}, nil}}},
 			expectedIDs: []any{"array-first-embedded"},
 		},
 		"LongArrayEmbedded": {
-			filter:      bson.D{{"value", bson.A{bson.A{int32(42), "foo"}, nil, "foo"}}},
+			filter:      bson.D{{"v", bson.A{bson.A{int32(42), "foo"}, nil, "foo"}}},
 			expectedIDs: []any{},
 		},
 		"ArraySlice": {
-			filter:      bson.D{{"value", bson.A{int32(42), "foo"}}},
+			filter:      bson.D{{"v", bson.A{int32(42), "foo"}}},
 			expectedIDs: []any{"array-first-embedded", "array-last-embedded", "array-middle-embedded"},
 		},
 		"ArrayShuffledValues": {
-			filter:      bson.D{{"value", bson.A{"foo", nil, int32(42)}}},
+			filter:      bson.D{{"v", bson.A{"foo", nil, int32(42)}}},
 			expectedIDs: []any{},
 		},
 		"ArrayDotNotationNoSuchField": {
-			filter:      bson.D{{"value.some.0", bson.A{42}}},
+			filter:      bson.D{{"v.some.0", bson.A{42}}},
 			expectedIDs: []any{},
 		},
 
 		"Double": {
-			filter:      bson.D{{"value", 42.13}},
+			filter:      bson.D{{"v", 42.13}},
 			expectedIDs: []any{"array-two", "double"},
 		},
 		"DoubleNegativeInfinity": {
-			filter:      bson.D{{"value", math.Inf(-1)}},
+			filter:      bson.D{{"v", math.Inf(-1)}},
 			expectedIDs: []any{"double-negative-infinity"},
 		},
 		"DoublePositiveInfinity": {
-			filter:      bson.D{{"value", math.Inf(+1)}},
+			filter:      bson.D{{"v", math.Inf(+1)}},
 			expectedIDs: []any{"double-positive-infinity"},
 		},
 		"DoubleMax": {
-			filter:      bson.D{{"value", math.MaxFloat64}},
+			filter:      bson.D{{"v", math.MaxFloat64}},
 			expectedIDs: []any{"double-max"},
 		},
 		"DoubleSmallest": {
-			filter:      bson.D{{"value", math.SmallestNonzeroFloat64}},
+			filter:      bson.D{{"v", math.SmallestNonzeroFloat64}},
 			expectedIDs: []any{"double-smallest"},
 		},
 		"DoubleBig": {
-			filter:      bson.D{{"value", float64(2 << 60)}},
+			filter:      bson.D{{"v", float64(2 << 60)}},
 			expectedIDs: []any{"double-big"},
 		},
 		"DoubleNaN": {
-			filter:      bson.D{{"value", math.NaN()}},
+			filter:      bson.D{{"v", math.NaN()}},
 			expectedIDs: []any{"array-two", "double-nan"},
 		},
 
 		"String": {
-			filter:      bson.D{{"value", "foo"}},
+			filter:      bson.D{{"v", "foo"}},
 			expectedIDs: []any{"array-three", "array-three-reverse", "string"},
 		},
 		"StringEmpty": {
-			filter:      bson.D{{"value", ""}},
+			filter:      bson.D{{"v", ""}},
 			expectedIDs: []any{"string-empty"},
 		},
 
 		"Binary": {
-			filter:      bson.D{{"value", primitive.Binary{Subtype: 0x80, Data: []byte{42, 0, 13}}}},
+			filter:      bson.D{{"v", primitive.Binary{Subtype: 0x80, Data: []byte{42, 0, 13}}}},
 			expectedIDs: []any{"binary"},
 		},
 		"BinaryEmpty": {
-			filter:      bson.D{{"value", primitive.Binary{}}},
+			filter:      bson.D{{"v", primitive.Binary{}}},
 			expectedIDs: []any{"binary-empty"},
 		},
 
 		"BoolFalse": {
-			filter:      bson.D{{"value", false}},
+			filter:      bson.D{{"v", false}},
 			expectedIDs: []any{"bool-false"},
 		},
 		"BoolTrue": {
-			filter:      bson.D{{"value", true}},
+			filter:      bson.D{{"v", true}},
 			expectedIDs: []any{"bool-true"},
 		},
 
@@ -170,7 +170,7 @@ func TestQueryComparisonImplicit(t *testing.T) {
 			expectedIDs: []any{},
 		},
 		"ValueNull": {
-			filter: bson.D{{"value", nil}},
+			filter: bson.D{{"v", nil}},
 			expectedIDs: []any{
 				"array-first-embedded", "array-last-embedded", "array-middle-embedded", "array-null",
 				"array-three", "array-three-reverse", "null",
@@ -198,12 +198,12 @@ func TestQueryComparisonImplicit(t *testing.T) {
 		},
 
 		"ValueNumber": {
-			filter:      bson.D{{"value", 42}},
+			filter:      bson.D{{"v", 42}},
 			expectedIDs: []any{"array", "array-three", "array-three-reverse", "double-whole", "int32", "int64"},
 		},
 
 		"ValueRegex": {
-			filter:      bson.D{{"value", primitive.Regex{Pattern: "^fo"}}},
+			filter:      bson.D{{"v", primitive.Regex{Pattern: "^fo"}}},
 			expectedIDs: []any{"array-three", "array-three-reverse", "string"},
 		},
 	} {
@@ -232,171 +232,171 @@ func TestQueryComparisonEq(t *testing.T) {
 		expectedIDs []any
 	}{
 		"Document": {
-			filter:      bson.D{{"value", bson.D{{"$eq", bson.D{{"foo", int32(42)}, {"42", "foo"}, {"array", bson.A{int32(42), "foo", nil}}}}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", bson.D{{"foo", int32(42)}, {"42", "foo"}, {"array", bson.A{int32(42), "foo", nil}}}}}}},
 			expectedIDs: []any{"document-composite"},
 		},
 		"DocumentShuffledKeys": {
-			filter:      bson.D{{"value", bson.D{{"$eq", bson.D{{"42", "foo"}, {"array", bson.A{int32(42), "foo", nil}}, {"foo", int32(42)}}}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", bson.D{{"42", "foo"}, {"array", bson.A{int32(42), "foo", nil}}, {"foo", int32(42)}}}}}},
 			expectedIDs: []any{},
 		},
 		"DocumentDotNotation": {
-			filter:      bson.D{{"value.foo", bson.D{{"$eq", int32(42)}}}},
+			filter:      bson.D{{"v.foo", bson.D{{"$eq", int32(42)}}}},
 			expectedIDs: []any{"document", "document-composite", "document-composite-reverse"},
 		},
 		"DocumentReverse": {
-			filter:      bson.D{{"value", bson.D{{"$eq", bson.D{{"array", bson.A{int32(42), "foo", nil}}, {"42", "foo"}, {"foo", int32(42)}}}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", bson.D{{"array", bson.A{int32(42), "foo", nil}}, {"42", "foo"}, {"foo", int32(42)}}}}}},
 			expectedIDs: []any{"document-composite-reverse"},
 		},
 		"DocumentNull": {
-			filter:      bson.D{{"value", bson.D{{"$eq", bson.D{{"foo", nil}}}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", bson.D{{"foo", nil}}}}}},
 			expectedIDs: []any{"document-null"},
 		},
 		"DocumentEmpty": {
-			filter:      bson.D{{"value", bson.D{{"$eq", bson.D{}}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", bson.D{}}}}},
 			expectedIDs: []any{"document-empty"},
 		},
 
 		"Array": {
-			filter:      bson.D{{"value", bson.D{{"$eq", bson.A{int32(42), "foo", nil}}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", bson.A{int32(42), "foo", nil}}}}},
 			expectedIDs: []any{"array-three"},
 		},
 		"ArrayEmbedded": {
-			filter:      bson.D{{"value", bson.D{{"$eq", bson.A{bson.A{int32(42), "foo"}, nil}}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", bson.A{bson.A{int32(42), "foo"}, nil}}}}},
 			expectedIDs: []any{"array-first-embedded"},
 		},
 		"LongArrayEmbedded": {
-			filter:      bson.D{{"value", bson.D{{"$eq", bson.A{bson.A{int32(42), "foo"}, nil, "foo"}}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", bson.A{bson.A{int32(42), "foo"}, nil, "foo"}}}}},
 			expectedIDs: []any{},
 		},
 		"ArraySlice": {
-			filter:      bson.D{{"value", bson.D{{"$eq", bson.A{int32(42), "foo"}}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", bson.A{int32(42), "foo"}}}}},
 			expectedIDs: []any{"array-first-embedded", "array-last-embedded", "array-middle-embedded"},
 		},
 		"ArrayShuffledValues": {
-			filter:      bson.D{{"value", bson.D{{"$eq", bson.A{"foo", nil, int32(42)}}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", bson.A{"foo", nil, int32(42)}}}}},
 			expectedIDs: []any{},
 		},
 		"ArrayReverse": {
-			filter:      bson.D{{"value", bson.D{{"$eq", bson.A{nil, "foo", int32(42)}}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", bson.A{nil, "foo", int32(42)}}}}},
 			expectedIDs: []any{"array-three-reverse"},
 		},
 		"ArrayNull": {
-			filter:      bson.D{{"value", bson.D{{"$eq", bson.A{nil}}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", bson.A{nil}}}}},
 			expectedIDs: []any{"array-null"},
 		},
 		"ArrayEmpty": {
-			filter:      bson.D{{"value", bson.D{{"$eq", bson.A{}}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", bson.A{}}}}},
 			expectedIDs: []any{"array-empty", "array-empty-nested"},
 		},
 
 		"Double": {
-			filter:      bson.D{{"value", bson.D{{"$eq", 42.13}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", 42.13}}}},
 			expectedIDs: []any{"array-two", "double"},
 		},
 		"DoubleWhole": {
-			filter:      bson.D{{"value", bson.D{{"$eq", 42.0}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", 42.0}}}},
 			expectedIDs: []any{"array", "array-three", "array-three-reverse", "double-whole", "int32", "int64"},
 		},
 		"DoubleZero": {
-			filter:      bson.D{{"value", bson.D{{"$eq", 0.0}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", 0.0}}}},
 			expectedIDs: []any{"double-negative-zero", "double-zero", "int32-zero", "int64-zero"},
 		},
 		"DoubleNegativeZero": {
-			filter:      bson.D{{"value", bson.D{{"$eq", math.Copysign(0, -1)}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", math.Copysign(0, -1)}}}},
 			expectedIDs: []any{"double-negative-zero", "double-zero", "int32-zero", "int64-zero"},
 		},
 		"DoubleMax": {
-			filter:      bson.D{{"value", bson.D{{"$eq", math.MaxFloat64}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", math.MaxFloat64}}}},
 			expectedIDs: []any{"double-max"},
 		},
 		"DoubleSmallest": {
-			filter:      bson.D{{"value", bson.D{{"$eq", math.SmallestNonzeroFloat64}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", math.SmallestNonzeroFloat64}}}},
 			expectedIDs: []any{"double-smallest"},
 		},
 		"DoublePositiveInfinity": {
-			filter:      bson.D{{"value", bson.D{{"$eq", math.Inf(+1)}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", math.Inf(+1)}}}},
 			expectedIDs: []any{"double-positive-infinity"},
 		},
 		"DoubleNegativeInfinity": {
-			filter:      bson.D{{"value", bson.D{{"$eq", math.Inf(-1)}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", math.Inf(-1)}}}},
 			expectedIDs: []any{"double-negative-infinity"},
 		},
 		"DoubleNaN": {
-			filter:      bson.D{{"value", bson.D{{"$eq", math.NaN()}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", math.NaN()}}}},
 			expectedIDs: []any{"array-two", "double-nan"},
 		},
 		"DoubleBigInt64": {
-			filter:      bson.D{{"value", bson.D{{"$eq", float64(2 << 61)}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", float64(2 << 61)}}}},
 			expectedIDs: []any{"int64-big"},
 		},
 		"DoubleBigInt64PlusOne": {
-			filter:      bson.D{{"value", bson.D{{"$eq", float64(2<<61 + 1)}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", float64(2<<61 + 1)}}}},
 			expectedIDs: []any{"int64-big"},
 		},
 
 		"String": {
-			filter:      bson.D{{"value", bson.D{{"$eq", "foo"}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", "foo"}}}},
 			expectedIDs: []any{"array-three", "array-three-reverse", "string"},
 		},
 		"StringDouble": {
-			filter:      bson.D{{"value", bson.D{{"$eq", "42.13"}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", "42.13"}}}},
 			expectedIDs: []any{"string-double"},
 		},
 		"StringWhole": {
-			filter:      bson.D{{"value", bson.D{{"$eq", "42"}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", "42"}}}},
 			expectedIDs: []any{"string-whole"},
 		},
 		"StringEmpty": {
-			filter:      bson.D{{"value", bson.D{{"$eq", ""}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", ""}}}},
 			expectedIDs: []any{"string-empty"},
 		},
 
 		"Binary": {
-			filter:      bson.D{{"value", bson.D{{"$eq", primitive.Binary{Subtype: 0x80, Data: []byte{42, 0, 13}}}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", primitive.Binary{Subtype: 0x80, Data: []byte{42, 0, 13}}}}}},
 			expectedIDs: []any{"binary"},
 		},
 		"BinaryEmpty": {
-			filter:      bson.D{{"value", bson.D{{"$eq", primitive.Binary{Data: []byte{}}}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", primitive.Binary{Data: []byte{}}}}}},
 			expectedIDs: []any{"binary-empty"},
 		},
 
 		"ObjectID": {
-			filter:      bson.D{{"value", bson.D{{"$eq", must.NotFail(primitive.ObjectIDFromHex("000102030405060708091011"))}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", must.NotFail(primitive.ObjectIDFromHex("000102030405060708091011"))}}}},
 			expectedIDs: []any{"objectid"},
 		},
 		"ObjectIDEmpty": {
-			filter:      bson.D{{"value", bson.D{{"$eq", primitive.NilObjectID}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", primitive.NilObjectID}}}},
 			expectedIDs: []any{"objectid-empty"},
 		},
 
 		"BoolFalse": {
-			filter:      bson.D{{"value", bson.D{{"$eq", false}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", false}}}},
 			expectedIDs: []any{"bool-false"},
 		},
 		"BoolTrue": {
-			filter:      bson.D{{"value", bson.D{{"$eq", true}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", true}}}},
 			expectedIDs: []any{"bool-true"},
 		},
 
 		"Datetime": {
-			filter:      bson.D{{"value", bson.D{{"$eq", primitive.NewDateTimeFromTime(time.Date(2021, 11, 1, 10, 18, 42, 123000000, time.UTC))}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", primitive.NewDateTimeFromTime(time.Date(2021, 11, 1, 10, 18, 42, 123000000, time.UTC))}}}},
 			expectedIDs: []any{"datetime"},
 		},
 		"DatetimeEpoch": {
-			filter:      bson.D{{"value", bson.D{{"$eq", primitive.NewDateTimeFromTime(time.Unix(0, 0))}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", primitive.NewDateTimeFromTime(time.Unix(0, 0))}}}},
 			expectedIDs: []any{"datetime-epoch"},
 		},
 		"DatetimeYearMax": {
-			filter:      bson.D{{"value", bson.D{{"$eq", primitive.NewDateTimeFromTime(time.Date(0, 1, 1, 0, 0, 0, 0, time.UTC))}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", primitive.NewDateTimeFromTime(time.Date(0, 1, 1, 0, 0, 0, 0, time.UTC))}}}},
 			expectedIDs: []any{"datetime-year-min"},
 		},
 		"DatetimeYearMin": {
-			filter:      bson.D{{"value", bson.D{{"$eq", primitive.NewDateTimeFromTime(time.Date(9999, 12, 31, 23, 59, 59, 999000000, time.UTC))}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", primitive.NewDateTimeFromTime(time.Date(9999, 12, 31, 23, 59, 59, 999000000, time.UTC))}}}},
 			expectedIDs: []any{"datetime-year-max"},
 		},
 
 		"Null": {
-			filter: bson.D{{"value", bson.D{{"$eq", nil}}}},
+			filter: bson.D{{"v", bson.D{{"$eq", nil}}}},
 			expectedIDs: []any{
 				"array-first-embedded", "array-last-embedded", "array-middle-embedded", "array-null", "array-three",
 				"array-three-reverse", "null",
@@ -404,66 +404,66 @@ func TestQueryComparisonEq(t *testing.T) {
 		},
 
 		"RegexWithoutOption": {
-			filter:      bson.D{{"value", bson.D{{"$eq", primitive.Regex{Pattern: "foo"}}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", primitive.Regex{Pattern: "foo"}}}}},
 			expectedIDs: []any{},
 		},
 		"RegexWithOption": {
-			filter:      bson.D{{"value", bson.D{{"$eq", primitive.Regex{Pattern: "foo", Options: "i"}}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", primitive.Regex{Pattern: "foo", Options: "i"}}}}},
 			expectedIDs: []any{"regex"},
 		},
 		"RegexEmpty": {
-			filter:      bson.D{{"value", bson.D{{"$eq", primitive.Regex{}}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", primitive.Regex{}}}}},
 			expectedIDs: []any{"regex-empty"},
 		},
 
 		"Int32": {
-			filter:      bson.D{{"value", bson.D{{"$eq", int32(42)}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", int32(42)}}}},
 			expectedIDs: []any{"array", "array-three", "array-three-reverse", "double-whole", "int32", "int64"},
 		},
 		"Int32Zero": {
-			filter:      bson.D{{"value", bson.D{{"$eq", int32(0)}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", int32(0)}}}},
 			expectedIDs: []any{"double-negative-zero", "double-zero", "int32-zero", "int64-zero"},
 		},
 		"Int32Max": {
-			filter:      bson.D{{"value", bson.D{{"$eq", int32(math.MaxInt32)}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", int32(math.MaxInt32)}}}},
 			expectedIDs: []any{"int32-max"},
 		},
 		"Int32Min": {
-			filter:      bson.D{{"value", bson.D{{"$eq", int32(math.MinInt32)}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", int32(math.MinInt32)}}}},
 			expectedIDs: []any{"int32-min"},
 		},
 
 		"Timestamp": {
-			filter:      bson.D{{"value", bson.D{{"$eq", primitive.Timestamp{T: 42, I: 13}}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", primitive.Timestamp{T: 42, I: 13}}}}},
 			expectedIDs: []any{"timestamp"},
 		},
 		"TimestampI": {
-			filter:      bson.D{{"value", bson.D{{"$eq", primitive.Timestamp{I: 1}}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", primitive.Timestamp{I: 1}}}}},
 			expectedIDs: []any{"timestamp-i"},
 		},
 
 		"Int64": {
-			filter:      bson.D{{"value", bson.D{{"$eq", int64(42)}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", int64(42)}}}},
 			expectedIDs: []any{"array", "array-three", "array-three-reverse", "double-whole", "int32", "int64"},
 		},
 		"Int64Zero": {
-			filter:      bson.D{{"value", bson.D{{"$eq", int64(0)}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", int64(0)}}}},
 			expectedIDs: []any{"double-negative-zero", "double-zero", "int32-zero", "int64-zero"},
 		},
 		"Int64Max": {
-			filter:      bson.D{{"value", bson.D{{"$eq", int64(math.MaxInt64)}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", int64(math.MaxInt64)}}}},
 			expectedIDs: []any{"int64-max"},
 		},
 		"Int64Min": {
-			filter:      bson.D{{"value", bson.D{{"$eq", int64(math.MinInt64)}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", int64(math.MinInt64)}}}},
 			expectedIDs: []any{"int64-min"},
 		},
 		"Int64DoubleBig": {
-			filter:      bson.D{{"value", bson.D{{"$eq", int64(2 << 60)}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", int64(2 << 60)}}}},
 			expectedIDs: []any{"double-big"},
 		},
 		"Int64DoubleBigPlusOne": {
-			filter:      bson.D{{"value", bson.D{{"$eq", int64(2<<60 + 1)}}}},
+			filter:      bson.D{{"v", bson.D{{"$eq", int64(2<<60 + 1)}}}},
 			expectedIDs: []any{},
 		},
 
@@ -654,7 +654,7 @@ func TestQueryComparisonGt(t *testing.T) {
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
-				Message: "Can't have RegEx as arg to predicate over field 'value'.",
+				Message: "Can't have RegEx as arg to predicate over field 'v'.",
 			},
 		},
 
@@ -713,7 +713,7 @@ func TestQueryComparisonGt(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			filter := bson.D{{"value", bson.D{{"$gt", tc.value}}}}
+			filter := bson.D{{"v", bson.D{{"$gt", tc.value}}}}
 			cursor, err := collection.Find(ctx, filter, options.Find().SetSort(bson.D{{"_id", 1}}))
 			if tc.err != nil {
 				require.Nil(t, tc.expectedIDs)
@@ -880,7 +880,7 @@ func TestQueryComparisonGte(t *testing.T) {
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
-				Message: "Can't have RegEx as arg to predicate over field 'value'.",
+				Message: "Can't have RegEx as arg to predicate over field 'v'.",
 			},
 		},
 
@@ -929,7 +929,7 @@ func TestQueryComparisonGte(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			filter := bson.D{{"value", bson.D{{"$gte", tc.value}}}}
+			filter := bson.D{{"v", bson.D{{"$gte", tc.value}}}}
 			cursor, err := collection.Find(ctx, filter, options.Find().SetSort(bson.D{{"_id", 1}}))
 			if tc.err != nil {
 				require.Nil(t, tc.expectedIDs)
@@ -1098,7 +1098,7 @@ func TestQueryComparisonLt(t *testing.T) {
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
-				Message: "Can't have RegEx as arg to predicate over field 'value'.",
+				Message: "Can't have RegEx as arg to predicate over field 'v'.",
 			},
 		},
 
@@ -1154,7 +1154,7 @@ func TestQueryComparisonLt(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			filter := bson.D{{"value", bson.D{{"$lt", tc.value}}}}
+			filter := bson.D{{"v", bson.D{{"$lt", tc.value}}}}
 			cursor, err := collection.Find(ctx, filter, options.Find().SetSort(bson.D{{"_id", 1}}))
 			if tc.err != nil {
 				require.Nil(t, tc.expectedIDs)
@@ -1330,7 +1330,7 @@ func TestQueryComparisonLte(t *testing.T) {
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
-				Message: "Can't have RegEx as arg to predicate over field 'value'.",
+				Message: "Can't have RegEx as arg to predicate over field 'v'.",
 			},
 		},
 
@@ -1379,7 +1379,7 @@ func TestQueryComparisonLte(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			filter := bson.D{{"value", bson.D{{"$lte", tc.value}}}}
+			filter := bson.D{{"v", bson.D{{"$lte", tc.value}}}}
 			cursor, err := collection.Find(ctx, filter, options.Find().SetSort(bson.D{{"_id", 1}}))
 			if tc.err != nil {
 				require.Nil(t, tc.expectedIDs)
@@ -1403,12 +1403,12 @@ func TestQueryComparisonNin(t *testing.T) {
 
 	var scalarDataTypesFilter bson.A
 	for _, scalarDataType := range shareddata.Scalars.Docs() {
-		scalarDataTypesFilter = append(scalarDataTypesFilter, scalarDataType.Map()["value"])
+		scalarDataTypesFilter = append(scalarDataTypesFilter, scalarDataType.Map()["v"])
 	}
 
 	var compositeDataTypesFilter bson.A
 	for _, compositeDataType := range shareddata.Composites.Docs() {
-		compositeDataTypesFilter = append(compositeDataTypesFilter, compositeDataType.Map()["value"])
+		compositeDataTypesFilter = append(compositeDataTypesFilter, compositeDataType.Map()["v"])
 	}
 
 	for name, tc := range map[string]struct {
@@ -1491,7 +1491,7 @@ func TestQueryComparisonNin(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			filter := bson.D{{"value", bson.D{{"$nin", tc.value}}}}
+			filter := bson.D{{"v", bson.D{{"$nin", tc.value}}}}
 			cursor, err := collection.Find(ctx, filter, options.Find().SetSort(bson.D{{"_id", 1}}))
 			if tc.err != nil {
 				require.Nil(t, tc.expectedIDs)
@@ -1515,12 +1515,12 @@ func TestQueryComparisonIn(t *testing.T) {
 
 	var scalarDataTypesFilter bson.A
 	for _, scalarDataType := range shareddata.Scalars.Docs() {
-		scalarDataTypesFilter = append(scalarDataTypesFilter, scalarDataType.Map()["value"])
+		scalarDataTypesFilter = append(scalarDataTypesFilter, scalarDataType.Map()["v"])
 	}
 
 	var compositeDataTypesFilter bson.A
 	for _, compositeDataType := range shareddata.Composites.Docs() {
-		compositeDataTypesFilter = append(compositeDataTypesFilter, compositeDataType.Map()["value"])
+		compositeDataTypesFilter = append(compositeDataTypesFilter, compositeDataType.Map()["v"])
 	}
 
 	for name, tc := range map[string]struct {
@@ -1590,7 +1590,7 @@ func TestQueryComparisonIn(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			filter := bson.D{{"value", bson.D{{"$in", tc.value}}}}
+			filter := bson.D{{"v", bson.D{{"$in", tc.value}}}}
 			cursor, err := collection.Find(ctx, filter, options.Find().SetSort(bson.D{{"_id", 1}}))
 			if tc.err != nil {
 				require.Nil(t, tc.expectedIDs)
@@ -1622,7 +1622,7 @@ func TestQueryComparisonNe(t *testing.T) {
 			unexpectedID: "document-composite",
 		},
 		"DocumentShuffledKeys": {
-			value:        bson.D{{"value", bson.D{{"42", "foo"}, {"array", bson.A{int32(42), "foo", nil}}, {"foo", int32(42)}}}},
+			value:        bson.D{{"v", bson.D{{"42", "foo"}, {"array", bson.A{int32(42), "foo", nil}}, {"foo", int32(42)}}}},
 			unexpectedID: "",
 		},
 
@@ -1789,7 +1789,7 @@ func TestQueryComparisonNe(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			filter := bson.D{{"value", bson.D{{"$ne", tc.value}}}}
+			filter := bson.D{{"v", bson.D{{"$ne", tc.value}}}}
 			cursor, err := collection.Find(ctx, filter, options.Find().SetSort(bson.D{{"_id", 1}}))
 			if tc.err != nil {
 				AssertEqualError(t, *tc.err, err)
@@ -1817,14 +1817,14 @@ func TestQueryComparisonMultipleOperators(t *testing.T) {
 		"InLteGte": {
 			filter: bson.D{
 				{"_id", bson.D{{"$in", bson.A{"int32"}}}},
-				{"value", bson.D{{"$lte", int32(42)}, {"$gte", int32(0)}}},
+				{"v", bson.D{{"$lte", int32(42)}, {"$gte", int32(0)}}},
 			},
 			expectedIDs: []any{"int32"},
 		},
 		"NinEqNe": {
 			filter: bson.D{
 				{"_id", bson.D{{"$nin", bson.A{"int64"}}, {"$ne", "int32"}}},
-				{"value", bson.D{{"$eq", int32(42)}}},
+				{"v", bson.D{{"$eq", int32(42)}}},
 			},
 			expectedIDs: []any{"array", "array-three", "array-three-reverse", "double-whole"},
 		},

--- a/integration/query_element_test.go
+++ b/integration/query_element_test.go
@@ -35,8 +35,8 @@ func TestQueryElementExists(t *testing.T) {
 		bson.D{{"_id", "empty-array"}, {"empty-array", []any{}}},
 		bson.D{{"_id", "nan"}, {"nan", math.NaN()}},
 		bson.D{{"_id", "null"}, {"null", nil}},
-		bson.D{{"_id", "string"}, {"value", "12"}},
-		bson.D{{"_id", "two-fields"}, {"value", "12"}, {"field", 42}},
+		bson.D{{"_id", "string"}, {"v", "12"}},
+		bson.D{{"_id", "two-fields"}, {"v", "12"}, {"field", 42}},
 	})
 	require.NoError(t, err)
 
@@ -267,7 +267,7 @@ func TestQueryElementType(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			filter := bson.D{{"value", bson.D{{"$type", tc.v}}}}
+			filter := bson.D{{"v", bson.D{{"$type", tc.v}}}}
 			cursor, err := collection.Find(ctx, filter, options.Find().SetSort(bson.D{{"_id", 1}}))
 			if tc.err != nil {
 				require.Nil(t, tc.expectedIDs)

--- a/integration/query_evaluation_test.go
+++ b/integration/query_evaluation_test.go
@@ -38,35 +38,35 @@ func TestQueryEvaluationMod(t *testing.T) {
 	ctx, collection := Setup(t)
 
 	_, err := collection.InsertMany(ctx, []any{
-		bson.D{{"_id", "Zero"}, {"value", 0}},
-		bson.D{{"_id", "NegativeZero"}, {"value", math.Copysign(0, -1)}},
-		bson.D{{"_id", "Int32_1"}, {"value", int32(4080)}},
-		bson.D{{"_id", "Int32_2"}, {"value", int32(1048560)}},
-		bson.D{{"_id", "Int32_3"}, {"value", int32(268435440)}},
-		bson.D{{"_id", "Int64_1"}, {"value", int64(1099511628000)}},
-		bson.D{{"_id", "Int64_2"}, {"value", int64(281474976700000)}},
-		bson.D{{"_id", "Int64_3"}, {"value", int64(72057594040000000)}},
-		bson.D{{"_id", "Nil"}, {"value", nil}},
-		bson.D{{"_id", "String"}, {"value", "12"}},
-		bson.D{{"_id", "NaN"}, {"value", math.NaN()}},
-		bson.D{{"_id", "Infinity"}, {"value", math.Inf(0)}},
-		bson.D{{"_id", "InfinityNegative"}, {"value", math.Inf(-1)}},
-		bson.D{{"_id", "InfinityPositive"}, {"value", math.Inf(+1)}},
-		bson.D{{"_id", "SmallestNonzeroFloat64"}, {"value", math.SmallestNonzeroFloat64}},
-		bson.D{{"_id", "PositiveNumber"}, {"value", 123456789}},
-		bson.D{{"_id", "NegativeNumber"}, {"value", -123456789}},
-		bson.D{{"_id", "MaxInt64"}, {"value", math.MaxInt64}},
-		bson.D{{"_id", "MaxInt64_float"}, {"value", float64(math.MaxInt64)}},
-		bson.D{{"_id", "MaxInt64_plus"}, {"value", float64(math.MaxInt64 + 1)}},
-		bson.D{{"_id", "MaxInt64_overflowVerge"}, {"value", 9.223372036854776832e+18}},
-		bson.D{{"_id", "MaxInt64_overflow"}, {"value", 9.223372036854776833e+18}},
-		bson.D{{"_id", "MaxFloat64_minus"}, {"value", 1.79769e+307}},
-		bson.D{{"_id", "MaxFloat64"}, {"value", math.MaxFloat64}},
-		bson.D{{"_id", "MinInt64"}, {"value", math.MinInt64}},
-		bson.D{{"_id", "MinInt64_float"}, {"value", float64(math.MinInt64)}},
-		bson.D{{"_id", "MinInt64_minus"}, {"value", float64(math.MinInt64 - 1)}},
-		bson.D{{"_id", "MinInt64_overflowVerge"}, {"value", -9.223372036854776832e+18}},
-		bson.D{{"_id", "MinInt64_overflow"}, {"value", -9.223372036854776833e+18}},
+		bson.D{{"_id", "Zero"}, {"v", 0}},
+		bson.D{{"_id", "NegativeZero"}, {"v", math.Copysign(0, -1)}},
+		bson.D{{"_id", "Int32_1"}, {"v", int32(4080)}},
+		bson.D{{"_id", "Int32_2"}, {"v", int32(1048560)}},
+		bson.D{{"_id", "Int32_3"}, {"v", int32(268435440)}},
+		bson.D{{"_id", "Int64_1"}, {"v", int64(1099511628000)}},
+		bson.D{{"_id", "Int64_2"}, {"v", int64(281474976700000)}},
+		bson.D{{"_id", "Int64_3"}, {"v", int64(72057594040000000)}},
+		bson.D{{"_id", "Nil"}, {"v", nil}},
+		bson.D{{"_id", "String"}, {"v", "12"}},
+		bson.D{{"_id", "NaN"}, {"v", math.NaN()}},
+		bson.D{{"_id", "Infinity"}, {"v", math.Inf(0)}},
+		bson.D{{"_id", "InfinityNegative"}, {"v", math.Inf(-1)}},
+		bson.D{{"_id", "InfinityPositive"}, {"v", math.Inf(+1)}},
+		bson.D{{"_id", "SmallestNonzeroFloat64"}, {"v", math.SmallestNonzeroFloat64}},
+		bson.D{{"_id", "PositiveNumber"}, {"v", 123456789}},
+		bson.D{{"_id", "NegativeNumber"}, {"v", -123456789}},
+		bson.D{{"_id", "MaxInt64"}, {"v", math.MaxInt64}},
+		bson.D{{"_id", "MaxInt64_float"}, {"v", float64(math.MaxInt64)}},
+		bson.D{{"_id", "MaxInt64_plus"}, {"v", float64(math.MaxInt64 + 1)}},
+		bson.D{{"_id", "MaxInt64_overflowVerge"}, {"v", 9.223372036854776832e+18}},
+		bson.D{{"_id", "MaxInt64_overflow"}, {"v", 9.223372036854776833e+18}},
+		bson.D{{"_id", "MaxFloat64_minus"}, {"v", 1.79769e+307}},
+		bson.D{{"_id", "MaxFloat64"}, {"v", math.MaxFloat64}},
+		bson.D{{"_id", "MinInt64"}, {"v", math.MinInt64}},
+		bson.D{{"_id", "MinInt64_float"}, {"v", float64(math.MinInt64)}},
+		bson.D{{"_id", "MinInt64_minus"}, {"v", float64(math.MinInt64 - 1)}},
+		bson.D{{"_id", "MinInt64_overflowVerge"}, {"v", -9.223372036854776832e+18}},
+		bson.D{{"_id", "MinInt64_overflow"}, {"v", -9.223372036854776833e+18}},
 	})
 	require.NoError(t, err)
 
@@ -76,79 +76,79 @@ func TestQueryEvaluationMod(t *testing.T) {
 		err         *mongo.CommandError
 	}{
 		"Int32": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{4000, 80}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{4000, 80}}}}},
 			expectedIDs: []any{"Int32_1"},
 		},
 		"Int32_floatDivisor": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{float64(1048500.444), 60}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{float64(1048500.444), 60}}}}},
 			expectedIDs: []any{"Int32_2"},
 		},
 		"Int32_floatRemainder": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{268435000, float64(440.555)}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{268435000, float64(440.555)}}}}},
 			expectedIDs: []any{"Int32_3"},
 		},
 		"Int32_emptyAnswer": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{268435000, float64(400)}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{268435000, float64(400)}}}}},
 			expectedIDs: []any{},
 		},
 		"Int64": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{1099511620000, 8000}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{1099511620000, 8000}}}}},
 			expectedIDs: []any{"Int64_1"},
 		},
 		"Int64_floatDivisor": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{float64(281474976000000.444), 700000}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{float64(281474976000000.444), 700000}}}}},
 			expectedIDs: []any{"Int64_2"},
 		},
 		"Int64_floatRemainder": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{72057594000000000, float64(40000000.555)}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{72057594000000000, float64(40000000.555)}}}}},
 			expectedIDs: []any{"Int64_3"},
 		},
 		"Int64_emptyAnswer": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{1234567890, float64(111)}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{1234567890, float64(111)}}}}},
 			expectedIDs: []any{},
 		},
 		"MaxInt64_Divisor": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{math.MaxInt64, 0}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{math.MaxInt64, 0}}}}},
 			expectedIDs: []any{"MaxInt64", "NegativeZero", "SmallestNonzeroFloat64", "Zero"},
 		},
 		"MaxInt64_Remainder": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{1, math.MaxInt64}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{1, math.MaxInt64}}}}},
 			expectedIDs: []any{},
 		},
 		"MaxInt64_floatDivisor": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{float64(math.MaxInt64), 0}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{float64(math.MaxInt64), 0}}}}},
 			expectedIDs: []any{"MinInt64", "MinInt64_float", "MinInt64_minus", "MinInt64_overflowVerge", "NegativeZero", "SmallestNonzeroFloat64", "Zero"},
 		},
 		"MaxInt64_floatRemainder": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{1, float64(math.MaxInt64)}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{1, float64(math.MaxInt64)}}}}},
 			expectedIDs: []any{},
 		},
 		"MaxInt64_plus": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{9.223372036854775808e+18, 0}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{9.223372036854775808e+18, 0}}}}},
 			expectedIDs: []any{"MinInt64", "MinInt64_float", "MinInt64_minus", "MinInt64_overflowVerge", "NegativeZero", "SmallestNonzeroFloat64", "Zero"},
 		},
 		"MaxInt64_1": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{922337203685477580, 7}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{922337203685477580, 7}}}}},
 			expectedIDs: []any{"MaxInt64"},
 		},
 		"MaxInt64_2": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{9.223372036854775807e+17, 7}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{9.223372036854775807e+17, 7}}}}},
 			expectedIDs: []any{},
 		},
 		"MaxInt64_3": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{9.223372036854775800e+17, 7}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{9.223372036854775800e+17, 7}}}}},
 			expectedIDs: []any{},
 		},
 		"MaxInt64_4": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{922337203, 6854775807}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{922337203, 6854775807}}}}},
 			expectedIDs: []any{},
 		},
 		"MaxInt64_overflowVerge": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{9.223372036854776832e+18, 0}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{9.223372036854776832e+18, 0}}}}},
 			expectedIDs: []any{"MinInt64", "MinInt64_float", "MinInt64_minus", "MinInt64_overflowVerge", "NegativeZero", "SmallestNonzeroFloat64", "Zero"},
 		},
 		"MaxInt64_overflowDivisor": {
-			filter: bson.D{{"value", bson.D{{"$mod", bson.A{9.223372036854776833e+18, 0}}}}},
+			filter: bson.D{{"v", bson.D{{"$mod", bson.A{9.223372036854776833e+18, 0}}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
@@ -156,7 +156,7 @@ func TestQueryEvaluationMod(t *testing.T) {
 			},
 		},
 		"MaxInt64_overflowBoth": {
-			filter: bson.D{{"value", bson.D{{"$mod", bson.A{9.223372036854776833e+18, 9.223372036854776833e+18}}}}},
+			filter: bson.D{{"v", bson.D{{"$mod", bson.A{9.223372036854776833e+18, 9.223372036854776833e+18}}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
@@ -164,47 +164,47 @@ func TestQueryEvaluationMod(t *testing.T) {
 			},
 		},
 		"MinInt64_Divisor": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{math.MinInt64, 0}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{math.MinInt64, 0}}}}},
 			expectedIDs: []any{"MinInt64", "MinInt64_float", "MinInt64_minus", "MinInt64_overflowVerge", "NegativeZero", "SmallestNonzeroFloat64", "Zero"},
 		},
 		"MinInt64_Remainder": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{1, math.MinInt64}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{1, math.MinInt64}}}}},
 			expectedIDs: []any{},
 		},
 		"MinInt64_floatDivisor": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{float64(math.MinInt64), 0}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{float64(math.MinInt64), 0}}}}},
 			expectedIDs: []any{"MinInt64", "MinInt64_float", "MinInt64_minus", "MinInt64_overflowVerge", "NegativeZero", "SmallestNonzeroFloat64", "Zero"},
 		},
 		"MinInt64_floatRemainder": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{1, float64(math.MinInt64)}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{1, float64(math.MinInt64)}}}}},
 			expectedIDs: []any{},
 		},
 		"MinInt64_minus": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{-9.223372036854775809e+18, 0}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{-9.223372036854775809e+18, 0}}}}},
 			expectedIDs: []any{"MinInt64", "MinInt64_float", "MinInt64_minus", "MinInt64_overflowVerge", "NegativeZero", "SmallestNonzeroFloat64", "Zero"},
 		},
 		"MinInt64_1": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{-922337203685477580, -8}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{-922337203685477580, -8}}}}},
 			expectedIDs: []any{"MinInt64", "MinInt64_float", "MinInt64_minus", "MinInt64_overflowVerge"},
 		},
 		"MinInt64_2": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{-9.223372036854775808e+17, -8}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{-9.223372036854775808e+17, -8}}}}},
 			expectedIDs: []any{},
 		},
 		"MinInt64_3": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{-9.223372036854775800e+17, -8}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{-9.223372036854775800e+17, -8}}}}},
 			expectedIDs: []any{},
 		},
 		"MinInt64_4": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{-922337203, -6854775808}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{-922337203, -6854775808}}}}},
 			expectedIDs: []any{},
 		},
 		"MinInt64_overflowVerge": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{-9.223372036854776832e+18, 0}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{-9.223372036854776832e+18, 0}}}}},
 			expectedIDs: []any{"MinInt64", "MinInt64_float", "MinInt64_minus", "MinInt64_overflowVerge", "NegativeZero", "SmallestNonzeroFloat64", "Zero"},
 		},
 		"MinInt64_overflowDivisor": {
-			filter: bson.D{{"value", bson.D{{"$mod", bson.A{-9.223372036854776833e+18, 0}}}}},
+			filter: bson.D{{"v", bson.D{{"$mod", bson.A{-9.223372036854776833e+18, 0}}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
@@ -212,7 +212,7 @@ func TestQueryEvaluationMod(t *testing.T) {
 			},
 		},
 		"MinInt64_overflowBoth": {
-			filter: bson.D{{"value", bson.D{{"$mod", bson.A{-9.223372036854776833e+18, -9.223372036854776833e+18}}}}},
+			filter: bson.D{{"v", bson.D{{"$mod", bson.A{-9.223372036854776833e+18, -9.223372036854776833e+18}}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
@@ -220,7 +220,7 @@ func TestQueryEvaluationMod(t *testing.T) {
 			},
 		},
 		"Float64_1": {
-			filter: bson.D{{"value", bson.D{{"$mod", bson.A{1.79769e+307, 0}}}}},
+			filter: bson.D{{"v", bson.D{{"$mod", bson.A{1.79769e+307, 0}}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
@@ -228,7 +228,7 @@ func TestQueryEvaluationMod(t *testing.T) {
 			},
 		},
 		"Float64_2": {
-			filter: bson.D{{"value", bson.D{{"$mod", bson.A{math.MaxFloat64, 0}}}}},
+			filter: bson.D{{"v", bson.D{{"$mod", bson.A{math.MaxFloat64, 0}}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
@@ -236,7 +236,7 @@ func TestQueryEvaluationMod(t *testing.T) {
 			},
 		},
 		"Float64_3": {
-			filter: bson.D{{"value", bson.D{{"$mod", bson.A{math.MaxFloat64, math.MaxFloat64}}}}},
+			filter: bson.D{{"v", bson.D{{"$mod", bson.A{math.MaxFloat64, math.MaxFloat64}}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
@@ -244,31 +244,31 @@ func TestQueryEvaluationMod(t *testing.T) {
 			},
 		},
 		"NegativeDivisor": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{-100, 89}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{-100, 89}}}}},
 			expectedIDs: []any{"PositiveNumber"},
 		},
 		"NegativeRemainder": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{100, -89}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{100, -89}}}}},
 			expectedIDs: []any{"NegativeNumber"},
 		},
 		"NegativeBoth": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{-100, -89}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{-100, -89}}}}},
 			expectedIDs: []any{"NegativeNumber"},
 		},
 		"NegativeDivisorFloat": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{-100.5, 89.5}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{-100.5, 89.5}}}}},
 			expectedIDs: []any{"PositiveNumber"},
 		},
 		"NegativeRemainderFloat": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{100.5, -89.5}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{100.5, -89.5}}}}},
 			expectedIDs: []any{"NegativeNumber"},
 		},
 		"NegativeBothFloat": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{-100.5, -89.5}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{-100.5, -89.5}}}}},
 			expectedIDs: []any{"NegativeNumber"},
 		},
 		"DivisorZero": {
-			filter: bson.D{{"value", bson.D{{"$mod", bson.A{0, 1}}}}},
+			filter: bson.D{{"v", bson.D{{"$mod", bson.A{0, 1}}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
@@ -276,7 +276,7 @@ func TestQueryEvaluationMod(t *testing.T) {
 			},
 		},
 		"ZeroNegativeDevisor": {
-			filter: bson.D{{"value", bson.D{{"$mod", bson.A{math.Copysign(0, -1), 1}}}}},
+			filter: bson.D{{"v", bson.D{{"$mod", bson.A{math.Copysign(0, -1), 1}}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
@@ -284,7 +284,7 @@ func TestQueryEvaluationMod(t *testing.T) {
 			},
 		},
 		"DivisorSmallestNonzeroFloat64": {
-			filter: bson.D{{"value", bson.D{{"$mod", bson.A{math.SmallestNonzeroFloat64, 1}}}}},
+			filter: bson.D{{"v", bson.D{{"$mod", bson.A{math.SmallestNonzeroFloat64, 1}}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
@@ -292,11 +292,11 @@ func TestQueryEvaluationMod(t *testing.T) {
 			},
 		},
 		"RemainderSmallestNonzeroFloat64": {
-			filter:      bson.D{{"value", bson.D{{"$mod", bson.A{23456789, math.SmallestNonzeroFloat64}}}}},
+			filter:      bson.D{{"v", bson.D{{"$mod", bson.A{23456789, math.SmallestNonzeroFloat64}}}}},
 			expectedIDs: []any{"NegativeZero", "SmallestNonzeroFloat64", "Zero"},
 		},
 		"EmptyArray": {
-			filter: bson.D{{"value", bson.D{{"$mod", bson.A{}}}}},
+			filter: bson.D{{"v", bson.D{{"$mod", bson.A{}}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
@@ -304,7 +304,7 @@ func TestQueryEvaluationMod(t *testing.T) {
 			},
 		},
 		"NotEnoughElements": {
-			filter: bson.D{{"value", bson.D{{"$mod", bson.A{1}}}}},
+			filter: bson.D{{"v", bson.D{{"$mod", bson.A{1}}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
@@ -312,7 +312,7 @@ func TestQueryEvaluationMod(t *testing.T) {
 			},
 		},
 		"TooManyElements": {
-			filter: bson.D{{"value", bson.D{{"$mod", bson.A{1, 2, 3}}}}},
+			filter: bson.D{{"v", bson.D{{"$mod", bson.A{1, 2, 3}}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
@@ -320,7 +320,7 @@ func TestQueryEvaluationMod(t *testing.T) {
 			},
 		},
 		"DivisorNotNumber": {
-			filter: bson.D{{"value", bson.D{{"$mod", bson.A{"1", 2}}}}},
+			filter: bson.D{{"v", bson.D{{"$mod", bson.A{"1", 2}}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
@@ -328,7 +328,7 @@ func TestQueryEvaluationMod(t *testing.T) {
 			},
 		},
 		"RemainderNotNumber": {
-			filter: bson.D{{"value", bson.D{{"$mod", bson.A{1, "2"}}}}},
+			filter: bson.D{{"v", bson.D{{"$mod", bson.A{1, "2"}}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
@@ -336,7 +336,7 @@ func TestQueryEvaluationMod(t *testing.T) {
 			},
 		},
 		"Nil": {
-			filter: bson.D{{"value", bson.D{{"$mod", bson.A{nil, 3}}}}},
+			filter: bson.D{{"v", bson.D{{"$mod", bson.A{nil, 3}}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
@@ -344,7 +344,7 @@ func TestQueryEvaluationMod(t *testing.T) {
 			},
 		},
 		"DivisorNaN": {
-			filter: bson.D{{"value", bson.D{{"$mod", bson.A{math.NaN(), 1}}}}},
+			filter: bson.D{{"v", bson.D{{"$mod", bson.A{math.NaN(), 1}}}}},
 			err: &mongo.CommandError{
 				Code: 2,
 				Name: "BadValue",
@@ -353,7 +353,7 @@ func TestQueryEvaluationMod(t *testing.T) {
 			},
 		},
 		"RemainderNaN": {
-			filter: bson.D{{"value", bson.D{{"$mod", bson.A{1, math.NaN()}}}}},
+			filter: bson.D{{"v", bson.D{{"$mod", bson.A{1, math.NaN()}}}}},
 			err: &mongo.CommandError{
 				Code: 2,
 				Name: "BadValue",
@@ -362,7 +362,7 @@ func TestQueryEvaluationMod(t *testing.T) {
 			},
 		},
 		"InfinityNegative": {
-			filter: bson.D{{"value", bson.D{{"$mod", bson.A{1, math.Inf(-1)}}}}},
+			filter: bson.D{{"v", bson.D{{"$mod", bson.A{1, math.Inf(-1)}}}}},
 			err: &mongo.CommandError{
 				Code: 2,
 				Name: "BadValue",
@@ -371,7 +371,7 @@ func TestQueryEvaluationMod(t *testing.T) {
 			},
 		},
 		"Infinity": {
-			filter: bson.D{{"value", bson.D{{"$mod", bson.A{1, math.Inf(0)}}}}},
+			filter: bson.D{{"v", bson.D{{"$mod", bson.A{1, math.Inf(0)}}}}},
 			err: &mongo.CommandError{
 				Code: 2,
 				Name: "BadValue",
@@ -380,7 +380,7 @@ func TestQueryEvaluationMod(t *testing.T) {
 			},
 		},
 		"InfinityPositive": {
-			filter: bson.D{{"value", bson.D{{"$mod", bson.A{math.Inf(+1), 0}}}}},
+			filter: bson.D{{"v", bson.D{{"$mod", bson.A{math.Inf(+1), 0}}}}},
 			err: &mongo.CommandError{
 				Code: 2,
 				Name: "BadValue",
@@ -414,10 +414,10 @@ func TestQueryEvaluationRegex(t *testing.T) {
 	ctx, collection := Setup(t, shareddata.Scalars)
 
 	_, err := collection.InsertMany(ctx, []any{
-		bson.D{{"_id", "multiline-string"}, {"value", "bar\nfoo"}},
+		bson.D{{"_id", "multiline-string"}, {"v", "bar\nfoo"}},
 		bson.D{
 			{"_id", "document-nested-strings"},
-			{"value", bson.D{{"foo", bson.D{{"bar", "quz"}}}}},
+			{"v", bson.D{{"foo", bson.D{{"bar", "quz"}}}}},
 		},
 	})
 	require.NoError(t, err)
@@ -427,27 +427,27 @@ func TestQueryEvaluationRegex(t *testing.T) {
 		expectedIDs []any
 	}{
 		"Regex": {
-			filter:      bson.D{{"value", bson.D{{"$regex", primitive.Regex{Pattern: "foo"}}}}},
+			filter:      bson.D{{"v", bson.D{{"$regex", primitive.Regex{Pattern: "foo"}}}}},
 			expectedIDs: []any{"multiline-string", "string"},
 		},
 		"RegexNested": {
-			filter:      bson.D{{"value.foo.bar", bson.D{{"$regex", primitive.Regex{Pattern: "quz"}}}}},
+			filter:      bson.D{{"v.foo.bar", bson.D{{"$regex", primitive.Regex{Pattern: "quz"}}}}},
 			expectedIDs: []any{"document-nested-strings"},
 		},
 		"RegexWithOption": {
-			filter:      bson.D{{"value", bson.D{{"$regex", primitive.Regex{Pattern: "42", Options: "i"}}}}},
+			filter:      bson.D{{"v", bson.D{{"$regex", primitive.Regex{Pattern: "42", Options: "i"}}}}},
 			expectedIDs: []any{"string-double", "string-whole"},
 		},
 		"RegexStringOptionMatchCaseInsensitive": {
-			filter:      bson.D{{"value", bson.D{{"$regex", "foo"}, {"$options", "i"}}}},
+			filter:      bson.D{{"v", bson.D{{"$regex", "foo"}, {"$options", "i"}}}},
 			expectedIDs: []any{"multiline-string", "regex", "string"},
 		},
 		"RegexStringOptionMatchLineEnd": {
-			filter:      bson.D{{"value", bson.D{{"$regex", "b.*foo"}, {"$options", "s"}}}},
+			filter:      bson.D{{"v", bson.D{{"$regex", "b.*foo"}, {"$options", "s"}}}},
 			expectedIDs: []any{"multiline-string"},
 		},
 		"RegexStringOptionMatchMultiline": {
-			filter:      bson.D{{"value", bson.D{{"$regex", "^foo"}, {"$options", "m"}}}},
+			filter:      bson.D{{"v", bson.D{{"$regex", "^foo"}, {"$options", "m"}}}},
 			expectedIDs: []any{"multiline-string", "string"},
 		},
 		"RegexNoSuchField": {
@@ -459,7 +459,7 @@ func TestQueryEvaluationRegex(t *testing.T) {
 			expectedIDs: []any{},
 		},
 		"RegexBadOption": {
-			filter:      bson.D{{"value", bson.D{{"$regex", primitive.Regex{Pattern: "foo", Options: "123"}}}}},
+			filter:      bson.D{{"v", bson.D{{"$regex", primitive.Regex{Pattern: "foo", Options: "123"}}}}},
 			expectedIDs: []any{"multiline-string", "string"},
 		},
 	} {
@@ -483,7 +483,7 @@ func TestQueryEvaluationRegexErrors(t *testing.T) {
 	ctx, collection := Setup(t, shareddata.Scalars)
 
 	_, err := collection.InsertMany(ctx, []any{
-		bson.D{{"_id", "multiline-string"}, {"value", "bar\nfoo"}},
+		bson.D{{"_id", "multiline-string"}, {"v", "bar\nfoo"}},
 	})
 	require.NoError(t, err)
 
@@ -492,7 +492,7 @@ func TestQueryEvaluationRegexErrors(t *testing.T) {
 		err    *mongo.CommandError
 	}{
 		"MissingClosingParen": {
-			filter: bson.D{{"value", bson.D{{"$regex", primitive.Regex{Pattern: "g(-z]+ng  wrong regex"}}}}},
+			filter: bson.D{{"v", bson.D{{"$regex", primitive.Regex{Pattern: "g(-z]+ng  wrong regex"}}}}},
 			err: &mongo.CommandError{
 				Code:    51091,
 				Name:    "Location51091",
@@ -500,7 +500,7 @@ func TestQueryEvaluationRegexErrors(t *testing.T) {
 			},
 		},
 		"MissingClosingBracket": {
-			filter: bson.D{{"value", bson.D{{"$regex", primitive.Regex{Pattern: "g[-z+ng  wrong regex"}}}}},
+			filter: bson.D{{"v", bson.D{{"$regex", primitive.Regex{Pattern: "g[-z+ng  wrong regex"}}}}},
 			err: &mongo.CommandError{
 				Code:    51091,
 				Name:    "Location51091",
@@ -508,7 +508,7 @@ func TestQueryEvaluationRegexErrors(t *testing.T) {
 			},
 		},
 		"InvalidEscape": {
-			filter: bson.D{{"value", bson.D{{"$regex", primitive.Regex{Pattern: "\\uZ"}}}}},
+			filter: bson.D{{"v", bson.D{{"$regex", primitive.Regex{Pattern: "\\uZ"}}}}},
 			err: &mongo.CommandError{
 				Code:    51091,
 				Name:    "Location51091",
@@ -516,7 +516,7 @@ func TestQueryEvaluationRegexErrors(t *testing.T) {
 			},
 		},
 		"NamedCapture": {
-			filter: bson.D{{"value", bson.D{{"$regex", primitive.Regex{Pattern: "(?P<name)"}}}}},
+			filter: bson.D{{"v", bson.D{{"$regex", primitive.Regex{Pattern: "(?P<name)"}}}}},
 			err: &mongo.CommandError{
 				Code:    51091,
 				Name:    "Location51091",
@@ -524,7 +524,7 @@ func TestQueryEvaluationRegexErrors(t *testing.T) {
 			},
 		},
 		"UnexpectedParen": {
-			filter: bson.D{{"value", bson.D{{"$regex", primitive.Regex{Pattern: ")"}}}}},
+			filter: bson.D{{"v", bson.D{{"$regex", primitive.Regex{Pattern: ")"}}}}},
 			err: &mongo.CommandError{
 				Code:    51091,
 				Name:    "Location51091",
@@ -532,7 +532,7 @@ func TestQueryEvaluationRegexErrors(t *testing.T) {
 			},
 		},
 		"TrailingBackslash": {
-			filter: bson.D{{"value", bson.D{{"$regex", primitive.Regex{Pattern: `abc\`}}}}},
+			filter: bson.D{{"v", bson.D{{"$regex", primitive.Regex{Pattern: `abc\`}}}}},
 			err: &mongo.CommandError{
 				Code:    51091,
 				Name:    "Location51091",
@@ -540,7 +540,7 @@ func TestQueryEvaluationRegexErrors(t *testing.T) {
 			},
 		},
 		"InvalidRepetition": {
-			filter: bson.D{{"value", bson.D{{"$regex", primitive.Regex{Pattern: `a**`}}}}},
+			filter: bson.D{{"v", bson.D{{"$regex", primitive.Regex{Pattern: `a**`}}}}},
 			err: &mongo.CommandError{
 				Code:    51091,
 				Name:    "Location51091",
@@ -548,7 +548,7 @@ func TestQueryEvaluationRegexErrors(t *testing.T) {
 			},
 		},
 		"MissingRepetitionArgumentStar": {
-			filter: bson.D{{"value", bson.D{{"$regex", primitive.Regex{Pattern: `*`}}}}},
+			filter: bson.D{{"v", bson.D{{"$regex", primitive.Regex{Pattern: `*`}}}}},
 			err: &mongo.CommandError{
 				Code:    51091,
 				Name:    "Location51091",
@@ -556,7 +556,7 @@ func TestQueryEvaluationRegexErrors(t *testing.T) {
 			},
 		},
 		"MissingRepetitionArgumentPlus": {
-			filter: bson.D{{"value", bson.D{{"$regex", primitive.Regex{Pattern: `+`}}}}},
+			filter: bson.D{{"v", bson.D{{"$regex", primitive.Regex{Pattern: `+`}}}}},
 			err: &mongo.CommandError{
 				Code:    51091,
 				Name:    "Location51091",
@@ -564,7 +564,7 @@ func TestQueryEvaluationRegexErrors(t *testing.T) {
 			},
 		},
 		"MissingRepetitionArgumentQuestion": {
-			filter: bson.D{{"value", bson.D{{"$regex", primitive.Regex{Pattern: `?`}}}}},
+			filter: bson.D{{"v", bson.D{{"$regex", primitive.Regex{Pattern: `?`}}}}},
 			err: &mongo.CommandError{
 				Code:    51091,
 				Name:    "Location51091",
@@ -572,7 +572,7 @@ func TestQueryEvaluationRegexErrors(t *testing.T) {
 			},
 		},
 		"InvalidClassRange": {
-			filter: bson.D{{"value", bson.D{{"$regex", primitive.Regex{Pattern: `[z-a]`}}}}},
+			filter: bson.D{{"v", bson.D{{"$regex", primitive.Regex{Pattern: `[z-a]`}}}}},
 			err: &mongo.CommandError{
 				Code:    51091,
 				Name:    "Location51091",
@@ -580,7 +580,7 @@ func TestQueryEvaluationRegexErrors(t *testing.T) {
 			},
 		},
 		"InvalidNestedRepetitionOperatorStar": {
-			filter: bson.D{{"value", bson.D{{"$regex", primitive.Regex{Pattern: `a**`}}}}},
+			filter: bson.D{{"v", bson.D{{"$regex", primitive.Regex{Pattern: `a**`}}}}},
 			err: &mongo.CommandError{
 				Code:    51091,
 				Name:    "Location51091",
@@ -588,7 +588,7 @@ func TestQueryEvaluationRegexErrors(t *testing.T) {
 			},
 		},
 		"InvalidPerlOp": {
-			filter: bson.D{{"value", bson.D{{"$regex", `(?z)`}}}},
+			filter: bson.D{{"v", bson.D{{"$regex", `(?z)`}}}},
 			err: &mongo.CommandError{
 				Code:    51091,
 				Name:    "Location51091",
@@ -596,7 +596,7 @@ func TestQueryEvaluationRegexErrors(t *testing.T) {
 			},
 		},
 		"InvalidRepeatSize": {
-			filter: bson.D{{"value", bson.D{{"$regex", `(aa){3,10001}`}}}},
+			filter: bson.D{{"v", bson.D{{"$regex", `(aa){3,10001}`}}}},
 			err: &mongo.CommandError{
 				Code:    51091,
 				Name:    "Location51091",

--- a/integration/query_logical_compat_test.go
+++ b/integration/query_logical_compat_test.go
@@ -27,8 +27,8 @@ func TestQueryLogicalCompatAnd(t *testing.T) {
 		"And": {
 			filter: bson.D{{
 				"$and", bson.A{
-					bson.D{{"value", bson.D{{"$gt", int32(0)}}}},
-					bson.D{{"value", bson.D{{"$lt", int64(42)}}}},
+					bson.D{{"v", bson.D{{"$gt", int32(0)}}}},
+					bson.D{{"v", bson.D{{"$lt", int64(42)}}}},
 				},
 			}},
 		},
@@ -38,7 +38,7 @@ func TestQueryLogicalCompatAnd(t *testing.T) {
 		"BadExpressionValue": {
 			filter: bson.D{{
 				"$and", bson.A{
-					bson.D{{"value", bson.D{{"$gt", int32(0)}}}},
+					bson.D{{"v", bson.D{{"$gt", int32(0)}}}},
 					nil,
 				},
 			}},
@@ -46,10 +46,10 @@ func TestQueryLogicalCompatAnd(t *testing.T) {
 		"AndOr": {
 			filter: bson.D{{
 				"$and", bson.A{
-					bson.D{{"value", bson.D{{"$gt", int32(0)}}}},
+					bson.D{{"v", bson.D{{"$gt", int32(0)}}}},
 					bson.D{{"$or", bson.A{
-						bson.D{{"value", bson.D{{"$lt", int64(42)}}}},
-						bson.D{{"value", bson.D{{"$lte", 42.13}}}},
+						bson.D{{"v", bson.D{{"$lt", int64(42)}}}},
+						bson.D{{"v", bson.D{{"$lte", 42.13}}}},
 					}}},
 				},
 			}},
@@ -58,10 +58,10 @@ func TestQueryLogicalCompatAnd(t *testing.T) {
 			filter: bson.D{{
 				"$and", bson.A{
 					bson.D{{"$and", bson.A{
-						bson.D{{"value", bson.D{{"$gt", int32(0)}}}},
-						bson.D{{"value", bson.D{{"$lte", 42.13}}}},
+						bson.D{{"v", bson.D{{"$gt", int32(0)}}}},
+						bson.D{{"v", bson.D{{"$lte", 42.13}}}},
 					}}},
-					bson.D{{"value", bson.D{{"$type", "int"}}}},
+					bson.D{{"v", bson.D{{"$type", "int"}}}},
 				},
 			}},
 		},

--- a/integration/query_logical_test.go
+++ b/integration/query_logical_test.go
@@ -38,8 +38,8 @@ func TestQueryLogicalOr(t *testing.T) {
 	}{
 		"Or": {
 			filter: bson.A{
-				bson.D{{"value", bson.D{{"$lt", 0}}}},
-				bson.D{{"value", bson.D{{"$lt", 42}}}},
+				bson.D{{"v", bson.D{{"$lt", 0}}}},
+				bson.D{{"v", bson.D{{"$lt", 42}}}},
 			},
 			expectedIDs: []any{
 				"double-negative-infinity", "double-negative-zero",
@@ -80,7 +80,7 @@ func TestQueryLogicalOr(t *testing.T) {
 		},
 		"BadExpressionValue": {
 			filter: bson.A{
-				bson.D{{"value", bson.D{{"$gt", 0}}}},
+				bson.D{{"v", bson.D{{"$gt", 0}}}},
 				nil,
 			},
 			err: &mongo.CommandError{
@@ -122,8 +122,8 @@ func TestQueryLogicalNor(t *testing.T) {
 	}{
 		"Nor": {
 			filter: bson.A{
-				bson.D{{"value", bson.D{{"$gt", 0}}}},
-				bson.D{{"value", bson.D{{"$gt", 42}}}},
+				bson.D{{"v", bson.D{{"$gt", 0}}}},
+				bson.D{{"v", bson.D{{"$gt", 42}}}},
 			},
 			expectedIDs: []any{
 				"binary", "binary-empty", "bool-false", "bool-true",
@@ -145,7 +145,7 @@ func TestQueryLogicalNor(t *testing.T) {
 		},
 		"BadExpressionValue": {
 			filter: bson.A{
-				bson.D{{"value", bson.D{{"$gt", 0}}}},
+				bson.D{{"v", bson.D{{"$gt", 0}}}},
 				nil,
 			},
 			err: &mongo.CommandError{
@@ -187,7 +187,7 @@ func TestQueryLogicalNot(t *testing.T) {
 		err         *mongo.CommandError
 	}{
 		"Not": {
-			filter: bson.D{{"value", bson.D{{"$not", bson.D{{"$eq", 42}}}}}},
+			filter: bson.D{{"v", bson.D{{"$not", bson.D{{"$eq", 42}}}}}},
 			expectedIDs: []any{
 				"array-embedded", "array-empty", "array-empty-nested", "array-first-embedded", "array-last-embedded",
 				"array-middle-embedded", "array-null", "array-two",
@@ -216,7 +216,7 @@ func TestQueryLogicalNot(t *testing.T) {
 			},
 		},
 		"NotEqNull": {
-			filter: bson.D{{"value", bson.D{{"$not", bson.D{{"$eq", nil}}}}}},
+			filter: bson.D{{"v", bson.D{{"$not", bson.D{{"$eq", nil}}}}}},
 			expectedIDs: []any{
 				"array", "array-embedded", "array-empty", "array-empty-nested", "array-two",
 				"binary", "binary-empty",
@@ -234,7 +234,7 @@ func TestQueryLogicalNot(t *testing.T) {
 			},
 		},
 		"ValueRegex": {
-			filter: bson.D{{"value", bson.D{{"$not", primitive.Regex{Pattern: "^fo"}}}}},
+			filter: bson.D{{"v", bson.D{{"$not", primitive.Regex{Pattern: "^fo"}}}}},
 			expectedIDs: []any{
 				"array", "array-embedded", "array-empty", "array-empty-nested", "array-first-embedded",
 				"array-last-embedded", "array-middle-embedded", "array-null", "array-two",
@@ -275,7 +275,7 @@ func TestQueryLogicalNot(t *testing.T) {
 			},
 		},
 		"NestedNot": {
-			filter:      bson.D{{"value", bson.D{{"$not", bson.D{{"$not", bson.D{{"$eq", 42}}}}}}}},
+			filter:      bson.D{{"v", bson.D{{"$not", bson.D{{"$not", bson.D{{"$eq", 42}}}}}}}},
 			expectedIDs: []any{"array", "array-three", "array-three-reverse", "double-whole", "int32", "int64"},
 		},
 	} {

--- a/integration/query_projection_test.go
+++ b/integration/query_projection_test.go
@@ -35,7 +35,7 @@ func TestQueryProjection(t *testing.T) {
 	_, err := collection.InsertMany(ctx, []any{
 		bson.D{
 			{"_id", "document-composite-2"},
-			{"value", bson.A{
+			{"v", bson.A{
 				bson.D{{"field", int32(42)}},
 				bson.D{{"field", int32(44)}},
 			}},
@@ -58,7 +58,7 @@ func TestQueryProjection(t *testing.T) {
 			filter: bson.D{{"_id", "document-composite"}},
 			// TODO: https://github.com/FerretDB/FerretDB/issues/537
 			projection: bson.D{{"foo", int32(0)}, {"array", false}},
-			expected:   bson.D{{"_id", "document-composite"}, {"value", bson.D{{"foo", int32(42)}, {"42", "foo"}, {"array", bson.A{int32(42), "foo", nil}}}}},
+			expected:   bson.D{{"_id", "document-composite"}, {"v", bson.D{{"foo", int32(42)}, {"42", "foo"}, {"array", bson.A{int32(42), "foo", nil}}}}},
 		},
 		"FindProjectionIDExclusion": {
 			filter: bson.D{{"_id", "document-composite"}},
@@ -69,7 +69,7 @@ func TestQueryProjection(t *testing.T) {
 		"ProjectionSliceNonArrayField": {
 			filter:     bson.D{{"_id", "document"}},
 			projection: bson.D{{"_id", bson.D{{"$slice", 1}}}},
-			expected:   bson.D{{"_id", "document"}, {"value", bson.D{{"foo", int32(42)}}}},
+			expected:   bson.D{{"_id", "document"}, {"v", bson.D{{"foo", int32(42)}}}},
 		},
 	} {
 		name, tc := name, tc
@@ -96,7 +96,7 @@ func TestQueryProjectionElemMatch(t *testing.T) {
 	_, err := collection.InsertMany(ctx, []any{
 		bson.D{
 			{"_id", "document-composite-2"},
-			{"value", bson.A{
+			{"v", bson.A{
 				bson.D{{"field", int32(42)}},
 				bson.D{{"field", int32(44)}},
 			}},
@@ -110,7 +110,7 @@ func TestQueryProjectionElemMatch(t *testing.T) {
 	}{
 		"ElemMatch": {
 			projection: bson.D{{
-				"value",
+				"v",
 				bson.D{{"$elemMatch", bson.D{{"field", bson.D{{"$eq", 42}}}}}},
 			}},
 			expectedIDs: []any{
@@ -142,7 +142,7 @@ func TestQueryProjectionSlice(t *testing.T) {
 	t.Parallel()
 	ctx, collection := Setup(t)
 	_, err := collection.InsertOne(ctx,
-		bson.D{{"_id", "array"}, {"value", bson.A{1, 2, 3, 4}}},
+		bson.D{{"_id", "array"}, {"v", bson.A{1, 2, 3, 4}}},
 	)
 	require.NoError(t, err)
 
@@ -153,7 +153,7 @@ func TestQueryProjectionSlice(t *testing.T) {
 		altMessage    string
 	}{
 		"SingleArgDocument": {
-			projection: bson.D{{"value", bson.D{
+			projection: bson.D{{"v", bson.D{
 				{"$slice", bson.D{{"a", bson.D{{"b", 3}}}, {"b", "string"}}},
 			}}},
 			err: &mongo.CommandError{
@@ -174,7 +174,7 @@ func TestQueryProjectionSlice(t *testing.T) {
 				"but 1 were passed in.",
 		},
 		"SingleArgString": {
-			projection: bson.D{{"value", bson.D{{"$slice", "string"}}}},
+			projection: bson.D{{"v", bson.D{{"$slice", "string"}}}},
 			err: &mongo.CommandError{
 				Code: 28667,
 				Name: "Location28667",
@@ -193,7 +193,7 @@ func TestQueryProjectionSlice(t *testing.T) {
 				"but 1 were passed in.",
 		},
 		"SkipIsString": {
-			projection: bson.D{{"value", bson.D{{"$slice", bson.A{"string", 5}}}}},
+			projection: bson.D{{"v", bson.D{{"$slice", bson.A{"string", 5}}}}},
 			err: &mongo.CommandError{
 				Code:    28724,
 				Name:    "Location28724",
@@ -201,7 +201,7 @@ func TestQueryProjectionSlice(t *testing.T) {
 			},
 		},
 		"LimitIsString": {
-			projection: bson.D{{"value", bson.D{{"$slice", bson.A{int32(2), "string"}}}}},
+			projection: bson.D{{"v", bson.D{{"$slice", bson.A{int32(2), "string"}}}}},
 			err: &mongo.CommandError{
 				Code:    28724,
 				Name:    "Location28724",
@@ -209,7 +209,7 @@ func TestQueryProjectionSlice(t *testing.T) {
 			},
 		},
 		"ArgEmptyArr": {
-			projection: bson.D{{"value", bson.D{{"$slice", bson.A{}}}}},
+			projection: bson.D{{"v", bson.D{{"$slice", bson.A{}}}}},
 			err: &mongo.CommandError{
 				Code: 28667,
 				Name: "Location28667",
@@ -228,7 +228,7 @@ func TestQueryProjectionSlice(t *testing.T) {
 				"Expression $slice takes at least 2 arguments, and at most 3, but 0 were passed in.",
 		},
 		"ThreeArgs": {
-			projection: bson.D{{"value", bson.D{{"$slice", bson.A{"string", 2, 3}}}}},
+			projection: bson.D{{"v", bson.D{{"$slice", bson.A{"string", 2, 3}}}}},
 			err: &mongo.CommandError{
 				Code:    28724,
 				Name:    "Location28724",
@@ -236,7 +236,7 @@ func TestQueryProjectionSlice(t *testing.T) {
 			},
 		},
 		"TooManyArgs": {
-			projection: bson.D{{"value", bson.D{{"$slice", bson.A{1, 2, 3, 4}}}}},
+			projection: bson.D{{"v", bson.D{{"$slice", bson.A{1, 2, 3, 4}}}}},
 			err: &mongo.CommandError{
 				Code: 28667,
 				Name: "Location28667",
@@ -255,39 +255,39 @@ func TestQueryProjectionSlice(t *testing.T) {
 				"Expression $slice takes at least 2 arguments, and at most 3, but 4 were passed in.",
 		},
 		"Int64SingleArg": {
-			projection:    bson.D{{"value", bson.D{{"$slice", int64(2)}}}},
+			projection:    bson.D{{"v", bson.D{{"$slice", int64(2)}}}},
 			expectedArray: bson.A{int32(1), int32(2)},
 		},
 		"PositiveSingleArg": {
-			projection:    bson.D{{"value", bson.D{{"$slice", 2}}}},
+			projection:    bson.D{{"v", bson.D{{"$slice", 2}}}},
 			expectedArray: bson.A{int32(1), int32(2)},
 		},
 		"NegativeSingleArg": {
-			projection:    bson.D{{"value", bson.D{{"$slice", -2}}}},
+			projection:    bson.D{{"v", bson.D{{"$slice", -2}}}},
 			expectedArray: bson.A{int32(3), int32(4)},
 		},
 		"SingleArgFloat": {
-			projection:    bson.D{{"value", bson.D{{"$slice", 1.4}}}},
+			projection:    bson.D{{"v", bson.D{{"$slice", 1.4}}}},
 			expectedArray: bson.A{int32(1)},
 		},
 		"SkipFloat": {
-			projection:    bson.D{{"value", bson.D{{"$slice", bson.A{-2.5, 2}}}}},
+			projection:    bson.D{{"v", bson.D{{"$slice", bson.A{-2.5, 2}}}}},
 			expectedArray: bson.A{int32(3), int32(4)},
 		},
 		"LimitFloat": {
-			projection:    bson.D{{"value", bson.D{{"$slice", bson.A{1, 2.8}}}}},
+			projection:    bson.D{{"v", bson.D{{"$slice", bson.A{1, 2.8}}}}},
 			expectedArray: bson.A{int32(2), int32(3)},
 		},
 		"PositiveSkip": {
-			projection:    bson.D{{"value", bson.D{{"$slice", bson.A{1, 2}}}}},
+			projection:    bson.D{{"v", bson.D{{"$slice", bson.A{1, 2}}}}},
 			expectedArray: bson.A{int32(2), int32(3)},
 		},
 		"NegativeSkip": {
-			projection:    bson.D{{"value", bson.D{{"$slice", bson.A{-3, 2}}}}},
+			projection:    bson.D{{"v", bson.D{{"$slice", bson.A{-3, 2}}}}},
 			expectedArray: bson.A{int32(2), int32(3)},
 		},
 		"NegativeLimitSkipInt64": {
-			projection: bson.D{{"value", bson.D{{"$slice", bson.A{int64(3), -2}}}}},
+			projection: bson.D{{"v", bson.D{{"$slice", bson.A{int64(3), -2}}}}},
 			err: &mongo.CommandError{
 				Code:    28724,
 				Name:    "Location28724",
@@ -295,7 +295,7 @@ func TestQueryProjectionSlice(t *testing.T) {
 			},
 		},
 		"NegativeLimitSkipInt": {
-			projection: bson.D{{"value", bson.D{{"$slice", bson.A{3, -2}}}}},
+			projection: bson.D{{"v", bson.D{{"$slice", bson.A{3, -2}}}}},
 			err: &mongo.CommandError{
 				Code:    28724,
 				Name:    "Location28724",
@@ -303,7 +303,7 @@ func TestQueryProjectionSlice(t *testing.T) {
 			},
 		},
 		"NegativeLimitSkipFloat": {
-			projection: bson.D{{"value", bson.D{{"$slice", bson.A{0.3, -2}}}}},
+			projection: bson.D{{"v", bson.D{{"$slice", bson.A{0.3, -2}}}}},
 			err: &mongo.CommandError{
 				Code:    28724,
 				Name:    "Location28724",
@@ -311,15 +311,15 @@ func TestQueryProjectionSlice(t *testing.T) {
 			},
 		},
 		"ArgNaN": {
-			projection:    bson.D{{"value", bson.D{{"$slice", math.NaN()}}}},
+			projection:    bson.D{{"v", bson.D{{"$slice", math.NaN()}}}},
 			expectedArray: bson.A{},
 		},
 		"ArgInf": {
-			projection:    bson.D{{"value", bson.D{{"$slice", math.Inf(+1)}}}},
+			projection:    bson.D{{"v", bson.D{{"$slice", math.Inf(+1)}}}},
 			expectedArray: bson.A{int32(1), int32(2), int32(3), int32(4)},
 		},
 		"SingleArgNull": {
-			projection: bson.D{{"value", bson.D{{"$slice", nil}}}},
+			projection: bson.D{{"v", bson.D{{"$slice", nil}}}},
 			err: &mongo.CommandError{
 				Code: 28667,
 				Name: "Location28667",
@@ -336,7 +336,7 @@ func TestQueryProjectionSlice(t *testing.T) {
 				"Expression $slice takes at least 2 arguments, and at most 3, but 1 were passed in.",
 		},
 		"NullInArr": {
-			projection: bson.D{{"value", bson.D{{"$slice", bson.A{nil}}}}},
+			projection: bson.D{{"v", bson.D{{"$slice", bson.A{nil}}}}},
 			err: &mongo.CommandError{
 				Code: 28667,
 				Name: "Location28667",
@@ -355,7 +355,7 @@ func TestQueryProjectionSlice(t *testing.T) {
 				"and at most 3, but 1 were passed in.",
 		},
 		"NullInPair": {
-			projection: bson.D{{"value", bson.D{{"$slice", bson.A{2, nil}}}}},
+			projection: bson.D{{"v", bson.D{{"$slice", bson.A{2, nil}}}}},
 		},
 	} {
 		name, tc := name, tc
@@ -374,10 +374,10 @@ func TestQueryProjectionSlice(t *testing.T) {
 			require.NoError(t, err)
 
 			if tc.expectedArray == nil {
-				assert.Nil(t, actual.Map()["value"])
+				assert.Nil(t, actual.Map()["v"])
 				return
 			}
-			assert.Equal(t, tc.expectedArray, actual.Map()["value"])
+			assert.Equal(t, tc.expectedArray, actual.Map()["v"])
 		})
 	}
 }

--- a/integration/query_test.go
+++ b/integration/query_test.go
@@ -32,7 +32,7 @@ func TestQueryUnknownFilterOperator(t *testing.T) {
 	t.Parallel()
 	ctx, collection := Setup(t, shareddata.Scalars)
 
-	filter := bson.D{{"value", bson.D{{"$someUnknownOperator", 42}}}}
+	filter := bson.D{{"v", bson.D{{"$someUnknownOperator", 42}}}}
 	errExpected := mongo.CommandError{Code: 2, Name: "BadValue", Message: "unknown operator: $someUnknownOperator"}
 	_, err := collection.Find(ctx, filter)
 	AssertEqualError(t, errExpected, err)
@@ -49,7 +49,7 @@ func TestQuerySort(t *testing.T) {
 		expectedIDs []any
 	}{
 		"Asc": {
-			sort: bson.D{{"value", 1}, {"_id", 1}},
+			sort: bson.D{{"v", 1}, {"_id", 1}},
 			expectedIDs: []any{
 				"array-empty",
 				"array-embedded",
@@ -101,7 +101,7 @@ func TestQuerySort(t *testing.T) {
 			},
 		},
 		"Desc": {
-			sort: bson.D{{"value", -1}, {"_id", 1}},
+			sort: bson.D{{"v", -1}, {"_id", 1}},
 			expectedIDs: []any{
 				"regex",
 				"regex-empty",
@@ -178,7 +178,7 @@ func TestQuerySortValue(t *testing.T) {
 		err         *mongo.CommandError
 	}{
 		"AscValueScalar": {
-			sort: bson.D{{"value", 1}},
+			sort: bson.D{{"v", 1}},
 			expectedIDs: []any{
 				"null",
 				"double-nan",
@@ -221,7 +221,7 @@ func TestQuerySortValue(t *testing.T) {
 			},
 		},
 		"DescValueScalar": {
-			sort: bson.D{{"value", -1}},
+			sort: bson.D{{"v", -1}},
 			expectedIDs: []any{
 				"regex",
 				"regex-empty",
@@ -264,7 +264,7 @@ func TestQuerySortValue(t *testing.T) {
 			},
 		},
 		"BadSortValue": {
-			sort: bson.D{{"value", 11}},
+			sort: bson.D{{"v", 11}},
 			err: &mongo.CommandError{
 				Code:    15975,
 				Name:    "Location15975",
@@ -272,7 +272,7 @@ func TestQuerySortValue(t *testing.T) {
 			},
 		},
 		"BadSortZeroValue": {
-			sort: bson.D{{"value", 0}},
+			sort: bson.D{{"v", 0}},
 			err: &mongo.CommandError{
 				Code:    15975,
 				Name:    "Location15975",
@@ -280,11 +280,11 @@ func TestQuerySortValue(t *testing.T) {
 			},
 		},
 		"BadSortNullValue": {
-			sort: bson.D{{"value", nil}},
+			sort: bson.D{{"v", nil}},
 			err: &mongo.CommandError{
 				Code:    15974,
 				Name:    "Location15974",
-				Message: "Illegal key in $sort specification: value: null",
+				Message: "Illegal key in $sort specification: v: null",
 			},
 		},
 	} {
@@ -323,21 +323,21 @@ func TestQueryCount(t *testing.T) {
 		"CountExactlyOneDocument": {
 			command: bson.D{
 				{"count", collection.Name()},
-				{"query", bson.D{{"value", true}}},
+				{"query", bson.D{{"v", true}}},
 			},
 			response: 1,
 		},
 		"CountArrays": {
 			command: bson.D{
 				{"count", collection.Name()},
-				{"query", bson.D{{"value", bson.D{{"$type", "array"}}}}},
+				{"query", bson.D{{"v", bson.D{{"$type", "array"}}}}},
 			},
 			response: 11,
 		},
 		"CountNonExistingCollection": {
 			command: bson.D{
 				{"count", "doesnotexist"},
-				{"query", bson.D{{"value", true}}},
+				{"query", bson.D{{"v", true}}},
 			},
 			response: 0,
 		},
@@ -372,7 +372,7 @@ func TestQueryBadFindType(t *testing.T) {
 		"Document": {
 			command: bson.D{
 				{"find", bson.D{}},
-				{"projection", bson.D{{"value", "some"}}},
+				{"projection", bson.D{{"v", "some"}}},
 			},
 			err: &mongo.CommandError{
 				Code:    2,
@@ -383,7 +383,7 @@ func TestQueryBadFindType(t *testing.T) {
 		"Array": {
 			command: bson.D{
 				{"find", primitive.A{}},
-				{"projection", bson.D{{"value", "some"}}},
+				{"projection", bson.D{{"v", "some"}}},
 			},
 			err: &mongo.CommandError{
 				Code:    2,
@@ -394,7 +394,7 @@ func TestQueryBadFindType(t *testing.T) {
 		"Double": {
 			command: bson.D{
 				{"find", 3.14},
-				{"projection", bson.D{{"value", "some"}}},
+				{"projection", bson.D{{"v", "some"}}},
 			},
 			err: &mongo.CommandError{
 				Code:    2,
@@ -405,7 +405,7 @@ func TestQueryBadFindType(t *testing.T) {
 		"DoubleWhole": {
 			command: bson.D{
 				{"find", 42.0},
-				{"projection", bson.D{{"value", "some"}}},
+				{"projection", bson.D{{"v", "some"}}},
 			},
 			err: &mongo.CommandError{
 				Code:    2,
@@ -416,7 +416,7 @@ func TestQueryBadFindType(t *testing.T) {
 		"Binary": {
 			command: bson.D{
 				{"find", primitive.Binary{}},
-				{"projection", bson.D{{"value", "some"}}},
+				{"projection", bson.D{{"v", "some"}}},
 			},
 			err: &mongo.CommandError{
 				Code:    2,
@@ -427,7 +427,7 @@ func TestQueryBadFindType(t *testing.T) {
 		"ObjectID": {
 			command: bson.D{
 				{"find", primitive.ObjectID{}},
-				{"projection", bson.D{{"value", "some"}}},
+				{"projection", bson.D{{"v", "some"}}},
 			},
 			err: &mongo.CommandError{
 				Code:    2,
@@ -438,7 +438,7 @@ func TestQueryBadFindType(t *testing.T) {
 		"Bool": {
 			command: bson.D{
 				{"find", true},
-				{"projection", bson.D{{"value", "some"}}},
+				{"projection", bson.D{{"v", "some"}}},
 			},
 			err: &mongo.CommandError{
 				Code:    2,
@@ -449,7 +449,7 @@ func TestQueryBadFindType(t *testing.T) {
 		"Date": {
 			command: bson.D{
 				{"find", time.Now()},
-				{"projection", bson.D{{"value", "some"}}},
+				{"projection", bson.D{{"v", "some"}}},
 			},
 			err: &mongo.CommandError{
 				Code:    2,
@@ -460,7 +460,7 @@ func TestQueryBadFindType(t *testing.T) {
 		"Null": {
 			command: bson.D{
 				{"find", nil},
-				{"projection", bson.D{{"value", "some"}}},
+				{"projection", bson.D{{"v", "some"}}},
 			},
 			err: &mongo.CommandError{
 				Code:    2,
@@ -471,7 +471,7 @@ func TestQueryBadFindType(t *testing.T) {
 		"Regex": {
 			command: bson.D{
 				{"find", primitive.Regex{Pattern: "/foo/"}},
-				{"projection", bson.D{{"value", "some"}}},
+				{"projection", bson.D{{"v", "some"}}},
 			},
 			err: &mongo.CommandError{
 				Code:    2,
@@ -482,7 +482,7 @@ func TestQueryBadFindType(t *testing.T) {
 		"Int": {
 			command: bson.D{
 				{"find", int32(42)},
-				{"projection", bson.D{{"value", "some"}}},
+				{"projection", bson.D{{"v", "some"}}},
 			},
 			err: &mongo.CommandError{
 				Code:    2,
@@ -493,7 +493,7 @@ func TestQueryBadFindType(t *testing.T) {
 		"Timestamp": {
 			command: bson.D{
 				{"find", primitive.Timestamp{}},
-				{"projection", bson.D{{"value", "some"}}},
+				{"projection", bson.D{{"v", "some"}}},
 			},
 			err: &mongo.CommandError{
 				Code:    2,
@@ -504,7 +504,7 @@ func TestQueryBadFindType(t *testing.T) {
 		"Long": {
 			command: bson.D{
 				{"find", int64(42)},
-				{"projection", bson.D{{"value", "some"}}},
+				{"projection", bson.D{{"v", "some"}}},
 			},
 			err: &mongo.CommandError{
 				Code:    2,
@@ -537,7 +537,7 @@ func TestQueryBadSortType(t *testing.T) {
 		"BadSortTypeDouble": {
 			command: bson.D{
 				{"find", collection.Name()},
-				{"projection", bson.D{{"value", "some"}}},
+				{"projection", bson.D{{"v", "some"}}},
 				{"sort", 42.13},
 			},
 			err: &mongo.CommandError{
@@ -550,7 +550,7 @@ func TestQueryBadSortType(t *testing.T) {
 		"BadSortType": {
 			command: bson.D{
 				{"find", collection.Name()},
-				{"projection", bson.D{{"value", "some"}}},
+				{"projection", bson.D{{"v", "some"}}},
 				{"sort", "123"},
 			},
 			err: &mongo.CommandError{
@@ -563,7 +563,7 @@ func TestQueryBadSortType(t *testing.T) {
 		"BadSortTypeValue": {
 			command: bson.D{
 				{"find", collection.Name()},
-				{"projection", bson.D{{"value", 42}}},
+				{"projection", bson.D{{"v", 42}}},
 				{"sort", bson.D{{"asc", "123"}}},
 			},
 			err: &mongo.CommandError{
@@ -599,7 +599,7 @@ func TestQueryExactMatches(t *testing.T) {
 		},
 		bson.D{
 			{"_id", "document-value-two-fields"},
-			{"value", bson.D{{"foo", "bar"}, {"baz", int32(42)}}},
+			{"v", bson.D{{"foo", "bar"}, {"baz", int32(42)}}},
 		},
 	})
 	require.NoError(t, err)
@@ -617,16 +617,16 @@ func TestQueryExactMatches(t *testing.T) {
 			expectedIDs: []any{"document-two-fields"},
 		},
 		"DocumentValueFields": {
-			filter:      bson.D{{"value", bson.D{{"foo", "bar"}, {"baz", int32(42)}}}},
+			filter:      bson.D{{"v", bson.D{{"foo", "bar"}, {"baz", int32(42)}}}},
 			expectedIDs: []any{"document-value-two-fields"},
 		},
 
 		"Array": {
-			filter:      bson.D{{"value", bson.A{int32(42), "foo", nil}}},
+			filter:      bson.D{{"v", bson.A{int32(42), "foo", nil}}},
 			expectedIDs: []any{"array-three"},
 		},
 		"ArrayChangedOrder": {
-			filter:      bson.D{{"value", bson.A{int32(42), nil, "foo"}}},
+			filter:      bson.D{{"v", bson.A{int32(42), nil, "foo"}}},
 			expectedIDs: []any{},
 		},
 	} {

--- a/integration/shareddata/shareddata.go
+++ b/integration/shareddata/shareddata.go
@@ -87,7 +87,7 @@ func (docs *Maps[idType]) Docs() []bson.D {
 	return res
 }
 
-// Values stores shared data documents as {"_id": key, "value": value} documents.
+// Values stores shared data documents as {"_id": key, "v": value} documents.
 //
 // TODO replace constraints.Ordered with comparable: https://github.com/FerretDB/FerretDB/issues/914
 type Values[idType constraints.Ordered] struct {
@@ -104,7 +104,7 @@ func (values *Values[idType]) Docs() []bson.D {
 		doc := bson.D{{"_id", id}}
 		v := values.data[id]
 		if v != unset {
-			doc = append(doc, bson.E{"value", v})
+			doc = append(doc, bson.E{"v", v})
 		}
 		res = append(res, doc)
 	}

--- a/integration/update_field_compat_test.go
+++ b/integration/update_field_compat_test.go
@@ -25,11 +25,11 @@ func TestUpdateFieldCompatInc(t *testing.T) {
 
 	testCases := map[string]updateCompatTestCase{
 		"Double": {
-			update: bson.D{{"$inc", bson.D{{"value", 42.13}}}},
+			update: bson.D{{"$inc", bson.D{{"v", 42.13}}}},
 			skip:   "https://github.com/FerretDB/FerretDB/issues/904",
 		},
 		"DoubleNegative": {
-			update: bson.D{{"$inc", bson.D{{"value", -42.13}}}},
+			update: bson.D{{"$inc", bson.D{{"v", -42.13}}}},
 			skip:   "https://github.com/FerretDB/FerretDB/issues/904",
 		},
 	}

--- a/integration/update_field_test.go
+++ b/integration/update_field_test.go
@@ -44,13 +44,13 @@ func TestUpdateFieldCurrentDate(t *testing.T) {
 			ModifiedCount: 1,
 			UpsertedCount: 0,
 		}
-		path := types.NewPathFromString("value")
-		result := bson.D{{"_id", id}, {"value", nowTimestamp}}
+		path := types.NewPathFromString("v")
+		result := bson.D{{"_id", id}, {"v", nowTimestamp}}
 
 		ctx, collection := Setup(t, shareddata.Scalars, shareddata.Composites)
 
 		// store the current timestamp with $currentDate operator;
-		update := bson.D{{"$currentDate", bson.D{{"value", bson.D{{"$type", "timestamp"}}}}}}
+		update := bson.D{{"$currentDate", bson.D{{"v", bson.D{{"$type", "timestamp"}}}}}}
 		res, err := collection.UpdateOne(ctx, bson.D{{"_id", id}}, update)
 		require.NoError(t, err)
 		require.Equal(t, stat, res)
@@ -66,8 +66,8 @@ func TestUpdateFieldCurrentDate(t *testing.T) {
 		testutil.CompareAndSetByPathTime(t, expected, actualDocument, maxDifference, path)
 
 		// write a new timestamp value with the same time;
-		updateBSON := bson.D{{"$set", bson.D{{"value", nowTimestamp}}}}
-		expectedBSON := bson.D{{"_id", id}, {"value", nowTimestamp}}
+		updateBSON := bson.D{{"$set", bson.D{{"v", nowTimestamp}}}}
+		expectedBSON := bson.D{{"_id", id}, {"v", nowTimestamp}}
 		res, err = collection.UpdateOne(ctx, bson.D{{"_id", id}}, updateBSON)
 		require.NoError(t, err)
 		require.Equal(t, stat, res)
@@ -100,7 +100,7 @@ func TestUpdateFieldCurrentDate(t *testing.T) {
 			"DocumentEmpty": {
 				id:       "double",
 				update:   bson.D{{"$currentDate", bson.D{}}},
-				expected: bson.D{{"_id", "double"}, {"value", float64(42.13)}},
+				expected: bson.D{{"_id", "double"}, {"v", float64(42.13)}},
 				stat: &mongo.UpdateResult{
 					MatchedCount:  1,
 					ModifiedCount: 0,
@@ -139,43 +139,43 @@ func TestUpdateFieldCurrentDate(t *testing.T) {
 			},
 			"BoolTrue": {
 				id:       "double",
-				update:   bson.D{{"$currentDate", bson.D{{"value", true}}}},
-				expected: bson.D{{"_id", "double"}, {"value", now}},
+				update:   bson.D{{"$currentDate", bson.D{{"v", true}}}},
+				expected: bson.D{{"_id", "double"}, {"v", now}},
 				stat: &mongo.UpdateResult{
 					MatchedCount:  1,
 					ModifiedCount: 1,
 					UpsertedCount: 0,
 				},
-				paths: []types.Path{types.NewPathFromString("value")},
+				paths: []types.Path{types.NewPathFromString("v")},
 			},
 			"BoolTwoTrue": {
 				id:       "double",
-				update:   bson.D{{"$currentDate", bson.D{{"value", true}, {"unexistent", true}}}},
-				expected: bson.D{{"_id", "double"}, {"value", now}, {"unexistent", now}},
+				update:   bson.D{{"$currentDate", bson.D{{"v", true}, {"unexistent", true}}}},
+				expected: bson.D{{"_id", "double"}, {"v", now}, {"unexistent", now}},
 				stat: &mongo.UpdateResult{
 					MatchedCount:  1,
 					ModifiedCount: 1,
 					UpsertedCount: 0,
 				},
 				paths: []types.Path{
-					types.NewPathFromString("value"),
+					types.NewPathFromString("v"),
 					types.NewPathFromString("unexistent"),
 				},
 			},
 			"BoolFalse": {
 				id:       "double",
-				update:   bson.D{{"$currentDate", bson.D{{"value", false}}}},
-				expected: bson.D{{"_id", "double"}, {"value", now}},
+				update:   bson.D{{"$currentDate", bson.D{{"v", false}}}},
+				expected: bson.D{{"_id", "double"}, {"v", now}},
 				stat: &mongo.UpdateResult{
 					MatchedCount:  1,
 					ModifiedCount: 1,
 					UpsertedCount: 0,
 				},
-				paths: []types.Path{types.NewPathFromString("value")},
+				paths: []types.Path{types.NewPathFromString("v")},
 			},
 			"Int32": {
 				id:     "double",
-				update: bson.D{{"$currentDate", bson.D{{"value", int32(1)}}}},
+				update: bson.D{{"$currentDate", bson.D{{"v", int32(1)}}}},
 				err: &mongo.WriteError{
 					Code:    2,
 					Message: "int is not valid type for $currentDate. Please use a boolean ('true') or a $type expression ({$type: 'timestamp/date'}).",
@@ -183,18 +183,18 @@ func TestUpdateFieldCurrentDate(t *testing.T) {
 			},
 			"Timestamp": {
 				id:       "double",
-				update:   bson.D{{"$currentDate", bson.D{{"value", bson.D{{"$type", "timestamp"}}}}}},
-				expected: bson.D{{"_id", "double"}, {"value", nowTimestamp}},
+				update:   bson.D{{"$currentDate", bson.D{{"v", bson.D{{"$type", "timestamp"}}}}}},
+				expected: bson.D{{"_id", "double"}, {"v", nowTimestamp}},
 				stat: &mongo.UpdateResult{
 					MatchedCount:  1,
 					ModifiedCount: 1,
 					UpsertedCount: 0,
 				},
-				paths: []types.Path{types.NewPathFromString("value")},
+				paths: []types.Path{types.NewPathFromString("v")},
 			},
 			"TimestampCapitalised": {
 				id:     "double",
-				update: bson.D{{"$currentDate", bson.D{{"value", bson.D{{"$type", "Timestamp"}}}}}},
+				update: bson.D{{"$currentDate", bson.D{{"v", bson.D{{"$type", "Timestamp"}}}}}},
 				err: &mongo.WriteError{
 					Code:    2,
 					Message: "The '$type' string field is required to be 'date' or 'timestamp': {$currentDate: {field : {$type: 'date'}}}",
@@ -203,18 +203,18 @@ func TestUpdateFieldCurrentDate(t *testing.T) {
 			},
 			"Date": {
 				id:       "double",
-				update:   bson.D{{"$currentDate", bson.D{{"value", bson.D{{"$type", "date"}}}}}},
-				expected: bson.D{{"_id", "double"}, {"value", now}},
+				update:   bson.D{{"$currentDate", bson.D{{"v", bson.D{{"$type", "date"}}}}}},
+				expected: bson.D{{"_id", "double"}, {"v", now}},
 				stat: &mongo.UpdateResult{
 					MatchedCount:  1,
 					ModifiedCount: 1,
 					UpsertedCount: 0,
 				},
-				paths: []types.Path{types.NewPathFromString("value")},
+				paths: []types.Path{types.NewPathFromString("v")},
 			},
 			"WrongType": {
 				id:     "double",
-				update: bson.D{{"$currentDate", bson.D{{"value", bson.D{{"$type", bson.D{{"abcd", int32(1)}}}}}}}},
+				update: bson.D{{"$currentDate", bson.D{{"v", bson.D{{"$type", bson.D{{"abcd", int32(1)}}}}}}}},
 				err: &mongo.WriteError{
 					Code:    2,
 					Message: "The '$type' string field is required to be 'date' or 'timestamp': {$currentDate: {field : {$type: 'date'}}}",
@@ -224,7 +224,7 @@ func TestUpdateFieldCurrentDate(t *testing.T) {
 			"NoField": {
 				id:       "double",
 				update:   bson.D{{"$currentDate", bson.D{{"unexsistent", bson.D{{"$type", "date"}}}}}},
-				expected: bson.D{{"_id", "double"}, {"value", 42.13}, {"unexsistent", now}},
+				expected: bson.D{{"_id", "double"}, {"v", 42.13}, {"unexsistent", now}},
 				stat: &mongo.UpdateResult{
 					MatchedCount:  1,
 					ModifiedCount: 1,
@@ -236,7 +236,7 @@ func TestUpdateFieldCurrentDate(t *testing.T) {
 				id: "array",
 				update: bson.D{{
 					"$currentDate",
-					bson.D{{"value", bson.D{{"array", bson.D{{"unexsistent", bson.D{}}}}}}},
+					bson.D{{"v", bson.D{{"array", bson.D{{"unexsistent", bson.D{}}}}}}},
 				}},
 				err: &mongo.WriteError{
 					Code:    2,
@@ -288,94 +288,94 @@ func TestUpdateFieldInc(t *testing.T) {
 		}{
 			"DoubleIncrement": {
 				filter:   bson.D{{"_id", "double"}},
-				update:   bson.D{{"$inc", bson.D{{"value", float64(42.13)}}}},
-				expected: bson.D{{"_id", "double"}, {"value", float64(84.26)}},
+				update:   bson.D{{"$inc", bson.D{{"v", float64(42.13)}}}},
+				expected: bson.D{{"_id", "double"}, {"v", float64(84.26)}},
 			},
 			"DoubleIncrementNaN": {
 				filter:   bson.D{{"_id", "double"}},
-				update:   bson.D{{"$inc", bson.D{{"value", math.NaN()}}}},
-				expected: bson.D{{"_id", "double"}, {"value", math.NaN()}},
+				update:   bson.D{{"$inc", bson.D{{"v", math.NaN()}}}},
+				expected: bson.D{{"_id", "double"}, {"v", math.NaN()}},
 			},
 			"DoubleIncrementPlusInfinity": {
 				filter:   bson.D{{"_id", "double-nan"}},
-				update:   bson.D{{"$inc", bson.D{{"value", math.Inf(+1)}}}},
-				expected: bson.D{{"_id", "double-nan"}, {"value", math.NaN()}},
+				update:   bson.D{{"$inc", bson.D{{"v", math.Inf(+1)}}}},
+				expected: bson.D{{"_id", "double-nan"}, {"v", math.NaN()}},
 			},
 			"DoubleNegativeIncrement": {
 				filter:   bson.D{{"_id", "double"}},
-				update:   bson.D{{"$inc", bson.D{{"value", float64(-42.13)}}}},
-				expected: bson.D{{"_id", "double"}, {"value", float64(0)}},
+				update:   bson.D{{"$inc", bson.D{{"v", float64(-42.13)}}}},
+				expected: bson.D{{"_id", "double"}, {"v", float64(0)}},
 			},
 			"DoubleIncrementIntField": {
 				filter:   bson.D{{"_id", "int32"}},
-				update:   bson.D{{"$inc", bson.D{{"value", float64(1.13)}}}},
-				expected: bson.D{{"_id", "int32"}, {"value", float64(43.13)}},
+				update:   bson.D{{"$inc", bson.D{{"v", float64(1.13)}}}},
+				expected: bson.D{{"_id", "int32"}, {"v", float64(43.13)}},
 			},
 			"DoubleIncrementLongField": {
 				filter:   bson.D{{"_id", "int64"}},
-				update:   bson.D{{"$inc", bson.D{{"value", float64(1.13)}}}},
-				expected: bson.D{{"_id", "int64"}, {"value", float64(43.13)}},
+				update:   bson.D{{"$inc", bson.D{{"v", float64(1.13)}}}},
+				expected: bson.D{{"_id", "int64"}, {"v", float64(43.13)}},
 			},
 			"DoubleIntIncrement": {
 				filter:   bson.D{{"_id", "double"}},
-				update:   bson.D{{"$inc", bson.D{{"value", int32(1)}}}},
-				expected: bson.D{{"_id", "double"}, {"value", float64(43.13)}},
+				update:   bson.D{{"$inc", bson.D{{"v", int32(1)}}}},
+				expected: bson.D{{"_id", "double"}, {"v", float64(43.13)}},
 			},
 			"DoubleLongIncrement": {
 				filter:   bson.D{{"_id", "double"}},
-				update:   bson.D{{"$inc", bson.D{{"value", int64(1)}}}},
-				expected: bson.D{{"_id", "double"}, {"value", float64(43.13)}},
+				update:   bson.D{{"$inc", bson.D{{"v", int64(1)}}}},
+				expected: bson.D{{"_id", "double"}, {"v", float64(43.13)}},
 			},
 			"IntIncrement": {
 				filter:   bson.D{{"_id", "int32"}},
-				update:   bson.D{{"$inc", bson.D{{"value", int32(1)}}}},
-				expected: bson.D{{"_id", "int32"}, {"value", int32(43)}},
+				update:   bson.D{{"$inc", bson.D{{"v", int32(1)}}}},
+				expected: bson.D{{"_id", "int32"}, {"v", int32(43)}},
 			},
 			"IntNegativeIncrement": {
 				filter:   bson.D{{"_id", "int32"}},
-				update:   bson.D{{"$inc", bson.D{{"value", int32(-1)}}}},
-				expected: bson.D{{"_id", "int32"}, {"value", int32(41)}},
+				update:   bson.D{{"$inc", bson.D{{"v", int32(-1)}}}},
+				expected: bson.D{{"_id", "int32"}, {"v", int32(41)}},
 			},
 			"IntIncrementDoubleField": {
 				filter:   bson.D{{"_id", "double"}},
-				update:   bson.D{{"$inc", bson.D{{"value", int32(1)}}}},
-				expected: bson.D{{"_id", "double"}, {"value", float64(43.13)}},
+				update:   bson.D{{"$inc", bson.D{{"v", int32(1)}}}},
+				expected: bson.D{{"_id", "double"}, {"v", float64(43.13)}},
 			},
 			"IntIncrementLongField": {
 				filter:   bson.D{{"_id", "int64"}},
-				update:   bson.D{{"$inc", bson.D{{"value", int32(1)}}}},
-				expected: bson.D{{"_id", "int64"}, {"value", int64(43)}},
+				update:   bson.D{{"$inc", bson.D{{"v", int32(1)}}}},
+				expected: bson.D{{"_id", "int64"}, {"v", int64(43)}},
 			},
 			"LongIncrement": {
 				filter:   bson.D{{"_id", "int64"}},
-				update:   bson.D{{"$inc", bson.D{{"value", int64(1)}}}},
-				expected: bson.D{{"_id", "int64"}, {"value", int64(43)}},
+				update:   bson.D{{"$inc", bson.D{{"v", int64(1)}}}},
+				expected: bson.D{{"_id", "int64"}, {"v", int64(43)}},
 			},
 			"LongNegativeIncrement": {
 				filter:   bson.D{{"_id", "int64"}},
-				update:   bson.D{{"$inc", bson.D{{"value", int64(-1)}}}},
-				expected: bson.D{{"_id", "int64"}, {"value", int64(41)}},
+				update:   bson.D{{"$inc", bson.D{{"v", int64(-1)}}}},
+				expected: bson.D{{"_id", "int64"}, {"v", int64(41)}},
 			},
 			"LongIncrementDoubleField": {
 				filter:   bson.D{{"_id", "double"}},
-				update:   bson.D{{"$inc", bson.D{{"value", int64(1)}}}},
-				expected: bson.D{{"_id", "double"}, {"value", float64(43.13)}},
+				update:   bson.D{{"$inc", bson.D{{"v", int64(1)}}}},
+				expected: bson.D{{"_id", "double"}, {"v", float64(43.13)}},
 			},
 			"LongIncrementIntField": {
 				filter:   bson.D{{"_id", "int32"}},
-				update:   bson.D{{"$inc", bson.D{{"value", int64(1)}}}},
-				expected: bson.D{{"_id", "int32"}, {"value", int64(43)}},
+				update:   bson.D{{"$inc", bson.D{{"v", int64(1)}}}},
+				expected: bson.D{{"_id", "int32"}, {"v", int64(43)}},
 			},
 
 			"FieldNotExist": {
 				filter:   bson.D{{"_id", "int32"}},
 				update:   bson.D{{"$inc", bson.D{{"foo", int32(1)}}}},
-				expected: bson.D{{"_id", "int32"}, {"value", int32(42)}, {"foo", int32(1)}},
+				expected: bson.D{{"_id", "int32"}, {"v", int32(42)}, {"foo", int32(1)}},
 			},
 			"IncTwoFields": {
 				filter:   bson.D{{"_id", "int32"}},
-				update:   bson.D{{"$inc", bson.D{{"foo", int32(12)}, {"value", int32(1)}}}},
-				expected: bson.D{{"_id", "int32"}, {"value", int32(43)}, {"foo", int32(12)}},
+				update:   bson.D{{"$inc", bson.D{{"foo", int32(12)}, {"v", int32(1)}}}},
+				expected: bson.D{{"_id", "int32"}, {"v", int32(43)}, {"foo", int32(12)}},
 			},
 		} {
 			name, tc := name, tc
@@ -406,20 +406,20 @@ func TestUpdateFieldInc(t *testing.T) {
 		}{
 			"IncOnDocument": {
 				filter: bson.D{{"_id", "document"}},
-				update: bson.D{{"$inc", bson.D{{"value", int32(1)}}}},
+				update: bson.D{{"$inc", bson.D{{"v", int32(1)}}}},
 				err: &mongo.WriteError{
 					Code: 14,
 					Message: `Cannot apply $inc to a value of non-numeric type. ` +
-						`{_id: "document"} has the field 'value' of non-numeric type object`,
+						`{_id: "document"} has the field 'v' of non-numeric type object`,
 				},
 			},
 			"IncOnArray": {
 				filter: bson.D{{"_id", "array"}},
-				update: bson.D{{"$inc", bson.D{{"value", int32(1)}}}},
+				update: bson.D{{"$inc", bson.D{{"v", int32(1)}}}},
 				err: &mongo.WriteError{
 					Code: 14,
 					Message: `Cannot apply $inc to a value of non-numeric type. ` +
-						`{_id: "array"} has the field 'value' of non-numeric type array`,
+						`{_id: "array"} has the field 'v' of non-numeric type array`,
 				},
 			},
 			"IncOnString": {
@@ -434,37 +434,37 @@ func TestUpdateFieldInc(t *testing.T) {
 			},
 			"IncWithStringValue": {
 				filter: bson.D{{"_id", "string"}},
-				update: bson.D{{"$inc", bson.D{{"value", "bad value"}}}},
+				update: bson.D{{"$inc", bson.D{{"v", "bad value"}}}},
 				err: &mongo.WriteError{
 					Code:    14,
-					Message: `Cannot increment with non-numeric argument: {value: "bad value"}`,
+					Message: `Cannot increment with non-numeric argument: {v: "bad value"}`,
 				},
 			},
 			"DoubleIncOnNullValue": {
 				filter: bson.D{{"_id", "string"}},
-				update: bson.D{{"$inc", bson.D{{"value", float64(1)}}}},
+				update: bson.D{{"$inc", bson.D{{"v", float64(1)}}}},
 				err: &mongo.WriteError{
 					Code: 14,
 					Message: `Cannot apply $inc to a value of non-numeric type. ` +
-						`{_id: "string"} has the field 'value' of non-numeric type string`,
+						`{_id: "string"} has the field 'v' of non-numeric type string`,
 				},
 			},
 			"IntIncOnNullValue": {
 				filter: bson.D{{"_id", "string"}},
-				update: bson.D{{"$inc", bson.D{{"value", int32(1)}}}},
+				update: bson.D{{"$inc", bson.D{{"v", int32(1)}}}},
 				err: &mongo.WriteError{
 					Code: 14,
 					Message: `Cannot apply $inc to a value of non-numeric type. ` +
-						`{_id: "string"} has the field 'value' of non-numeric type string`,
+						`{_id: "string"} has the field 'v' of non-numeric type string`,
 				},
 			},
 			"LongIncOnNullValue": {
 				filter: bson.D{{"_id", "string"}},
-				update: bson.D{{"$inc", bson.D{{"value", int64(1)}}}},
+				update: bson.D{{"$inc", bson.D{{"v", int64(1)}}}},
 				err: &mongo.WriteError{
 					Code: 14,
 					Message: `Cannot apply $inc to a value of non-numeric type. ` +
-						`{_id: "string"} has the field 'value' of non-numeric type string`,
+						`{_id: "string"} has the field 'v' of non-numeric type string`,
 				},
 			},
 		} {
@@ -511,7 +511,7 @@ func TestUpdateFieldSet(t *testing.T) {
 		"Many": {
 			id:     "string",
 			update: bson.D{{"$set", bson.D{{"foo", int32(1)}, {"bar", bson.A{}}}}},
-			result: bson.D{{"_id", "string"}, {"value", "foo"}, {"bar", bson.A{}}, {"foo", int32(1)}},
+			result: bson.D{{"_id", "string"}, {"v", "foo"}, {"bar", bson.A{}}, {"foo", int32(1)}},
 			stat: &mongo.UpdateResult{
 				MatchedCount:  1,
 				ModifiedCount: 1,
@@ -551,7 +551,7 @@ func TestUpdateFieldSet(t *testing.T) {
 		"EmptyDoc": {
 			id:     "string",
 			update: bson.D{{"$set", bson.D{}}},
-			result: bson.D{{"_id", "string"}, {"value", "foo"}},
+			result: bson.D{{"_id", "string"}, {"v", "foo"}},
 			stat: &mongo.UpdateResult{
 				MatchedCount:  1,
 				ModifiedCount: 0,
@@ -560,8 +560,8 @@ func TestUpdateFieldSet(t *testing.T) {
 		},
 		"OkSetString": {
 			id:     "string",
-			update: bson.D{{"$set", bson.D{{"value", "ok value"}}}},
-			result: bson.D{{"_id", "string"}, {"value", "ok value"}},
+			update: bson.D{{"$set", bson.D{{"v", "ok value"}}}},
+			result: bson.D{{"_id", "string"}, {"v", "ok value"}},
 			stat: &mongo.UpdateResult{
 				MatchedCount:  1,
 				ModifiedCount: 1,
@@ -570,8 +570,8 @@ func TestUpdateFieldSet(t *testing.T) {
 		},
 		"ArrayNil": {
 			id:     "string",
-			update: bson.D{{"$set", bson.D{{"value", bson.A{nil}}}}},
-			result: bson.D{{"_id", "string"}, {"value", bson.A{nil}}},
+			update: bson.D{{"$set", bson.D{{"v", bson.A{nil}}}}},
+			result: bson.D{{"_id", "string"}, {"v", bson.A{nil}}},
 			stat: &mongo.UpdateResult{
 				MatchedCount:  1,
 				ModifiedCount: 1,
@@ -581,7 +581,7 @@ func TestUpdateFieldSet(t *testing.T) {
 		"FieldNotExist": {
 			id:     "string",
 			update: bson.D{{"$set", bson.D{{"foo", int32(1)}}}},
-			result: bson.D{{"_id", "string"}, {"value", "foo"}, {"foo", int32(1)}},
+			result: bson.D{{"_id", "string"}, {"v", "foo"}, {"foo", int32(1)}},
 			stat: &mongo.UpdateResult{
 				MatchedCount:  1,
 				ModifiedCount: 1,
@@ -590,8 +590,8 @@ func TestUpdateFieldSet(t *testing.T) {
 		},
 		"Double": {
 			id:     "double",
-			update: bson.D{{"$set", bson.D{{"value", float64(1)}}}},
-			result: bson.D{{"_id", "double"}, {"value", float64(1)}},
+			update: bson.D{{"$set", bson.D{{"v", float64(1)}}}},
+			result: bson.D{{"_id", "double"}, {"v", float64(1)}},
 			stat: &mongo.UpdateResult{
 				MatchedCount:  1,
 				ModifiedCount: 1,
@@ -600,8 +600,8 @@ func TestUpdateFieldSet(t *testing.T) {
 		},
 		"NaN": {
 			id:     "double",
-			update: bson.D{{"$set", bson.D{{"value", math.NaN()}}}},
-			result: bson.D{{"_id", "double"}, {"value", math.NaN()}},
+			update: bson.D{{"$set", bson.D{{"v", math.NaN()}}}},
+			result: bson.D{{"_id", "double"}, {"v", math.NaN()}},
 			stat: &mongo.UpdateResult{
 				MatchedCount:  1,
 				ModifiedCount: 1,
@@ -610,8 +610,8 @@ func TestUpdateFieldSet(t *testing.T) {
 		},
 		"EmptyArray": {
 			id:     "double",
-			update: bson.D{{"$set", bson.D{{"value", bson.A{}}}}},
-			result: bson.D{{"_id", "double"}, {"value", bson.A{}}},
+			update: bson.D{{"$set", bson.D{{"v", bson.A{}}}}},
+			result: bson.D{{"_id", "double"}, {"v", bson.A{}}},
 			stat: &mongo.UpdateResult{
 				MatchedCount:  1,
 				ModifiedCount: 1,
@@ -620,8 +620,8 @@ func TestUpdateFieldSet(t *testing.T) {
 		},
 		"Null": {
 			id:     "double",
-			update: bson.D{{"$set", bson.D{{"value", nil}}}},
-			result: bson.D{{"_id", "double"}, {"value", nil}},
+			update: bson.D{{"$set", bson.D{{"v", nil}}}},
+			result: bson.D{{"_id", "double"}, {"v", nil}},
 			stat: &mongo.UpdateResult{
 				MatchedCount:  1,
 				ModifiedCount: 1,
@@ -630,8 +630,8 @@ func TestUpdateFieldSet(t *testing.T) {
 		},
 		"Int32": {
 			id:     "double",
-			update: bson.D{{"$set", bson.D{{"value", int32(1)}}}},
-			result: bson.D{{"_id", "double"}, {"value", int32(1)}},
+			update: bson.D{{"$set", bson.D{{"v", int32(1)}}}},
+			result: bson.D{{"_id", "double"}, {"v", int32(1)}},
 			stat: &mongo.UpdateResult{
 				MatchedCount:  1,
 				ModifiedCount: 1,
@@ -640,8 +640,8 @@ func TestUpdateFieldSet(t *testing.T) {
 		},
 		"Inf": {
 			id:     "double",
-			update: bson.D{{"$set", bson.D{{"value", math.Inf(+1)}}}},
-			result: bson.D{{"_id", "double"}, {"value", math.Inf(+1)}},
+			update: bson.D{{"$set", bson.D{{"v", math.Inf(+1)}}}},
+			result: bson.D{{"_id", "double"}, {"v", math.Inf(+1)}},
 			stat: &mongo.UpdateResult{
 				MatchedCount:  1,
 				ModifiedCount: 1,
@@ -650,8 +650,8 @@ func TestUpdateFieldSet(t *testing.T) {
 		},
 		"SetTwoFields": {
 			id:     "int32-zero",
-			update: bson.D{{"$set", bson.D{{"foo", int32(12)}, {"value", math.NaN()}}}},
-			result: bson.D{{"_id", "int32-zero"}, {"value", math.NaN()}, {"foo", int32(12)}},
+			update: bson.D{{"$set", bson.D{{"foo", int32(12)}, {"v", math.NaN()}}}},
+			result: bson.D{{"_id", "int32-zero"}, {"v", math.NaN()}, {"foo", int32(12)}},
 			stat: &mongo.UpdateResult{
 				MatchedCount:  1,
 				ModifiedCount: 1,
@@ -694,13 +694,13 @@ func TestUpdateFieldSetOnInsert(t *testing.T) {
 	}{
 		"Array": {
 			filter:      bson.D{{"_id", "array-set-on-insert"}},
-			setOnInsert: bson.D{{"value", bson.A{}}},
-			expected:    bson.D{{"_id", "array-set-on-insert"}, {"value", bson.A{}}},
+			setOnInsert: bson.D{{"v", bson.A{}}},
+			expected:    bson.D{{"_id", "array-set-on-insert"}, {"v", bson.A{}}},
 		},
 		"Nil": {
 			filter:      bson.D{{"_id", "nil"}},
-			setOnInsert: bson.D{{"value", nil}},
-			expected:    bson.D{{"_id", "nil"}, {"value", nil}},
+			setOnInsert: bson.D{{"v", nil}},
+			expected:    bson.D{{"_id", "nil"}, {"v", nil}},
 		},
 		"EmptyDoc": {
 			filter:      bson.D{{"_id", "doc"}},
@@ -806,7 +806,7 @@ func TestUpdateFieldUnset(t *testing.T) {
 	}{
 		"String": {
 			filter:   bson.D{{"_id", "string"}},
-			update:   bson.D{{"$unset", bson.D{{"value", int32(1)}}}},
+			update:   bson.D{{"$unset", bson.D{{"v", int32(1)}}}},
 			expected: bson.D{{"_id", "string"}},
 			stat: &mongo.UpdateResult{
 				MatchedCount:  1,
@@ -817,7 +817,7 @@ func TestUpdateFieldUnset(t *testing.T) {
 		"Empty": {
 			filter:   bson.D{{"_id", "string"}},
 			update:   bson.D{{"$unset", bson.D{}}},
-			expected: bson.D{{"_id", "string"}, {"value", "foo"}},
+			expected: bson.D{{"_id", "string"}, {"v", "foo"}},
 			stat: &mongo.UpdateResult{
 				MatchedCount:  1,
 				ModifiedCount: 0,
@@ -826,7 +826,7 @@ func TestUpdateFieldUnset(t *testing.T) {
 		},
 		"Field": {
 			filter:   bson.D{{"_id", "document-composite-unset-field"}},
-			update:   bson.D{{"$unset", bson.D{{"value", bson.D{{"array", int32(1)}}}}}},
+			update:   bson.D{{"$unset", bson.D{{"v", bson.D{{"array", int32(1)}}}}}},
 			expected: bson.D{{"_id", "document-composite-unset-field"}},
 			stat: &mongo.UpdateResult{
 				MatchedCount:  0,
@@ -885,16 +885,16 @@ func TestUpdateFieldMixed(t *testing.T) {
 			filter: bson.D{{"_id", "test"}},
 			update: bson.D{
 				{"$set", bson.D{{"foo", int32(12)}}},
-				{"$setOnInsert", bson.D{{"value", math.NaN()}}},
+				{"$setOnInsert", bson.D{{"v", math.NaN()}}},
 			},
-			expected: bson.D{{"_id", "test"}, {"foo", int32(12)}, {"value", math.NaN()}},
+			expected: bson.D{{"_id", "test"}, {"foo", int32(12)}, {"v", math.NaN()}},
 		},
 		"SetIncSetOnInsert": {
 			filter: bson.D{{"_id", "test"}},
 			update: bson.D{
 				{"$set", bson.D{{"foo", int32(12)}}},
 				{"$inc", bson.D{{"foo", int32(1)}}},
-				{"$setOnInsert", bson.D{{"value", math.NaN()}}},
+				{"$setOnInsert", bson.D{{"v", math.NaN()}}},
 			},
 			err: &mongo.WriteError{
 				Code:    40,

--- a/internal/handlers/common/update.go
+++ b/internal/handlers/common/update.go
@@ -261,11 +261,11 @@ func checkConflictingChanges(a, b *types.Document) error {
 //  bson.D{
 // 	{"$set", bson.D{{"foo", int32(12)}}},
 // 	{"$inc", bson.D{{"foo", int32(1)}}},
-// 	{"$setOnInsert", bson.D{{"value", math.NaN()}}},
+// 	{"$setOnInsert", bson.D{{"v", math.NaN()}}},
 //  }
 //
 // The result returned for "$setOnInsert" operator is
-//  bson.D{{"value", math.NaN()}}.
+//  bson.D{{"v", math.NaN()}}.
 func extractValueFromUpdateOperator(op string, update *types.Document) (*types.Document, error) {
 	if !update.Has(op) {
 		return nil, nil


### PR DESCRIPTION
`value` is a reserved field name in Tigris.

Refs #786.

## Readiness checklist

* [x] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] (for maintainers only) I set Reviewers, Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
