### PR TITLE
Tweak codecov settings

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,12 @@
 ---
+# https://docs.codecov.com/docs/codecovyml-reference
+codecov:
+  require_ci_to_pass: true
+  notify:
+    after_n_builds: 4 # 1 for unit tests + 3 for integration tests with different handlers
+    wait_for_ci: true
+
+# https://docs.codecov.com/docs/coverage-configuration
 coverage:
   range: "50...65"
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -95,6 +95,7 @@ jobs:
         with:
           files: ./cover.txt
           flags: unit
+          fail_ci_if_error: true
 
       # we don't want them on CI
       - name: Clean test and fuzz caches

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -70,6 +70,7 @@ jobs:
         with:
           files: ./integration/integration-${{ matrix.handler }}.txt
           flags: integration,${{ matrix.handler }}
+          fail_ci_if_error: true
 
       # we don't want them on CI
       - name: Clean test and fuzz caches

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -135,7 +135,7 @@ tasks:
     desc: "Run integration tests for Tigris handler"
     dir: integration/tigris
     cmds:
-      - go test -count=1 {{if ne OS "windows"}}-race{{end}} -tags=ferretdb_tigris -shuffle=on -coverprofile=integration-tigris.txt -coverpkg=../... -handler=tigris
+      - go test -count=1 {{if ne OS "windows"}}-race{{end}} -tags=ferretdb_tigris -shuffle=on -coverprofile=../integration-tigris.txt -coverpkg=../... -handler=tigris
 
   test-integration-mongodb:
     desc: "Run integration tests for MongoDB"


### PR DESCRIPTION
Prevents bogus "FerretDB Check codecov/project failed for branch: main" messages in Slack.
