### PR TITLE
Add test for a database name border case

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ and [contributing guidelines](CONTRIBUTING.md).
 
 * name cannot start with the reserved prefix `_ferretdb_`.
 * name must not include non-latin letters, spaces, dots, dollars or dashes.
-* collection name length must be less or equal than 120 symbols, database name length limit is 64 symbols.
+* collection name length must be less or equal than 120 symbols, database name length limit is 63 symbols.
 * name must not start with a number.
 * database name cannot contain capital letters.
 

--- a/integration/basic_test.go
+++ b/integration/basic_test.go
@@ -254,7 +254,7 @@ func TestDatabaseName(t *testing.T) {
 	})
 
 	t.Run("63ok", func(t *testing.T) {
-		ctx, collection := Setup(t)
+		ctx, collection := setup.Setup(t)
 
 		dbName63 := strings.Repeat("a", 63)
 		err := collection.Database().Client().Database(dbName63).CreateCollection(ctx, testutil.CollectionName(t))

--- a/integration/basic_test.go
+++ b/integration/basic_test.go
@@ -259,6 +259,5 @@ func TestDatabaseName(t *testing.T) {
 		dbName63 := strings.Repeat("a", 63)
 		err := collection.Database().Client().Database(dbName63).CreateCollection(ctx, testutil.CollectionName(t))
 		require.NoError(t, err)
-		collection.Database().Client().Database(dbName63).Drop(ctx)
 	})
 }

--- a/integration/basic_test.go
+++ b/integration/basic_test.go
@@ -259,5 +259,6 @@ func TestDatabaseName(t *testing.T) {
 		dbName63 := strings.Repeat("a", 63)
 		err := collection.Database().Client().Database(dbName63).CreateCollection(ctx, testutil.CollectionName(t))
 		require.NoError(t, err)
+		collection.Database().Client().Database(dbName63).Drop(ctx)
 	})
 }


### PR DESCRIPTION
# Description

This PR closes #807.

- fix typo in documentation
- add test border case 63 and 64 letters in a database name.

* [x] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [x] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [x] I checked comments rendering with `task godocs`.
* [x] (for maintainers only) I set Reviewers, Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
