### PR TITLE
Remove deprecated functions from `pgdb.Pool`

### DIFF
--- a/cmd/envtool/main.go
+++ b/cmd/envtool/main.go
@@ -201,7 +201,7 @@ func setupPostgres(ctx context.Context, logger *zap.SugaredLogger) error {
 
 	logger.Info("Creating databases...")
 	for _, db := range []string{"admin", "test"} {
-		if err = pgPool.CreateDatabase(ctx, db); err != nil {
+		if err = pgdb.CreateDatabase(ctx, pgPool, db); err != nil {
 			return err
 		}
 	}

--- a/internal/handlers/pg/msg_drop.go
+++ b/internal/handlers/pg/msg_drop.go
@@ -45,7 +45,7 @@ func (h *Handler) MsgDrop(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, er
 		return nil, err
 	}
 
-	err = h.pgPool.DropCollection(ctx, db, collection)
+	err = pgdb.DropCollection(ctx, h.pgPool, db, collection)
 	switch {
 	case err == nil:
 		// nothing

--- a/internal/handlers/pg/msg_listcollections.go
+++ b/internal/handlers/pg/msg_listcollections.go
@@ -55,7 +55,7 @@ func (h *Handler) MsgListCollections(ctx context.Context, msg *wire.OpMsg) (*wir
 		return nil, err
 	}
 
-	names, err := h.pgPool.Collections(ctx, db)
+	names, err := pgdb.Collections(ctx, h.pgPool, db)
 	if err != nil && !errors.Is(err, pgdb.ErrSchemaNotExist) {
 		return nil, lazyerrors.Error(err)
 	}

--- a/internal/handlers/pg/msg_listdatabases.go
+++ b/internal/handlers/pg/msg_listdatabases.go
@@ -67,7 +67,7 @@ func (h *Handler) MsgListDatabases(ctx context.Context, msg *wire.OpMsg) (*wire.
 			for _, name := range tables {
 				var tableSize int64
 				fullName := databaseName + "." + name
-				err = h.pgPool.QueryRow(ctx, "SELECT pg_total_relation_size($1)", fullName).Scan(&tableSize)
+				err = tx.QueryRow(ctx, "SELECT pg_total_relation_size($1)", fullName).Scan(&tableSize)
 				if err != nil {
 					return lazyerrors.Error(err)
 				}

--- a/internal/handlers/pg/msg_listdatabases.go
+++ b/internal/handlers/pg/msg_listdatabases.go
@@ -17,7 +17,10 @@ package pg
 import (
 	"context"
 
+	"github.com/jackc/pgx/v4"
+
 	"github.com/FerretDB/FerretDB/internal/handlers/common"
+	"github.com/FerretDB/FerretDB/internal/handlers/pg/pgdb"
 	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
 	"github.com/FerretDB/FerretDB/internal/util/must"
@@ -38,56 +41,65 @@ func (h *Handler) MsgListDatabases(ctx context.Context, msg *wire.OpMsg) (*wire.
 
 	common.Ignored(document, h.l, "comment", "authorizedDatabases")
 
-	databaseNames, err := h.pgPool.Schemas(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	nameOnly, err := common.GetBoolOptionalParam(document, "nameOnly")
 	if err != nil {
 		return nil, err
 	}
 
-	databases := types.MakeArray(len(databaseNames))
-	for _, databaseName := range databaseNames {
-		tables, err := h.pgPool.Tables(ctx, databaseName)
+	var databases *types.Array
+	err = h.pgPool.InTransaction(ctx, func(tx pgx.Tx) error {
+		var databaseNames []string
+		var err error
+		databaseNames, err = pgdb.Databases(ctx, tx)
 		if err != nil {
-			return nil, lazyerrors.Error(err)
+			return lazyerrors.Error(err)
 		}
 
-		// iterate over result to collect sizes
-		var sizeOnDisk int64
-		for _, name := range tables {
-			var tableSize int64
-			fullName := databaseName + "." + name
-			err = h.pgPool.QueryRow(ctx, "SELECT pg_total_relation_size($1)", fullName).Scan(&tableSize)
+		databases = types.MakeArray(len(databaseNames))
+		for _, databaseName := range databaseNames {
+			tables, err := pgdb.Tables(ctx, tx, databaseName)
 			if err != nil {
-				return nil, lazyerrors.Error(err)
+				return lazyerrors.Error(err)
 			}
-			sizeOnDisk += tableSize
-		}
 
-		d := must.NotFail(types.NewDocument(
-			"name", databaseName,
-			"sizeOnDisk", sizeOnDisk,
-			"empty", sizeOnDisk == 0,
-		))
-
-		matches, err := common.FilterDocument(d, filter)
-		if err != nil {
-			return nil, err
-		}
-
-		if matches {
-			if nameOnly {
-				d = must.NotFail(types.NewDocument(
-					"name", databaseName,
-				))
+			// iterate over result to collect sizes
+			var sizeOnDisk int64
+			for _, name := range tables {
+				var tableSize int64
+				fullName := databaseName + "." + name
+				err = h.pgPool.QueryRow(ctx, "SELECT pg_total_relation_size($1)", fullName).Scan(&tableSize)
+				if err != nil {
+					return lazyerrors.Error(err)
+				}
+				sizeOnDisk += tableSize
 			}
-			if err = databases.Append(d); err != nil {
-				return nil, lazyerrors.Error(err)
+
+			d := must.NotFail(types.NewDocument(
+				"name", databaseName,
+				"sizeOnDisk", sizeOnDisk,
+				"empty", sizeOnDisk == 0,
+			))
+
+			matches, err := common.FilterDocument(d, filter)
+			if err != nil {
+				return lazyerrors.Error(err)
+			}
+
+			if matches {
+				if nameOnly {
+					d = must.NotFail(types.NewDocument(
+						"name", databaseName,
+					))
+				}
+				if err = databases.Append(d); err != nil {
+					return lazyerrors.Error(err)
+				}
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	if nameOnly {

--- a/internal/handlers/pg/pgdb/pool.go
+++ b/internal/handlers/pg/pgdb/pool.go
@@ -169,20 +169,6 @@ func (pgPool *Pool) checkConnection(ctx context.Context) error {
 	return nil
 }
 
-// Collections method should not be used in new code.
-//
-// Deprecated: use Collections function instead.
-func (pgPool *Pool) Collections(ctx context.Context, db string) ([]string, error) {
-	return Collections(ctx, pgPool, db)
-}
-
-// CreateDatabase method should not be used in new code.
-//
-// Deprecated: use CreateDatabase function instead.
-func (pgPool *Pool) CreateDatabase(ctx context.Context, db string) error {
-	return CreateDatabase(ctx, pgPool, db)
-}
-
 // DropDatabase drops FerretDB database.
 //
 // It returns ErrTableNotExist if schema does not exist.
@@ -208,20 +194,13 @@ func (pgPool *Pool) DropDatabase(ctx context.Context, db string) error {
 	}
 }
 
-// DropCollection method should not be used in new code.
-//
-// Deprecated: use DropCollection function instead.
-func (pgPool *Pool) DropCollection(ctx context.Context, schema, collection string) error {
-	return DropCollection(ctx, pgPool, schema, collection)
-}
-
 // CreateTableIfNotExist ensures that given FerretDB database / PostgreSQL schema
 // and FerretDB collection / PostgreSQL table exist.
 // If needed, it creates both schema and table.
 //
 // True is returned if table was created.
 func (pgPool *Pool) CreateTableIfNotExist(ctx context.Context, db, collection string) (bool, error) {
-	exists, err := pgPool.CollectionExists(ctx, db, collection)
+	exists, err := CollectionExists(ctx, pgPool, db, collection)
 	if err != nil {
 		return false, lazyerrors.Error(err)
 	}
@@ -232,7 +211,7 @@ func (pgPool *Pool) CreateTableIfNotExist(ctx context.Context, db, collection st
 	// Table (or even schema) does not exist. Try to create it,
 	// but keep in mind that it can be created in concurrent connection.
 
-	if err := pgPool.CreateDatabase(ctx, db); err != nil && !errors.Is(err, ErrAlreadyExist) {
+	if err := CreateDatabase(ctx, pgPool, db); err != nil && !errors.Is(err, ErrAlreadyExist) {
 		return false, lazyerrors.Error(err)
 	}
 
@@ -245,13 +224,6 @@ func (pgPool *Pool) CreateTableIfNotExist(ctx context.Context, db, collection st
 	}
 
 	return true, nil
-}
-
-// CollectionExists method should not be used in new code.
-//
-// Deprecated: use CollectionExists function instead.
-func (pgPool *Pool) CollectionExists(ctx context.Context, db, collection string) (bool, error) {
-	return CollectionExists(ctx, pgPool, db, collection)
 }
 
 // SchemaStats returns a set of statistics for FerretDB database / PostgreSQL schema and table.

--- a/internal/handlers/pg/pgdb/pool.go
+++ b/internal/handlers/pg/pgdb/pool.go
@@ -176,13 +176,6 @@ func (pgPool *Pool) Collections(ctx context.Context, db string) ([]string, error
 	return Collections(ctx, pgPool, db)
 }
 
-// Tables method should not be used in new code.
-//
-// Deprecated: use Tables function instead.
-func (pgPool *Pool) Tables(ctx context.Context, schema string) ([]string, error) {
-	return Tables(ctx, pgPool, schema)
-}
-
 // CreateDatabase method should not be used in new code.
 //
 // Deprecated: use CreateDatabase function instead.

--- a/internal/handlers/pg/pgdb/pool.go
+++ b/internal/handlers/pg/pgdb/pool.go
@@ -169,13 +169,6 @@ func (pgPool *Pool) checkConnection(ctx context.Context) error {
 	return nil
 }
 
-// Schemas method should not be used in new code.
-//
-// Deprecated: use Databases function instead.
-func (pgPool *Pool) Schemas(ctx context.Context) ([]string, error) {
-	return Databases(ctx, pgPool)
-}
-
 // Collections method should not be used in new code.
 //
 // Deprecated: use Collections function instead.

--- a/internal/handlers/pg/pgdb/pool_test.go
+++ b/internal/handlers/pg/pgdb/pool_test.go
@@ -77,7 +77,7 @@ func TestCreateDrop(t *testing.T) {
 		// - table creation is not possible
 		// - schema creation is possible
 
-		err := pool.DropCollection(ctx, schemaName, tableName)
+		err := pgdb.DropCollection(ctx, pool, schemaName, tableName)
 		require.Equal(t, pgdb.ErrSchemaNotExist, err)
 
 		err = pool.DropDatabase(ctx, schemaName)
@@ -86,10 +86,10 @@ func TestCreateDrop(t *testing.T) {
 		err = pgdb.CreateCollection(ctx, pool, schemaName, tableName)
 		require.ErrorIs(t, err, pgdb.ErrSchemaNotExist)
 
-		err = pool.CreateDatabase(ctx, schemaName)
+		err = pgdb.CreateDatabase(ctx, pool, schemaName)
 		require.NoError(t, err)
 
-		tables, err := pool.Collections(ctx, schemaName)
+		tables, err := pgdb.Collections(ctx, pool, schemaName)
 		require.NoError(t, err)
 		assert.Empty(t, tables)
 	})
@@ -104,7 +104,7 @@ func TestCreateDrop(t *testing.T) {
 			pool.DropDatabase(ctx, schemaName)
 		})
 
-		err := pool.CreateDatabase(ctx, schemaName)
+		err := pgdb.CreateDatabase(ctx, pool, schemaName)
 		require.NoError(t, err)
 
 		// Schema exists ->
@@ -116,13 +116,13 @@ func TestCreateDrop(t *testing.T) {
 		err = pgdb.CreateDatabase(ctx, pool, schemaName)
 		require.ErrorIs(t, err, pgdb.ErrAlreadyExist)
 
-		err = pool.DropCollection(ctx, schemaName, tableName)
+		err = pgdb.DropCollection(ctx, pool, schemaName, tableName)
 		require.ErrorIs(t, err, pgdb.ErrTableNotExist)
 
 		err = pgdb.CreateCollection(ctx, pool, schemaName, tableName)
 		require.NoError(t, err)
 
-		tables, err := pool.Collections(ctx, schemaName)
+		tables, err := pgdb.Collections(ctx, pool, schemaName)
 		require.NoError(t, err)
 		assert.Equal(t, []string{tableName}, tables)
 
@@ -149,7 +149,7 @@ func TestCreateDrop(t *testing.T) {
 		err = pgdb.CreateCollection(ctx, pool, schemaName, tableName)
 		require.NoError(t, err)
 
-		tables, err := pool.Collections(ctx, schemaName)
+		tables, err := pgdb.Collections(ctx, pool, schemaName)
 		require.NoError(t, err)
 		assert.Equal(t, []string{tableName}, tables)
 
@@ -165,10 +165,10 @@ func TestCreateDrop(t *testing.T) {
 		err = pgdb.CreateDatabase(ctx, pool, schemaName)
 		require.ErrorIs(t, err, pgdb.ErrAlreadyExist)
 
-		err = pool.DropCollection(ctx, schemaName, tableName)
+		err = pgdb.DropCollection(ctx, pool, schemaName, tableName)
 		require.NoError(t, err)
 
-		err = pool.DropCollection(ctx, schemaName, tableName)
+		err = pgdb.DropCollection(ctx, pool, schemaName, tableName)
 		require.ErrorIs(t, err, pgdb.ErrTableNotExist)
 
 		err = pool.DropDatabase(ctx, schemaName)
@@ -268,7 +268,7 @@ func TestTableExists(t *testing.T) {
 			pool.DropDatabase(ctx, schemaName)
 		})
 
-		ok, err := pool.CollectionExists(ctx, schemaName, tableName)
+		ok, err := pgdb.CollectionExists(ctx, pool, schemaName, tableName)
 		require.NoError(t, err)
 		assert.False(t, ok)
 	})
@@ -279,13 +279,13 @@ func TestTableExists(t *testing.T) {
 		schemaName := testutil.SchemaName(t)
 		tableName := testutil.TableName(t)
 
-		pool.CreateDatabase(ctx, schemaName)
+		pgdb.CreateDatabase(ctx, pool, schemaName)
 
 		t.Cleanup(func() {
 			pool.DropDatabase(ctx, schemaName)
 		})
 
-		ok, err := pool.CollectionExists(ctx, schemaName, tableName)
+		ok, err := pgdb.CollectionExists(ctx, pool, schemaName, tableName)
 		require.NoError(t, err)
 		assert.False(t, ok)
 	})
@@ -296,14 +296,14 @@ func TestTableExists(t *testing.T) {
 		schemaName := testutil.SchemaName(t)
 		tableName := testutil.TableName(t)
 
-		pool.CreateDatabase(ctx, schemaName)
+		pgdb.CreateDatabase(ctx, pool, schemaName)
 		pgdb.CreateCollection(ctx, pool, schemaName, tableName)
 
 		t.Cleanup(func() {
 			pool.DropDatabase(ctx, schemaName)
 		})
 
-		ok, err := pool.CollectionExists(ctx, schemaName, tableName)
+		ok, err := pgdb.CollectionExists(ctx, pool, schemaName, tableName)
 		require.NoError(t, err)
 		assert.True(t, ok)
 	})
@@ -336,7 +336,7 @@ func TestCreateTableIfNotExist(t *testing.T) {
 		schemaName := testutil.SchemaName(t)
 		tableName := testutil.TableName(t)
 
-		pool.CreateDatabase(ctx, schemaName)
+		pgdb.CreateDatabase(ctx, pool, schemaName)
 
 		t.Cleanup(func() {
 			pool.DropDatabase(ctx, schemaName)
@@ -353,7 +353,7 @@ func TestCreateTableIfNotExist(t *testing.T) {
 		schemaName := testutil.SchemaName(t)
 		tableName := testutil.TableName(t)
 
-		pool.CreateDatabase(ctx, schemaName)
+		pgdb.CreateDatabase(ctx, pool, schemaName)
 		pgdb.CreateCollection(ctx, pool, schemaName, tableName)
 
 		t.Cleanup(func() {


### PR DESCRIPTION
# Description

Remove deprecated `Schema` and use `Databases` instead (in transaction).

## Readiness checklist

* [x] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [x] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [x] I checked comments rendering with `task godocs`.
* [x] (for maintainers only) I set Reviewers, Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
