### PR TITLE
Add a comment to the setup function about database and collection creation when provider list is empty

### DIFF
--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -200,10 +200,10 @@ func setupListener(tb testing.TB, ctx context.Context, logger *zap.Logger) int {
 }
 
 // setupCollection setups a single collection.
-// It there is no providers, database and collection are not created.
-// That is intentionally:
-//  * for those tests where no collection and database needed.
-//  * for Tigris (where we can’t create collection without a schema and we don’t know schema without documents).
+// If there are no providers, we don't create a database and collection.
+// That is intentional:
+//   * for those tests where no collection and database are needed.
+//   * for Tigris: we can't create a collection without a schema, and we don't know schema without documents.
 func setupCollection(tb testing.TB, ctx context.Context, port int, db string, providers []shareddata.Provider) *mongo.Collection {
 	tb.Helper()
 

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -233,7 +233,7 @@ func setupCollection(tb testing.TB, ctx context.Context, port int, db string, pr
 		require.NoError(tb, err)
 		require.Len(tb, res.InsertedIDs, len(docs))
 	}
-	// if there is no providers used in test, let's create collectio and database.
+	// if there is no providers used in test, let's create collection and database.
 	if len(providers) == 0 {
 		err := client.Database(db).CreateCollection(ctx, collectionName)
 		require.NoError(tb, err)

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -201,7 +201,7 @@ func setupListener(tb testing.TB, ctx context.Context, logger *zap.Logger) int {
 
 // setupCollection setups a single collection.
 // It there is no providers, database and collection are not created.
-// That is intentionally for:
+// That is intentionally:
 //  * for those tests where no collection and database needed.
 //  * for Tigris (where we can’t create collection without a schema and we don’t know schema without documents).
 func setupCollection(tb testing.TB, ctx context.Context, port int, db string, providers []shareddata.Provider) *mongo.Collection {

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -223,6 +223,8 @@ func setupCollection(tb testing.TB, ctx context.Context, port int, db string, pr
 		_ = database.Drop(ctx)
 	}
 
+	// this code creates database and collection
+	// and also inserts data
 	for _, provider := range providers {
 		docs := shareddata.Docs(provider)
 		require.NotEmpty(tb, docs)
@@ -230,6 +232,11 @@ func setupCollection(tb testing.TB, ctx context.Context, port int, db string, pr
 		res, err := collection.InsertMany(ctx, docs)
 		require.NoError(tb, err)
 		require.Len(tb, res.InsertedIDs, len(docs))
+	}
+	// if there is no providers used in test, let's create collectio and database.
+	if len(providers) == 0 {
+		err := client.Database(db).CreateCollection(ctx, collectionName)
+		require.NoError(tb, err)
 	}
 
 	// delete collection and (possibly) database unless test failed


### PR DESCRIPTION
# Description

Added comment to the setup function:
> Add comment to the setup function about database and collection creation when provider list is empty.

* [ ] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [x] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [x] I checked comments rendering with `task godocs`.
* [x] (for maintainers only) I set Reviewers, Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
