### PR TITLE
comment `url.Values` to prevent test failing

### DIFF
--- a/integration/setup.go
+++ b/integration/setup.go
@@ -256,18 +256,21 @@ func setupClient(tb testing.TB, ctx context.Context, port uint16) *mongo.Client 
 
 	// those options should not affect anything except tests speed
 	v := url.Values{
-		"connectTimeoutMS":         []string{"5000"},
-		"serverSelectionTimeoutMS": []string{"5000"},
-		"socketTimeoutMS":          []string{"5000"},
-		"heartbeatFrequencyMS":     []string{"30000"},
+		// TODO: Test fails occured on some platforms due to i/o timeout.
+		// Needs more investigation.
+		//
+		//"connectTimeoutMS":         []string{"5000"},
+		//"serverSelectionTimeoutMS": []string{"5000"},
+		//"socketTimeoutMS":          []string{"5000"},
+		//"heartbeatFrequencyMS":     []string{"30000"},
 
-		"minPoolSize":   []string{"1"},
-		"maxPoolSize":   []string{"1"},
-		"maxConnecting": []string{"1"},
-		"maxIdleTimeMS": []string{"0"},
+		//"minPoolSize":   []string{"1"},
+		//"maxPoolSize":   []string{"1"},
+		//"maxConnecting": []string{"1"},
+		//"maxIdleTimeMS": []string{"0"},
 
-		"directConnection": []string{"true"},
-		"appName":          []string{tb.Name()},
+		//"directConnection": []string{"true"},
+		//"appName":          []string{tb.Name()},
 	}
 
 	u := url.URL{


### PR DESCRIPTION
# Description

This PR comments `url.Values` in the `setupClient` function to prevent timeout errors in tests. Further investigation will be required.
<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

* [ ] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [x] I checked comments rendering with `task godocs`.
* [x] (for maintainers only) I set Reviewers, Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
