### PR TITLE
Fix tests for `$all`

### DIFF
--- a/integration/compat_test.go
+++ b/integration/compat_test.go
@@ -1,0 +1,31 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+// compatTestCaseResultType represents compatibility test case result type.
+//
+// It is used to avoid errors with invalid queries making tests pass.
+type compatTestCaseResultType int
+
+const (
+	// Test case should return non-empty result.
+	nonEmptyResult compatTestCaseResultType = iota
+
+	// Test case should return empty result.
+	emptyResult
+
+	// Test case should fail.
+	errorResult
+)

--- a/integration/query_array_compat_test.go
+++ b/integration/query_array_compat_test.go
@@ -26,55 +26,58 @@ func TestQueryArrayCompatAll(t *testing.T) {
 
 	testCases := map[string]queryCompatTestCase{
 		"String": {
-			filter: bson.D{{"value", bson.D{{"$all", bson.A{"foo"}}}}},
+			filter: bson.D{{"v", bson.D{{"$all", bson.A{"foo"}}}}},
 		},
 		"StringRepeated": {
-			filter: bson.D{{"value", bson.D{{"$all", bson.A{"foo", "foo", "foo"}}}}},
+			filter: bson.D{{"v", bson.D{{"$all", bson.A{"foo", "foo", "foo"}}}}},
 		},
 		"StringEmpty": {
-			filter: bson.D{{"value", bson.D{{"$all", bson.A{""}}}}},
+			filter: bson.D{{"v", bson.D{{"$all", bson.A{""}}}}},
 		},
 		"Whole": {
-			filter: bson.D{{"value", bson.D{{"$all", bson.A{int32(42)}}}}},
+			filter: bson.D{{"v", bson.D{{"$all", bson.A{int32(42)}}}}},
 		},
 		"Zero": {
-			filter: bson.D{{"value", bson.D{{"$all", bson.A{math.Copysign(0, +1)}}}}},
+			filter: bson.D{{"v", bson.D{{"$all", bson.A{math.Copysign(0, +1)}}}}},
 		},
 		"Double": {
-			filter: bson.D{{"value", bson.D{{"$all", bson.A{42.13}}}}},
+			filter: bson.D{{"v", bson.D{{"$all", bson.A{42.13}}}}},
 		},
 		"DoubleMax": {
-			filter: bson.D{{"value", bson.D{{"$all", bson.A{math.MaxFloat64}}}}},
+			filter: bson.D{{"v", bson.D{{"$all", bson.A{math.MaxFloat64}}}}},
 		},
 		"DoubleMin": {
-			filter: bson.D{{"value", bson.D{{"$all", bson.A{math.SmallestNonzeroFloat64}}}}},
+			filter: bson.D{{"v", bson.D{{"$all", bson.A{math.SmallestNonzeroFloat64}}}}},
 		},
 		"Nil": {
-			filter: bson.D{{"value", bson.D{{"$all", bson.A{nil}}}}},
+			filter: bson.D{{"v", bson.D{{"$all", bson.A{nil}}}}},
 		},
 		"MultiAll": {
-			filter: bson.D{{"value", bson.D{{"$all", bson.A{"foo", 42}}}}},
+			filter: bson.D{{"v", bson.D{{"$all", bson.A{"foo", 42}}}}},
 		},
 		"MultiAllWithNil": {
-			filter: bson.D{{"value", bson.D{{"$all", bson.A{"foo", nil}}}}},
+			filter: bson.D{{"v", bson.D{{"$all", bson.A{"foo", nil}}}}},
 		},
 		"ArrayEmbeddedEqual": {
-			filter: bson.D{{"value", bson.D{{"$all", bson.A{bson.A{int32(42), "foo"}}}}}},
+			filter: bson.D{{"v", bson.D{{"$all", bson.A{bson.A{int32(42), "foo"}}}}}},
 		},
 		"ArrayEmbeddedReverseOrder": {
-			filter: bson.D{{"value", bson.D{{"$all", bson.A{bson.A{"foo", int32(42)}}}}}},
+			filter:     bson.D{{"v", bson.D{{"$all", bson.A{bson.A{"foo", int32(42)}}}}}},
+			resultType: emptyResult,
 		},
 		"Empty": {
-			filter: bson.D{{"value", bson.D{{"$all", bson.A{}}}}},
+			filter:     bson.D{{"v", bson.D{{"$all", bson.A{}}}}},
+			resultType: emptyResult,
 		},
 		"EmptyNested": {
-			filter: bson.D{{"value", bson.D{{"$all", bson.A{bson.A{}}}}}},
+			filter: bson.D{{"v", bson.D{{"$all", bson.A{bson.A{}}}}}},
 		},
 		"NotFound": {
-			filter: bson.D{{"value", bson.D{{"$all", bson.A{"hello"}}}}},
+			filter:     bson.D{{"v", bson.D{{"$all", bson.A{"hello"}}}}},
+			resultType: emptyResult,
 		},
 		"NaN": {
-			filter: bson.D{{"value", bson.D{{"$all", bson.A{math.NaN()}}}}},
+			filter: bson.D{{"v", bson.D{{"$all", bson.A{math.NaN()}}}}},
 		},
 	}
 

--- a/integration/query_compat_test.go
+++ b/integration/query_compat_test.go
@@ -28,8 +28,9 @@ import (
 
 // queryCompatTestCase describes query compatibility test case.
 type queryCompatTestCase struct {
-	filter bson.D // required
-	sort   bson.D // defaults to `bson.D{{"_id", 1}}`
+	filter     bson.D                   // required
+	sort       bson.D                   // defaults to `bson.D{{"_id", 1}}`
+	resultType compatTestCaseResultType // defaults to nonEmptyResult
 }
 
 // testQueryCompat tests query compatibility test cases.
@@ -44,7 +45,7 @@ func testQueryCompat(t *testing.T, testCases map[string]queryCompatTestCase) {
 
 	// Use shared setup because find queries can't modify data.
 	// TODO use read-only user https://github.com/FerretDB/FerretDB/issues/914
-	ctx, collection, compatCollection := setup.SetupCompat(t, providers...)
+	ctx, targetCollection, compatCollection := setup.SetupCompat(t, providers...)
 
 	for name, tc := range testCases {
 		name, tc := name, tc
@@ -60,31 +61,45 @@ func testQueryCompat(t *testing.T, testCases map[string]queryCompatTestCase) {
 			}
 			opts := options.Find().SetSort(sort)
 
-			cursor, err := collection.Find(ctx, filter, opts)
+			targetCursor, targetErr := targetCollection.Find(ctx, filter, opts)
 			compatCursor, compatErr := compatCollection.Find(ctx, filter, opts)
 
-			if cursor != nil {
-				defer cursor.Close(ctx)
+			if targetCursor != nil {
+				defer targetCursor.Close(ctx)
 			}
 			if compatCursor != nil {
 				defer compatCursor.Close(ctx)
 			}
 
-			if err != nil {
-				err = UnsetRaw(t, err)
+			if targetErr != nil {
+				targetErr = UnsetRaw(t, targetErr)
 				compatErr = UnsetRaw(t, compatErr)
-				assert.Equal(t, compatErr, err)
+				assert.Equal(t, errorResult, tc.resultType)
+				assert.Equal(t, compatErr, targetErr)
 				return
 			}
 			require.NoError(t, compatErr)
 
-			var res, compatRes []bson.D
-			require.NoError(t, cursor.All(ctx, &res))
+			var targetRes, compatRes []bson.D
+			require.NoError(t, targetCursor.All(ctx, &targetRes))
 			require.NoError(t, compatCursor.All(ctx, &compatRes))
 
-			t.Logf("Expected IDs: %v", CollectIDs(t, compatRes))
-			t.Logf("Actual IDs: %v", CollectIDs(t, res))
-			AssertEqualDocumentsSlice(t, compatRes, res)
+			t.Logf("Compat (expected) IDs: %v", CollectIDs(t, compatRes))
+			t.Logf("Target (actual)   IDs: %v", CollectIDs(t, targetRes))
+
+			switch tc.resultType {
+			case nonEmptyResult:
+				assert.NotEmpty(t, compatRes)
+				assert.NotEmpty(t, targetRes)
+				AssertEqualDocumentsSlice(t, compatRes, targetRes)
+			case emptyResult:
+				assert.Empty(t, compatRes)
+				assert.Empty(t, targetRes)
+			case errorResult:
+				fallthrough
+			default:
+				t.Fatalf("unknown case type %v", tc.resultType)
+			}
 		})
 	}
 }

--- a/integration/query_logical_compat_test.go
+++ b/integration/query_logical_compat_test.go
@@ -33,7 +33,8 @@ func TestQueryLogicalCompatAnd(t *testing.T) {
 			}},
 		},
 		"BadInput": {
-			filter: bson.D{{"$and", nil}},
+			filter:     bson.D{{"$and", nil}},
+			resultType: errorResult,
 		},
 		"BadExpressionValue": {
 			filter: bson.D{{
@@ -42,6 +43,7 @@ func TestQueryLogicalCompatAnd(t *testing.T) {
 					nil,
 				},
 			}},
+			resultType: errorResult,
 		},
 		"AndOr": {
 			filter: bson.D{{

--- a/integration/update_compat_test.go
+++ b/integration/update_compat_test.go
@@ -52,7 +52,7 @@ func testUpdateCompat(t *testing.T, testCases map[string]updateCompatTestCase) {
 			}
 
 			// Use per-test setup because ypdate queries modify data.
-			ctx, collection, compatCollection := setup.SetupCompat(t, providers...)
+			ctx, targetCollection, compatCollection := setup.SetupCompat(t, providers...)
 
 			update := tc.update
 			require.NotNil(t, update)
@@ -63,23 +63,23 @@ func testUpdateCompat(t *testing.T, testCases map[string]updateCompatTestCase) {
 				t.Run(fmt.Sprint(id), func(t *testing.T) {
 					t.Helper()
 
-					updateRes, err := collection.UpdateByID(ctx, id, update)
+					targetUpdateRes, targetErr := targetCollection.UpdateByID(ctx, id, update)
 					compatUpdateRes, compatErr := compatCollection.UpdateByID(ctx, id, update)
 
-					if err != nil {
-						err = UnsetRaw(t, err)
+					if targetErr != nil {
+						targetErr = UnsetRaw(t, targetErr)
 						compatErr = UnsetRaw(t, compatErr)
-						assert.Equal(t, compatErr, err)
+						assert.Equal(t, compatErr, targetErr)
 					} else {
 						require.NoError(t, compatErr)
 					}
 
-					assert.Equal(t, compatUpdateRes, updateRes)
+					assert.Equal(t, compatUpdateRes, targetUpdateRes)
 
-					var findRes, compatFindRes bson.D
-					require.NoError(t, collection.FindOne(ctx, bson.D{{"_id", id}}).Decode(&findRes))
+					var targetFindRes, compatFindRes bson.D
+					require.NoError(t, targetCollection.FindOne(ctx, bson.D{{"_id", id}}).Decode(&targetFindRes))
 					require.NoError(t, compatCollection.FindOne(ctx, bson.D{{"_id", id}}).Decode(&compatFindRes))
-					AssertEqualDocuments(t, compatFindRes, findRes)
+					AssertEqualDocuments(t, compatFindRes, targetFindRes)
 				})
 			}
 		})


### PR DESCRIPTION
## Readiness checklist

* [x] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [x] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [x] I checked comments rendering with `task godocs`.
* [x] (for maintainers only) I set Reviewers, Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
