### PR TITLE
Fix `nModified` count for `update`'s `$set` operator with the same value

### DIFF
--- a/integration/update_field_test.go
+++ b/integration/update_field_test.go
@@ -804,6 +804,26 @@ func TestUpdateFieldSet(t *testing.T) {
 				UpsertedCount: 0,
 			},
 		},
+		"SetSameValueInt": {
+			id:     "int32",
+			update: bson.D{{"$set", bson.D{{"v", int32(42)}}}},
+			result: bson.D{{"_id", "int32"}, {"v", int32(42)}},
+			stat: &mongo.UpdateResult{
+				MatchedCount:  1,
+				ModifiedCount: 0,
+				UpsertedCount: 0,
+			},
+		},
+		"SetSameValueNan": {
+			id:     "double-nan",
+			update: bson.D{{"$set", bson.D{{"v", math.NaN()}}}},
+			result: bson.D{{"_id", "double-nan"}, {"v", math.NaN()}},
+			stat: &mongo.UpdateResult{
+				MatchedCount:  1,
+				ModifiedCount: 0,
+				UpsertedCount: 0,
+			},
+		},
 	} {
 		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {

--- a/internal/handlers/common/update.go
+++ b/internal/handlers/common/update.go
@@ -59,11 +59,23 @@ func UpdateDocument(doc, update *types.Document) (bool, error) {
 			sort.Strings(setDoc.Keys())
 			for _, setKey := range setDoc.Keys() {
 				setValue := must.NotFail(setDoc.Get(setKey))
+				if doc.Has(setKey) {
+					result := types.Compare(setValue, must.NotFail(doc.Get(setKey)))
+					if len(result) != 1 {
+						panic("$set: there should be only one result")
+					}
+
+					if result[0] == types.Equal {
+						continue
+					}
+				}
+
 				if err := doc.Set(setKey, setValue); err != nil {
 					return false, err
 				}
+
+				changed = true
 			}
-			changed = true
 
 		case "$unset":
 			unsetDoc := updateV.(*types.Document)
@@ -97,7 +109,7 @@ func UpdateDocument(doc, update *types.Document) (bool, error) {
 					result := types.Compare(docValue, incremented)
 
 					if len(result) != 1 {
-						panic("there should be only one result")
+						panic("$inc: there should be only one result")
 					}
 
 					docFloat, ok := docValue.(float64)


### PR DESCRIPTION
# Description

This PR closes #571.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [x] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] (for maintainers only) I set Reviewers, Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
