### PR TITLE
Fix some collection names breaking `listDatabases`

### DIFF
--- a/integration/basic_test.go
+++ b/integration/basic_test.go
@@ -106,7 +106,7 @@ func TestInsertFind(t *testing.T) {
 //nolint:paralleltest // we test a global list of databases
 func TestFindCommentMethod(t *testing.T) {
 	ctx, collection := setup.Setup(t, shareddata.Scalars)
-	name := collection.Name()
+	name := collection.Database().Name()
 	databaseNames, err := collection.Database().Client().ListDatabaseNames(ctx, bson.D{})
 	require.NoError(t, err)
 	comment := "*/ 1; DROP SCHEMA " + name + " CASCADE -- "
@@ -121,7 +121,7 @@ func TestFindCommentMethod(t *testing.T) {
 //nolint:paralleltest // we test a global list of databases
 func TestFindCommentQuery(t *testing.T) {
 	ctx, collection := setup.Setup(t, shareddata.Scalars)
-	name := collection.Name()
+	name := collection.Database().Name()
 	databaseNames, err := collection.Database().Client().ListDatabaseNames(ctx, bson.D{})
 	require.NoError(t, err)
 	comment := "*/ 1; DROP SCHEMA " + name + " CASCADE -- "
@@ -135,7 +135,7 @@ func TestFindCommentQuery(t *testing.T) {
 func TestUpdateCommentMethod(t *testing.T) {
 	t.Parallel()
 	ctx, collection := setup.Setup(t, shareddata.Scalars)
-	name := collection.Name()
+	name := collection.Database().Name()
 	databaseNames, err := collection.Database().Client().ListDatabaseNames(ctx, bson.D{})
 	require.NoError(t, err)
 
@@ -159,7 +159,7 @@ func TestUpdateCommentMethod(t *testing.T) {
 func TestUpdateCommentQuery(t *testing.T) {
 	t.Parallel()
 	ctx, collection := setup.Setup(t, shareddata.Scalars)
-	name := collection.Name()
+	name := collection.Database().Name()
 	databaseNames, err := collection.Database().Client().ListDatabaseNames(ctx, bson.D{})
 	require.NoError(t, err)
 
@@ -183,7 +183,7 @@ func TestCollectionName(t *testing.T) {
 	t.Run("Err", func(t *testing.T) {
 		ctx, collection := setup.Setup(t)
 
-		collectionName300 := strings.Repeat("a", 300)
+		collectionName300 := strings.Repeat("aB", 150)
 		cases := map[string]struct {
 			collection string
 			err        *mongo.CommandError
@@ -265,17 +265,17 @@ func TestDatabaseName(t *testing.T) {
 					Message: fmt.Sprintf(
 						"Invalid namespace specified '%s.%s'",
 						dbName64,
-						"testdatabasename_err_toolongforbothdbs",
+						"TestDatabaseName_Err_TooLongForBothDBs",
 					),
 				},
-				alt: fmt.Sprintf("Invalid namespace: %s.%s", dbName64, "testdatabasename_err_toolongforbothdbs"),
+				alt: fmt.Sprintf("Invalid namespace: %s.%s", dbName64, "TestDatabaseName_Err_TooLongForBothDBs"),
 			},
 			"WithADollarSign": {
 				db: "name_with_a-$",
 				err: &mongo.CommandError{
 					Name:    "InvalidNamespace",
 					Code:    73,
-					Message: `Invalid namespace: name_with_a-$.testdatabasename_err_withadollarsign`,
+					Message: `Invalid namespace: name_with_a-$.TestDatabaseName_Err_WithADollarSign`,
 				},
 			},
 		}

--- a/integration/commands_administration_test.go
+++ b/integration/commands_administration_test.go
@@ -70,7 +70,7 @@ func TestCommandsAdministrationCreateDropList(t *testing.T) {
 		Code: 48,
 		Name: "NamespaceExists",
 		Message: `Collection already exists. ` +
-			`NS: testcommandsadministrationcreatedroplist.testcommandsadministrationcreatedroplist`,
+			`NS: testcommandsadministrationcreatedroplist.TestCommandsAdministrationCreateDropList`,
 	}
 	AssertEqualError(t, expectedErr, err)
 

--- a/internal/handlers/pg/msg_listdatabases.go
+++ b/internal/handlers/pg/msg_listdatabases.go
@@ -66,7 +66,8 @@ func (h *Handler) MsgListDatabases(ctx context.Context, msg *wire.OpMsg) (*wire.
 			var sizeOnDisk int64
 			for _, name := range tables {
 				var tableSize int64
-				err = tx.QueryRow(ctx, "SELECT pg_total_relation_size($1)", pgx.Identifier{databaseName, name}.Sanitize()).Scan(&tableSize)
+				fullName := pgx.Identifier{databaseName, name}.Sanitize()
+				err = tx.QueryRow(ctx, "SELECT pg_total_relation_size($1)", fullName).Scan(&tableSize)
 				if err != nil {
 					return lazyerrors.Error(err)
 				}

--- a/internal/handlers/pg/msg_listdatabases.go
+++ b/internal/handlers/pg/msg_listdatabases.go
@@ -66,8 +66,7 @@ func (h *Handler) MsgListDatabases(ctx context.Context, msg *wire.OpMsg) (*wire.
 			var sizeOnDisk int64
 			for _, name := range tables {
 				var tableSize int64
-				fullName := databaseName + "." + name
-				err = tx.QueryRow(ctx, "SELECT pg_total_relation_size($1)", fullName).Scan(&tableSize)
+				err = tx.QueryRow(ctx, "SELECT pg_total_relation_size($1)", pgx.Identifier{databaseName, name}.Sanitize()).Scan(&tableSize)
 				if err != nil {
 					return lazyerrors.Error(err)
 				}

--- a/internal/util/testutil/db.go
+++ b/internal/util/testutil/db.go
@@ -25,7 +25,9 @@ import (
 func DatabaseName(tb testing.TB) string {
 	tb.Helper()
 
+	// database names are always lowercase
 	name := strings.ToLower(tb.Name())
+
 	name = strings.ReplaceAll(name, "/", "_")
 	name = strings.ReplaceAll(name, " ", "_")
 	name = strings.ReplaceAll(name, "$", "_")
@@ -38,7 +40,9 @@ func DatabaseName(tb testing.TB) string {
 func CollectionName(tb testing.TB) string {
 	tb.Helper()
 
-	name := strings.ToLower(tb.Name())
+	// do not use strings.ToLower because collection names can contain uppercase letters
+	name := tb.Name()
+
 	name = strings.ReplaceAll(name, "/", "_")
 	name = strings.ReplaceAll(name, " ", "_")
 	name = strings.ReplaceAll(name, "$", "_")


### PR DESCRIPTION
# Description

Closes #952.

Relevant PostgreSQL docs from https://www.postgresql.org/docs/current/sql-syntax-lexical.html

> Key words and unquoted identifiers are case insensitive.
> ...
> Quoting an identifier also makes it case-sensitive

## Readiness checklist

* [x] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] (for maintainers only) I set Reviewers, Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
