### PR TITLE
Add compatibility tests for `$and`

### DIFF
--- a/integration/query_compat_test.go
+++ b/integration/query_compat_test.go
@@ -1,0 +1,111 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/FerretDB/FerretDB/integration/setup"
+)
+
+// queryCompatTestCase describes query compatibility test case.
+type queryCompatTestCase struct {
+	filter     bson.D                   // required
+	sort       bson.D                   // defaults to `bson.D{{"_id", 1}}`
+	resultType compatTestCaseResultType // defaults to nonEmptyResult
+	skip       string                   // skips test in non-empty
+}
+
+// testQueryCompat tests query compatibility test cases.
+func testQueryCompat(t *testing.T, testCases map[string]queryCompatTestCase) {
+	t.Helper()
+
+	// Use shared setup because find queries can't modify data.
+	// TODO use read-only user https://github.com/FerretDB/FerretDB/issues/914
+	ctx, targetCollections, compatCollections := setup.SetupCompat(t)
+
+	for name, tc := range testCases {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			t.Helper()
+
+			if tc.skip != "" {
+				t.Skip(tc.skip)
+			}
+
+			filter := tc.filter
+			require.NotNil(t, filter)
+
+			sort := tc.sort
+			if sort == nil {
+				sort = bson.D{{"_id", 1}}
+			}
+			opts := options.Find().SetSort(sort)
+
+			var nonEmptyResults bool
+			for i := range targetCollections {
+				targetCollection := targetCollections[i]
+				compatCollection := compatCollections[i]
+				t.Run(targetCollection.Name(), func(t *testing.T) {
+					t.Helper()
+
+					targetCursor, targetErr := targetCollection.Find(ctx, filter, opts)
+					compatCursor, compatErr := compatCollection.Find(ctx, filter, opts)
+
+					if targetCursor != nil {
+						defer targetCursor.Close(ctx)
+					}
+					if compatCursor != nil {
+						defer compatCursor.Close(ctx)
+					}
+
+					if targetErr != nil {
+						targetErr = UnsetRaw(t, targetErr)
+						compatErr = UnsetRaw(t, compatErr)
+						assert.Equal(t, compatErr, targetErr)
+						return
+					}
+					require.NoError(t, compatErr)
+
+					var targetRes, compatRes []bson.D
+					require.NoError(t, targetCursor.All(ctx, &targetRes))
+					require.NoError(t, compatCursor.All(ctx, &compatRes))
+
+					t.Logf("Compat (expected) IDs: %v", CollectIDs(t, compatRes))
+					t.Logf("Target (actual)   IDs: %v", CollectIDs(t, targetRes))
+					AssertEqualDocumentsSlice(t, compatRes, targetRes)
+
+					if len(targetRes) > 0 || len(compatRes) > 0 {
+						nonEmptyResults = true
+					}
+				})
+			}
+
+			switch tc.resultType {
+			case nonEmptyResult:
+				assert.True(t, nonEmptyResults)
+			case emptyResult:
+				assert.False(t, nonEmptyResults)
+			default:
+				t.Fatalf("unknown result type %v", tc.resultType)
+			}
+		})
+	}
+}

--- a/integration/query_logical_compat_test.go
+++ b/integration/query_logical_compat_test.go
@@ -32,20 +32,6 @@ func TestQueryLogicalCompatAnd(t *testing.T) {
 				},
 			}},
 		},
-		"BadInput": {
-			filter:     bson.D{{"$and", nil}},
-			resultType: emptyResult,
-		},
-		"BadExpressionValue": {
-			filter: bson.D{{
-				"$and", bson.A{
-					bson.D{{"v", bson.D{{"$gt", int32(0)}}}},
-					nil,
-				},
-			}},
-			resultType: emptyResult,
-			skip:       "https://github.com/FerretDB/FerretDB/issues/962",
-		},
 		"AndOr": {
 			filter: bson.D{{
 				"$and", bson.A{
@@ -67,6 +53,20 @@ func TestQueryLogicalCompatAnd(t *testing.T) {
 					bson.D{{"v", bson.D{{"$type", "int"}}}},
 				},
 			}},
+		},
+		"BadInput": {
+			filter:     bson.D{{"$and", nil}},
+			resultType: emptyResult,
+		},
+		"BadValue": {
+			filter: bson.D{{
+				"$and", bson.A{
+					bson.D{{"v", bson.D{{"$gt", int32(0)}}}},
+					nil,
+				},
+			}},
+			resultType: emptyResult,
+			skip:       "https://github.com/FerretDB/FerretDB/issues/962",
 		},
 	}
 

--- a/integration/query_logical_compat_test.go
+++ b/integration/query_logical_compat_test.go
@@ -1,0 +1,74 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestQueryLogicalCompatAnd(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]queryCompatTestCase{
+		"And": {
+			filter: bson.D{{
+				"$and", bson.A{
+					bson.D{{"v", bson.D{{"$gt", int32(0)}}}},
+					bson.D{{"v", bson.D{{"$lt", int64(42)}}}},
+				},
+			}},
+		},
+		"BadInput": {
+			filter:     bson.D{{"$and", nil}},
+			resultType: emptyResult,
+		},
+		"BadExpressionValue": {
+			filter: bson.D{{
+				"$and", bson.A{
+					bson.D{{"v", bson.D{{"$gt", int32(0)}}}},
+					nil,
+				},
+			}},
+			resultType: emptyResult,
+			skip:       "https://github.com/FerretDB/FerretDB/issues/962",
+		},
+		"AndOr": {
+			filter: bson.D{{
+				"$and", bson.A{
+					bson.D{{"v", bson.D{{"$gt", int32(0)}}}},
+					bson.D{{"$or", bson.A{
+						bson.D{{"v", bson.D{{"$lt", int64(42)}}}},
+						bson.D{{"v", bson.D{{"$lte", 42.13}}}},
+					}}},
+				},
+			}},
+		},
+		"AndAnd": {
+			filter: bson.D{{
+				"$and", bson.A{
+					bson.D{{"$and", bson.A{
+						bson.D{{"v", bson.D{{"$gt", int32(0)}}}},
+						bson.D{{"v", bson.D{{"$lte", 42.13}}}},
+					}}},
+					bson.D{{"v", bson.D{{"$type", "int"}}}},
+				},
+			}},
+		},
+	}
+
+	testQueryCompat(t, testCases)
+}


### PR DESCRIPTION
Refs #962.

## Readiness checklist

* [x] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [x] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [x] I checked comments rendering with `task godocs`.
* [x] (for maintainers only) I set Reviewers, Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
