### PR TITLE
`tjson`: Check how we support `binary`

### DIFF
--- a/internal/tjson/binary_test.go
+++ b/internal/tjson/binary_test.go
@@ -1,0 +1,76 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tjson
+
+import (
+	"testing"
+
+	"github.com/FerretDB/FerretDB/internal/types"
+)
+
+var binaryTestCases = []testCase{{
+	name: "foo",
+	v: &binaryType{
+		Subtype: types.BinaryUser,
+		B:       []byte("foo"),
+	},
+	schema: binarySchema,
+	j:      `{"$b":"Zm9v","s":128}`,
+}, {
+	name: "empty",
+	v: &binaryType{
+		Subtype: types.BinaryGeneric,
+		B:       []byte{},
+	},
+	schema: binarySchema,
+	j:      `{"$b":""}`,
+	canonJ: `{"$b":"","s":0}`,
+}, {
+	name: "invalid subtype",
+	v: &binaryType{
+		Subtype: 0xff,
+		B:       []byte{},
+	},
+	schema: binarySchema,
+	j:      `{"$b":"","s":255}`,
+}, {
+	name: "extra JSON fields",
+	v: &binaryType{
+		Subtype: types.BinaryUser,
+		B:       []byte("foo"),
+	},
+	schema: binarySchema,
+	j:      `{"$b":"Zm9v","s":128,"foo":"bar"}`,
+	canonJ: `{"$b":"Zm9v","s":128}`,
+	jErr:   `json: unknown field "foo"`,
+}, {
+	name:   "EOF",
+	schema: binarySchema,
+	j:      `{`,
+	jErr:   `unexpected EOF`,
+}}
+
+func TestBinary(t *testing.T) {
+	t.Parallel()
+	testJSON(t, binaryTestCases, func() tjsontype { return new(binaryType) })
+}
+
+func FuzzBinary(f *testing.F) {
+	fuzzJSON(f, binaryTestCases)
+}
+
+func BenchmarkBinary(b *testing.B) {
+	benchmark(b, binaryTestCases)
+}

--- a/internal/tjson/bool_test.go
+++ b/internal/tjson/bool_test.go
@@ -38,9 +38,9 @@ func TestBool(t *testing.T) {
 }
 
 func FuzzBool(f *testing.F) {
-	fuzzJSON(f, boolTestCases, func() tjsontype { return new(boolType) })
+	fuzzJSON(f, boolTestCases)
 }
 
 func BenchmarkBool(b *testing.B) {
-	benchmark(b, boolTestCases, func() tjsontype { return new(boolType) })
+	benchmark(b, boolTestCases)
 }

--- a/internal/tjson/double_test.go
+++ b/internal/tjson/double_test.go
@@ -59,9 +59,9 @@ func TestDouble(t *testing.T) {
 }
 
 func FuzzDouble(f *testing.F) {
-	fuzzJSON(f, doubleTestCases, func() tjsontype { return new(doubleType) })
+	fuzzJSON(f, doubleTestCases)
 }
 
 func BenchmarkDouble(b *testing.B) {
-	benchmark(b, doubleTestCases, func() tjsontype { return new(doubleType) })
+	benchmark(b, doubleTestCases)
 }

--- a/internal/tjson/int32_test.go
+++ b/internal/tjson/int32_test.go
@@ -49,9 +49,9 @@ func TestInt32(t *testing.T) {
 }
 
 func FuzzInt32(f *testing.F) {
-	fuzzJSON(f, int32TestCases, func() tjsontype { return new(int32Type) })
+	fuzzJSON(f, int32TestCases)
 }
 
 func BenchmarkInt32(b *testing.B) {
-	benchmark(b, int32TestCases, func() tjsontype { return new(int32Type) })
+	benchmark(b, int32TestCases)
 }

--- a/internal/tjson/int64_test.go
+++ b/internal/tjson/int64_test.go
@@ -54,9 +54,9 @@ func TestInt64(t *testing.T) {
 }
 
 func FuzzInt64(f *testing.F) {
-	fuzzJSON(f, int64TestCases, func() tjsontype { return new(int64Type) })
+	fuzzJSON(f, int64TestCases)
 }
 
 func BenchmarkInt64(b *testing.B) {
-	benchmark(b, int64TestCases, func() tjsontype { return new(int64Type) })
+	benchmark(b, int64TestCases)
 }

--- a/internal/tjson/string_test.go
+++ b/internal/tjson/string_test.go
@@ -43,9 +43,9 @@ func TestString(t *testing.T) {
 }
 
 func FuzzString(f *testing.F) {
-	fuzzJSON(f, stringTestCases, func() tjsontype { return new(stringType) })
+	fuzzJSON(f, stringTestCases)
 }
 
 func BenchmarkString(b *testing.B) {
-	benchmark(b, stringTestCases, func() tjsontype { return new(stringType) })
+	benchmark(b, stringTestCases)
 }

--- a/internal/tjson/tjson_test.go
+++ b/internal/tjson/tjson_test.go
@@ -88,8 +88,8 @@ func TestMarshalUnmarshal(t *testing.T) {
 
 	assert.Equal(
 		t,
-		[]byte{0x00, 0x01, 0x02, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c},
-		ObjectID(must.NotFail(expected.Get("_id")).(types.ObjectID)),
+		types.ObjectID{0x00, 0x01, 0x02, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c},
+		must.NotFail(expected.Get("_id")).(types.ObjectID),
 	)
 }
 
@@ -215,7 +215,7 @@ func testJSON(t *testing.T, testCases []testCase, newFunc func() tjsontype) {
 	}
 }
 
-func fuzzJSON(f *testing.F, testCases []testCase, newFunc func() tjsontype) {
+func fuzzJSON(f *testing.F, testCases []testCase) {
 	for _, tc := range testCases {
 		f.Add(tc.j)
 		if tc.canonJ != "" {
@@ -260,7 +260,7 @@ func fuzzJSON(f *testing.F, testCases []testCase, newFunc func() tjsontype) {
 	})
 }
 
-func benchmark(b *testing.B, testCases []testCase, newFunc func() tjsontype) {
+func benchmark(b *testing.B, testCases []testCase) {
 	for _, tc := range testCases {
 		tc := tc
 		b.Run(tc.name, func(b *testing.B) {
@@ -282,6 +282,7 @@ func benchmark(b *testing.B, testCases []testCase, newFunc func() tjsontype) {
 				if tc.jErr == "" {
 					require.NoError(b, err)
 					assertEqual(b, tc.v, toTJSON(v))
+
 					return
 				}
 
@@ -306,6 +307,8 @@ func unmarshalJSON(v tjsontype, j string) error {
 	case *stringType:
 		err = v.UnmarshalJSON([]byte(j))
 	case *boolType:
+		err = v.UnmarshalJSON([]byte(j))
+	case *binaryType:
 		err = v.UnmarshalJSON([]byte(j))
 	default:
 		panic(fmt.Sprintf("testing is not implemented for the type %T", v))


### PR DESCRIPTION
# Description

This PR is a part of #900. 

In the scope of the PR:
- port tests for `binary`
- simplify `fuzz` and `benchmark` signatures (they don't need types)

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [x] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] (for maintainers only) I set Reviewers, Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
