### PR TITLE
Demo: Tigris returns an error on delete

### DIFF
--- a/integration/tigris/delete_smoke_test.go
+++ b/integration/tigris/delete_smoke_test.go
@@ -37,10 +37,12 @@ func TestSmokeObjectIDBinary(t *testing.T) {
 	ins, err := collection.InsertOne(ctx, bson.D{{"string_value", "foo_2"}})
 	require.NoError(t, err)
 
-	up, err := collection.UpdateOne(ctx, bson.D{{"_id", ins.InsertedID}}, bson.D{{"$set", bson.D{{"string_value", "bar_2"}}}})
+	//id := ins.InsertedID
+
+	/*up, err := collection.UpdateOne(ctx, bson.D{{"_id", id}}, bson.D{{"$set", bson.D{{"string_value", "bar_2"}}}})
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), up.MatchedCount)
-	assert.Equal(t, int64(1), up.ModifiedCount)
+	assert.Equal(t, int64(1), up.ModifiedCount)*/
 
 	del, err := collection.DeleteOne(ctx, bson.D{{"_id", ins.InsertedID}})
 	require.NoError(t, err)

--- a/integration/tigris/delete_smoke_test.go
+++ b/integration/tigris/delete_smoke_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 
 	"github.com/FerretDB/FerretDB/integration/setup"
 )
@@ -34,15 +35,21 @@ func TestSmokeObjectIDBinary(t *testing.T) {
 	ctx, collection := setup.Setup(t)
 
 	// Insert, update, delete a document with a "proper" ObjectID.
-	ins, err := collection.InsertOne(ctx, bson.D{{"string_value", "foo_2"}})
+
+	// id, err := primitive.ObjectIDFromHex("ffffffffffffffffffffffff")
+	// id, err := primitive.ObjectIDFromHex("000000000000000000000000")
+	id, err := primitive.ObjectIDFromHex("62e7d8a3d23915343c4a5f3a")
 	require.NoError(t, err)
 
-	//id := ins.InsertedID
+	ins, err := collection.InsertOne(ctx, bson.D{{"_id", id}, {"string_value", "foo_2"}})
+	require.NoError(t, err)
 
-	/*up, err := collection.UpdateOne(ctx, bson.D{{"_id", id}}, bson.D{{"$set", bson.D{{"string_value", "bar_2"}}}})
+	t.Logf("Inserted ID: %v", ins.InsertedID)
+
+	up, err := collection.UpdateOne(ctx, bson.D{{"_id", id}}, bson.D{{"$set", bson.D{{"string_value", "bar_2"}}}})
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), up.MatchedCount)
-	assert.Equal(t, int64(1), up.ModifiedCount)*/
+	assert.Equal(t, int64(1), up.ModifiedCount)
 
 	del, err := collection.DeleteOne(ctx, bson.D{{"_id", ins.InsertedID}})
 	require.NoError(t, err)

--- a/integration/tigris/delete_smoke_test.go
+++ b/integration/tigris/delete_smoke_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tigris
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+
+	"github.com/FerretDB/FerretDB/integration/setup"
+)
+
+// TODO This is a temporary test to check how ObjectID works.
+func TestSmokeObjectIDBinary(t *testing.T) {
+	// Fun fact: as Tigris has a schema, all the _id values in the collection can be either string or binary.
+	// It's not possible to insert a string value for the _id field into a collection and then expect the binary
+	// to work well with the same field.
+
+	t.Parallel()
+	ctx, collection := setup.Setup(t)
+
+	// Insert, update, delete a document with a "proper" ObjectID.
+	ins, err := collection.InsertOne(ctx, bson.D{{"string_value", "foo_2"}})
+	require.NoError(t, err)
+
+	up, err := collection.UpdateOne(ctx, bson.D{{"_id", ins.InsertedID}}, bson.D{{"$set", bson.D{{"string_value", "bar_2"}}}})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), up.MatchedCount)
+	assert.Equal(t, int64(1), up.ModifiedCount)
+
+	del, err := collection.DeleteOne(ctx, bson.D{{"_id", ins.InsertedID}})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), del.DeletedCount)
+}

--- a/integration/tigris/delete_smoke_test.go
+++ b/integration/tigris/delete_smoke_test.go
@@ -46,10 +46,10 @@ func TestSmokeObjectIDBinary(t *testing.T) {
 
 	t.Logf("Inserted ID: %v", ins.InsertedID)
 
-	up, err := collection.UpdateOne(ctx, bson.D{{"_id", id}}, bson.D{{"$set", bson.D{{"string_value", "bar_2"}}}})
+	/*up, err := collection.UpdateOne(ctx, bson.D{{"_id", ins.InsertedID}}, bson.D{{"$set", bson.D{{"string_value", "bar_2"}}}})
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), up.MatchedCount)
-	assert.Equal(t, int64(1), up.ModifiedCount)
+	assert.Equal(t, int64(1), up.ModifiedCount)*/
 
 	del, err := collection.DeleteOne(ctx, bson.D{{"_id", ins.InsertedID}})
 	require.NoError(t, err)

--- a/internal/handlers/tigris/msg_delete.go
+++ b/internal/handlers/tigris/msg_delete.go
@@ -139,9 +139,11 @@ func (h *Handler) MsgDelete(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 // delete deletes documents by _id.
 func (h *Handler) delete(ctx context.Context, fp fetchParam, docs []*types.Document) (int, error) {
 	ids := make([]filter.Expr, len(docs))
+	var iddd []byte
 	for i, doc := range docs {
 		id := must.NotFail(doc.Get("_id")).(types.ObjectID)
 		ids[i] = filter.Eq("_id", tjson.ObjectID(id))
+		iddd = tjson.ObjectID(id)
 	}
 
 	var f driver.Filter
@@ -154,6 +156,8 @@ func (h *Handler) delete(ctx context.Context, fp fetchParam, docs []*types.Docum
 		f = must.NotFail(filter.Or(ids...).Build())
 	}
 	h.L.Sugar().Debugf("Filter: %s", f)
+
+	f = must.NotFail(filter.Eq("_id", iddd).Build())
 
 	_, err := h.driver.UseDatabase(fp.db).Delete(ctx, fp.collection, f)
 	if err != nil {

--- a/internal/handlers/tigris/msg_delete.go
+++ b/internal/handlers/tigris/msg_delete.go
@@ -155,7 +155,7 @@ func (h *Handler) delete(ctx context.Context, fp fetchParam, docs []*types.Docum
 	default:
 		f = must.NotFail(filter.Or(ids...).Build())
 	}
-	h.L.Sugar().Debugf("Filter: %s", f)
+	h.L.Sugar().Debugf("Delete filter: %s", f)
 
 	f = must.NotFail(filter.Eq("_id", iddd).Build())
 

--- a/internal/handlers/tigris/msg_update.go
+++ b/internal/handlers/tigris/msg_update.go
@@ -190,7 +190,7 @@ func (h *Handler) MsgUpdate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 func (h *Handler) update(ctx context.Context, sp fetchParam, doc *types.Document) (int, error) {
 	id := must.NotFail(doc.Get("_id")).(types.ObjectID)
 	f := must.NotFail(filter.Eq("_id", tjson.ObjectID(id)).Build())
-	h.L.Sugar().Debugf("Filter: %s", f)
+	h.L.Sugar().Debugf("Update filter: %s", f)
 
 	update := fields.UpdateBuilder()
 	for _, k := range doc.Keys() {


### PR DESCRIPTION
# Description

This is a draft PR to demonstrate an error with `delete`:
```
Code: Code_DEADLINE_EXCEEDED (4)
Message: invalid character '\x1f' in string literal
```

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added tests for new functionality or bugfixes.
* [ ] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [ ] (for maintainers only) I set Reviewers, Assignee, Labels, Project and project's Sprint fields.
* [ ] I marked all done items in this checklist.
