### PR TITLE
Add missing `MaxTimeMS` support for Tigris

### DIFF
--- a/integration/query_test.go
+++ b/integration/query_test.go
@@ -599,8 +599,6 @@ func TestQueryBadSortType(t *testing.T) {
 }
 
 func TestQueryBadMaxTimeMSType(t *testing.T) {
-	setup.SkipForTigris(t)
-
 	t.Parallel()
 	ctx, collection := setup.Setup(t)
 
@@ -706,18 +704,6 @@ func TestQueryBadMaxTimeMSType(t *testing.T) {
 				Code:    2,
 				Name:    "BadValue",
 				Message: "-1123123 value for maxTimeMS is out of range",
-			},
-		},
-
-		"BadMaxTimeMSTypeStringFindAndModify": {
-			command: bson.D{
-				{"findAndModify", collection.Name()},
-				{"maxTimeMS", "string"},
-			},
-			err: &mongo.CommandError{
-				Code:    2,
-				Name:    "BadValue",
-				Message: "maxTimeMS must be a number",
 			},
 		},
 	} {

--- a/internal/handlers/tigris/msg_find.go
+++ b/internal/handlers/tigris/msg_find.go
@@ -53,7 +53,6 @@ func (h *Handler) MsgFind(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, er
 		"hint",
 		"batchSize",
 		"singleBatch",
-		"maxTimeMS",
 		"readConcern",
 		"max",
 		"min",


### PR DESCRIPTION
# Description

This PR adds a couple of missing things left after #608:

- the `findAndModify` part of the tests was moved to the correct file
- `maxTimeMS` was removed from unsupported fields for Tigris (as it was implemented in #608)

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
