### PR TITLE
Bump Tigris version to 1.0.0-alpha.27

### DIFF
--- a/build/deps/tigris.Dockerfile
+++ b/build/deps/tigris.Dockerfile
@@ -1,1 +1,1 @@
-FROM tigrisdata/tigris-local:1.0.0-alpha.26
+FROM tigrisdata/tigris-local:1.0.0-alpha.27


### PR DESCRIPTION
# Description

Let's bump Tigris to 1.0.0-alpha.27 as it has some nice fixes about setting `null` when running update operations.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [x] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
