### PR TITLE
[1036] Use --always to fallback to abbreviated hash

### DIFF
--- a/internal/util/version/generate.go
+++ b/internal/util/version/generate.go
@@ -49,7 +49,7 @@ func main() {
 	go func() {
 		defer wg.Done()
 
-		b := runGit("describe", "--tags", "--dirty")
+		b := runGit("describe", "--tags", "--dirty", "--always")
 		must.NoError(os.WriteFile(filepath.Join("gen", "version.txt"), b, 0o644))
 	}()
 


### PR DESCRIPTION
closes: #1036 
Use --always with git describe to fallback to an abbreviated tag.

https://stackoverflow.com/questions/4916492/git-describe-fails-with-fatal-no-names-found-cannot-describe-anything

* [ ] I added tests for new functionality or bugfixes.
[* ] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [ ] I marked all done items in this checklist.
