### PR TITLE
Add a few more tests for logical query operators

### DIFF
--- a/integration/delete_compat_test.go
+++ b/integration/delete_compat_test.go
@@ -103,7 +103,7 @@ func testDeleteCompat(t *testing.T, testCases map[string]deleteCompatTestCase) {
 						compatErr = UnsetRaw(t, compatErr)
 						assert.Equal(t, compatErr, targetErr)
 					} else {
-						require.NoError(t, compatErr)
+						require.NoError(t, compatErr, "compat error")
 					}
 
 					if pointer.Get(targetRes).DeletedCount > 0 || pointer.Get(compatRes).DeletedCount > 0 {

--- a/integration/query_compat_test.go
+++ b/integration/query_compat_test.go
@@ -85,7 +85,7 @@ func testQueryCompat(t *testing.T, testCases map[string]queryCompatTestCase) {
 						assert.Equal(t, compatErr, targetErr)
 						return
 					}
-					require.NoError(t, compatErr)
+					require.NoError(t, compatErr, "compat error")
 
 					var targetRes, compatRes []bson.D
 					require.NoError(t, targetCursor.All(ctx, &targetRes))

--- a/integration/query_logical_compat_test.go
+++ b/integration/query_logical_compat_test.go
@@ -76,7 +76,7 @@ func TestQueryLogicalCompatAnd(t *testing.T) {
 			filter: bson.D{{
 				"$and", bson.A{
 					bson.D{{"v", bson.D{{"$gt", int32(0)}}}},
-					nil,
+					true,
 				},
 			}},
 			resultType: emptyResult,
@@ -130,8 +130,8 @@ func TestQueryLogicalCompatOr(t *testing.T) {
 		"BadValue": {
 			filter: bson.D{{
 				"$or", bson.A{
-					bson.D{{"v", bson.D{{"$gt", int32(0)}}}},
-					nil,
+					bson.D{{"v", bson.D{{"$lt", int32(0)}}}},
+					true,
 				},
 			}},
 			resultType: emptyResult,
@@ -174,8 +174,8 @@ func TestQueryLogicalCompatNor(t *testing.T) {
 		"BadValue": {
 			filter: bson.D{{
 				"$nor", bson.A{
-					bson.D{{"v", bson.D{{"$gt", int32(0)}}}},
-					nil,
+					bson.D{{"v", bson.D{{"$lt", int32(0)}}}},
+					true,
 				},
 			}},
 			resultType: emptyResult,

--- a/integration/query_logical_compat_test.go
+++ b/integration/query_logical_compat_test.go
@@ -25,7 +25,20 @@ func TestQueryLogicalCompatAnd(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]queryCompatTestCase{
-		"And": {
+		"Zero": {
+			filter: bson.D{{
+				"$and", bson.A{},
+			}},
+			skip: "https://github.com/FerretDB/FerretDB/issues/962",
+		},
+		"One": {
+			filter: bson.D{{
+				"$and", bson.A{
+					bson.D{{"v", bson.D{{"$gt", int32(0)}}}},
+				},
+			}},
+		},
+		"Two": {
 			filter: bson.D{{
 				"$and", bson.A{
 					bson.D{{"v", bson.D{{"$gt", int32(0)}}}},
@@ -78,7 +91,20 @@ func TestQueryLogicalCompatOr(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]queryCompatTestCase{
-		"Or": {
+		"Zero": {
+			filter: bson.D{{
+				"$or", bson.A{},
+			}},
+			skip: "https://github.com/FerretDB/FerretDB/issues/962",
+		},
+		"One": {
+			filter: bson.D{{
+				"$or", bson.A{
+					bson.D{{"v", bson.D{{"$lt", int32(0)}}}},
+				},
+			}},
+		},
+		"Two": {
 			filter: bson.D{{
 				"$or", bson.A{
 					bson.D{{"v", bson.D{{"$lt", int32(0)}}}},
@@ -120,7 +146,20 @@ func TestQueryLogicalCompatNor(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]queryCompatTestCase{
-		"Nor": {
+		"Zero": {
+			filter: bson.D{{
+				"$nor", bson.A{},
+			}},
+			skip: "https://github.com/FerretDB/FerretDB/issues/962",
+		},
+		"One": {
+			filter: bson.D{{
+				"$nor", bson.A{
+					bson.D{{"v", bson.D{{"$lt", int32(0)}}}},
+				},
+			}},
+		},
+		"Two": {
 			filter: bson.D{{
 				"$nor", bson.A{
 					bson.D{{"v", bson.D{{"$lt", int32(0)}}}},

--- a/integration/update_compat_test.go
+++ b/integration/update_compat_test.go
@@ -81,7 +81,7 @@ func testUpdateCompat(t *testing.T, testCases map[string]updateCompatTestCase) {
 								compatErr = UnsetRaw(t, compatErr)
 								assert.Equal(t, compatErr, targetErr)
 							} else {
-								require.NoError(t, compatErr)
+								require.NoError(t, compatErr, "compat error")
 							}
 
 							assert.Equal(t, compatUpdateRes, targetUpdateRes)


### PR DESCRIPTION
## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [x] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
