### PR TITLE
Fix `ModifiedCount` for updates with an empty replacement document

### DIFF
--- a/integration/update_compat_test.go
+++ b/integration/update_compat_test.go
@@ -49,7 +49,6 @@ func TestUpdateCompat(t *testing.T) {
 		},
 		"ReplaceEmptyDocument": {
 			replace: bson.D{},
-			skip:    "https://github.com/FerretDB/FerretDB/issues/1045",
 		},
 	}
 

--- a/internal/handlers/common/update.go
+++ b/internal/handlers/common/update.go
@@ -32,6 +32,18 @@ import (
 func UpdateDocument(doc, update *types.Document) (bool, error) {
 	var changed bool
 	var err error
+
+	if update.Len() == 0 {
+		// replace to empty doc
+		for _, setKey := range doc.Keys() {
+			if setKey != "_id" {
+				changed = true
+				doc.Remove(setKey)
+			}
+		}
+		return changed, nil
+	}
+
 	for _, updateOp := range update.Keys() {
 		updateV := must.NotFail(update.Get(updateOp))
 

--- a/internal/handlers/common/update.go
+++ b/internal/handlers/common/update.go
@@ -35,12 +35,14 @@ func UpdateDocument(doc, update *types.Document) (bool, error) {
 
 	if update.Len() == 0 {
 		// replace to empty doc
-		for _, setKey := range doc.Keys() {
-			if setKey != "_id" {
+		for _, key := range doc.Keys() {
+			if key != "_id" {
 				changed = true
-				doc.Remove(setKey)
+
+				doc.Remove(key)
 			}
 		}
+
 		return changed, nil
 	}
 


### PR DESCRIPTION
# Improvements in the empty replacement

This PR closes #1045.

Basically I'am removing all keys `(!= _id)` when receiving an empty update object.

## Readiness checklist

* [x] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [x] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [x] I checked comments rendering with `task godocs`.
* [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
