### PR TITLE
Fix data race in test

### DIFF
--- a/integration/update_field_test.go
+++ b/integration/update_field_test.go
@@ -940,12 +940,6 @@ func TestUpdateFieldSetOnInsert(t *testing.T) {
 
 	t.Parallel()
 
-	stat := &mongo.UpdateResult{
-		MatchedCount:  0,
-		ModifiedCount: 0,
-		UpsertedCount: 1,
-	}
-
 	for name, tc := range map[string]struct {
 		id           string
 		update       bson.D
@@ -956,25 +950,37 @@ func TestUpdateFieldSetOnInsert(t *testing.T) {
 		upserted     bool
 	}{
 		"Array": {
-			id:           "array-set-on-insert",
-			update:       bson.D{{"$setOnInsert", bson.D{{"v", bson.A{}}}}},
-			expected:     bson.D{{"_id", "array-set-on-insert"}, {"v", bson.A{}}},
-			expectedStat: stat,
-			upserted:     true,
+			id:       "array-set-on-insert",
+			update:   bson.D{{"$setOnInsert", bson.D{{"v", bson.A{}}}}},
+			expected: bson.D{{"_id", "array-set-on-insert"}, {"v", bson.A{}}},
+			expectedStat: &mongo.UpdateResult{
+				MatchedCount:  0,
+				ModifiedCount: 0,
+				UpsertedCount: 1,
+			},
+			upserted: true,
 		},
 		"Nil": {
-			id:           "nil",
-			update:       bson.D{{"$setOnInsert", bson.D{{"v", nil}}}},
-			expected:     bson.D{{"_id", "nil"}, {"v", nil}},
-			expectedStat: stat,
-			upserted:     true,
+			id:       "nil",
+			update:   bson.D{{"$setOnInsert", bson.D{{"v", nil}}}},
+			expected: bson.D{{"_id", "nil"}, {"v", nil}},
+			expectedStat: &mongo.UpdateResult{
+				MatchedCount:  0,
+				ModifiedCount: 0,
+				UpsertedCount: 1,
+			},
+			upserted: true,
 		},
 		"EmptyDoc": {
-			id:           "doc",
-			update:       bson.D{{"$setOnInsert", bson.D{}}},
-			expected:     bson.D{{"_id", "doc"}},
-			expectedStat: stat,
-			upserted:     true,
+			id:       "doc",
+			update:   bson.D{{"$setOnInsert", bson.D{}}},
+			expected: bson.D{{"_id", "doc"}},
+			expectedStat: &mongo.UpdateResult{
+				MatchedCount:  0,
+				ModifiedCount: 0,
+				UpsertedCount: 1,
+			},
+			upserted: true,
 		},
 		"EmptyArray": {
 			id:     "array",


### PR DESCRIPTION
# Description

A part of parallel test cases was shared and modified by them.
Noticed at https://github.com/FerretDB/FerretDB/runs/7993947283?check_suite_focus=true.

## Readiness checklist

* [x] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
