### PR TITLE
Use `CODECOV_TOKEN` if available

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -90,9 +90,12 @@ jobs:
       - name: Run unit tests
         run: bin/task test-unit
 
+      # The token is not required but should make uploads more stable.
+      # If secrets are unavailable (for example, for a pull request from a fork), it fallbacks to the tokenless uploads.
       - name: Upload coverage information
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./cover.txt
           flags: unit
           fail_ci_if_error: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -65,9 +65,12 @@ jobs:
       - name: Run ${{ matrix.handler }} tests
         run: bin/task test-integration-${{ matrix.handler }}
 
+      # The token is not required but should make uploads more stable.
+      # If secrets are unavailable (for example, for a pull request from a fork), it fallbacks to the tokenless uploads.
       - name: Upload coverage information
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./integration/integration-${{ matrix.handler }}.txt
           flags: integration,${{ matrix.handler }}
           fail_ci_if_error: true


### PR DESCRIPTION
# Description

That should make codecov uploads more stable.

## Readiness checklist

* [ ] I added tests for new functionality or bugfixes.
* [ ] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
