### PR TITLE
Simplify/sync `delete` a bit

### DIFF
--- a/integration/delete_compat_test.go
+++ b/integration/delete_compat_test.go
@@ -43,7 +43,39 @@ func TestDeleteCompat(t *testing.T) {
 			filters:    []bson.D{},
 			resultType: emptyResult,
 		},
-		"OrderedTrue": {
+
+		"One": {
+			filters: []bson.D{
+				{{"v", int32(42)}},
+			},
+		},
+		"All": {
+			filters: []bson.D{
+				{},
+			},
+		},
+
+		"Two": {
+			filters: []bson.D{
+				{{"v", int32(42)}},
+				{{"v", int32(0)}},
+			},
+		},
+		"TwoAll": {
+			filters: []bson.D{
+				{{"v", int32(42)}},
+				{},
+			},
+		},
+		"TwoAllOrdered": {
+			filters: []bson.D{
+				{{"v", "foo"}},
+				{},
+			},
+			ordered: true,
+		},
+
+		"OrderedError": {
 			filters: []bson.D{
 				{{"v", "foo"}},
 				{{"v", bson.D{{"$all", 9}}}},
@@ -51,22 +83,15 @@ func TestDeleteCompat(t *testing.T) {
 			},
 			ordered: true,
 		},
-		"OrderedFalse": {
+		"UnorderedError": {
 			filters: []bson.D{
 				{{"v", "foo"}},
 				{{"v", bson.D{{"$all", 9}}}},
 				{{"v", float32(42.13)}},
 			},
-			ordered: false,
 		},
-		"OrderedTrueNoError": {
-			filters: []bson.D{
-				{{"v", "foo"}},
-				{{"v", float32(42.13)}},
-			},
-			ordered: true,
-		},
-		"OrderedTrueTwoErrors": {
+
+		"OrderedTwoErrors": {
 			filters: []bson.D{
 				{{"v", "foo"}},
 				{{"v", bson.D{{"$all", 9}}}},
@@ -75,16 +100,16 @@ func TestDeleteCompat(t *testing.T) {
 			},
 			ordered: true,
 		},
-		"OrderedFalseTwoErrors": {
+		"UnorderedTwoErrors": {
 			filters: []bson.D{
 				{{"v", "foo"}},
 				{{"v", bson.D{{"$all", 9}}}},
 				{{"v", float32(42.13)}},
 				{{"v", bson.D{{"$eq", 9}}}},
 			},
-			ordered: false,
 		},
-		"OrderedTrueAllErrors": {
+
+		"OrderedAllErrors": {
 			filters: []bson.D{
 				{{"v", bson.D{{"$all", 9}}}},
 				{{"v", bson.D{{"$eq", 9}}}},
@@ -93,25 +118,13 @@ func TestDeleteCompat(t *testing.T) {
 			ordered:    true,
 			resultType: emptyResult,
 		},
-		"OrderedFalseAllErrors": {
+		"UnorderedAllErrors": {
 			filters: []bson.D{
 				{{"v", bson.D{{"$all", 9}}}},
 				{{"v", bson.D{{"$eq", 9}}}},
 				{{"v", bson.D{{"$all", 9}}}},
 			},
-			ordered:    false,
 			resultType: emptyResult,
-		},
-		"One": {
-			filters: []bson.D{
-				{{"v", int32(42)}},
-			},
-		},
-		"Two": {
-			filters: []bson.D{
-				{{"v", int32(42)}},
-				{{"v", int32(0)}},
-			},
 		},
 	}
 

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -246,6 +246,8 @@ func AssertEqualAltWriteError(t *testing.T, expected mongo.WriteError, altMessag
 }
 
 // UnsetRaw returns error with all Raw fields unset. It returns nil if err is nil.
+//
+// Error is checked using a regular type assertion; wrapped errors (errors.As) are not checked.
 func UnsetRaw(t testing.TB, err error) error {
 	t.Helper()
 

--- a/internal/handlers/common/error.go
+++ b/internal/handlers/common/error.go
@@ -121,7 +121,7 @@ func ProtocolError(err error) (ProtoErr, bool) {
 		panic("err is nil")
 	}
 
-	var e *Error
+	var e *CommandError
 	if errors.As(err, &e) {
 		return e, true
 	}
@@ -131,14 +131,11 @@ func ProtocolError(err error) (ProtoErr, bool) {
 		return writeErr, true
 	}
 
-	return NewError(errInternalError, err).(*Error), false
+	return NewError(errInternalError, err).(*CommandError), false
 }
 
 // CommandError represents wire protocol command error.
-type CommandError = Error
-
-// Error is a deprecated name for CommandError; instead, use the later version in the new code.
-type Error struct {
+type CommandError struct {
 	err  error
 	code ErrorCode
 }
@@ -153,7 +150,7 @@ func NewError(code ErrorCode, err error) error {
 	if err == nil {
 		panic("err is nil")
 	}
-	return &Error{
+	return &CommandError{
 		code: code,
 		err:  err,
 	}
@@ -167,22 +164,22 @@ func NewErrorMsg(code ErrorCode, msg string) error {
 }
 
 // Error implements error interface.
-func (e *Error) Error() string {
+func (e *CommandError) Error() string {
 	return fmt.Sprintf("%[1]s (%[1]d): %[2]v", e.code, e.err)
 }
 
 // Code implements ProtoErr interface.
-func (e *Error) Code() ErrorCode {
+func (e *CommandError) Code() ErrorCode {
 	return e.code
 }
 
 // Unwrap implements standard error unwrapping interface.
-func (e *Error) Unwrap() error {
+func (e *CommandError) Unwrap() error {
 	return e.err
 }
 
 // Document returns wire protocol error document.
-func (e *Error) Document() *types.Document {
+func (e *CommandError) Document() *types.Document {
 	d := must.NotFail(types.NewDocument(
 		"ok", float64(0),
 		"errmsg", e.err.Error(),
@@ -331,6 +328,6 @@ func formatBitwiseOperatorErr(err error, operator string, maskValue any) error {
 
 // check interfaces
 var (
-	_ ProtoErr = (*Error)(nil)
+	_ ProtoErr = (*CommandError)(nil)
 	_ ProtoErr = (*WriteErrors)(nil)
 )

--- a/internal/handlers/common/error.go
+++ b/internal/handlers/common/error.go
@@ -150,6 +150,7 @@ func NewError(code ErrorCode, err error) error {
 	if err == nil {
 		panic("err is nil")
 	}
+
 	return &CommandError{
 		code: code,
 		err:  err,

--- a/internal/handlers/pg/msg_delete.go
+++ b/internal/handlers/pg/msg_delete.go
@@ -165,9 +165,7 @@ func (h *Handler) MsgDelete(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 		})
 	}
 
-	delErrors := new(common.WriteErrors)
-
-	var reply wire.OpMsg
+	var delErrors common.WriteErrors
 
 	// process every delete filter
 	for i := 0; i < deletes.Len(); i++ {
@@ -199,19 +197,17 @@ func (h *Handler) MsgDelete(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 		break
 	}
 
-	var replyDoc *types.Document
+	replyDoc := must.NotFail(types.NewDocument(
+		"ok", float64(1),
+	))
 
-	// if there are delete errors append writeErrors field
-	if len(*delErrors) > 0 {
+	if len(delErrors) > 0 {
 		replyDoc = delErrors.Document()
-	} else {
-		replyDoc = must.NotFail(types.NewDocument(
-			"ok", float64(1),
-		))
 	}
 
 	must.NoError(replyDoc.Set("n", deleted))
 
+	var reply wire.OpMsg
 	err = reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{replyDoc},
 	})

--- a/internal/handlers/pg/msg_delete.go
+++ b/internal/handlers/pg/msg_delete.go
@@ -112,7 +112,7 @@ func (h *Handler) MsgDelete(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 		}
 
 		resDocs := make([]*types.Document, 0, 16)
-		err = h.pgPool.InTransaction(ctx, func(tx pgx.Tx) error {
+		return h.pgPool.InTransaction(ctx, func(tx pgx.Tx) error {
 			// fetch current items from collection
 			fetchedChan, err := h.pgPool.QueryDocuments(ctx, tx, sp)
 			if err != nil {
@@ -163,8 +163,6 @@ func (h *Handler) MsgDelete(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 
 			return nil
 		})
-
-		return err
 	}
 
 	delErrors := new(common.WriteErrors)

--- a/internal/handlers/pg/msg_delete.go
+++ b/internal/handlers/pg/msg_delete.go
@@ -174,30 +174,31 @@ func (h *Handler) MsgDelete(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 	// process every delete filter
 	for i := 0; i < deletes.Len(); i++ {
 		err := processQuery(i)
-		if err != nil {
-			switch err.(type) {
+		switch err.(type) {
+		case nil:
+			continue
+
+		case *common.CommandError:
 			// command errors should be return immediately
-			case *common.CommandError:
-				return nil, err
+			return nil, err
 
+		default:
 			// write errors and others require to be handled in array
-			default:
-				delErrors.Append(err, int32(i))
+			delErrors.Append(err, int32(i))
 
-				// Delete statements in the `deletes` field are not transactional.
-				// It means that we run each delete statement separately.
-				// If `ordered` is set as `true`, we don't execute the remaining statements
-				// after the first failure.
-				// If `ordered` is set as `false`,  we execute all the statements and return
-				// the list of errors corresponding to the failed statements.
-				if !ordered {
-					continue
-				}
+			// Delete statements in the `deletes` field are not transactional.
+			// It means that we run each delete statement separately.
+			// If `ordered` is set as `true`, we don't execute the remaining statements
+			// after the first failure.
+			// If `ordered` is set as `false`, we execute all the statements and return
+			// the list of errors corresponding to the failed statements.
+			if !ordered {
+				continue
 			}
-
-			// send response if ordered is true
-			break
 		}
+
+		// send response if ordered is true
+		break
 	}
 
 	var replyDoc *types.Document

--- a/internal/handlers/pg/msg_delete.go
+++ b/internal/handlers/pg/msg_delete.go
@@ -112,6 +112,7 @@ func (h *Handler) MsgDelete(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 		}
 
 		resDocs := make([]*types.Document, 0, 16)
+
 		return h.pgPool.InTransaction(ctx, func(tx pgx.Tx) error {
 			// fetch current items from collection
 			fetchedChan, err := h.pgPool.QueryDocuments(ctx, tx, sp)

--- a/internal/handlers/tigris/msg_create.go
+++ b/internal/handlers/tigris/msg_create.go
@@ -81,19 +81,17 @@ func (h *Handler) MsgCreate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 	b := must.NotFail(json.Marshal(schema))
 
 	created, err := h.db.CreateCollectionIfNotExist(ctx, db, collection, b)
-	if err != nil {
-		switch err := err.(type) {
-		case nil:
-			// do nothing
-		case *driver.Error:
-			if tigrisdb.IsInvalidArgument(err) {
-				return nil, common.NewError(common.ErrBadValue, err)
-			}
-
-			return nil, lazyerrors.Error(err)
-		default:
-			return nil, lazyerrors.Error(err)
+	switch err := err.(type) {
+	case nil:
+		// do nothing
+	case *driver.Error:
+		if tigrisdb.IsInvalidArgument(err) {
+			return nil, common.NewError(common.ErrBadValue, err)
 		}
+
+		return nil, lazyerrors.Error(err)
+	default:
+		return nil, lazyerrors.Error(err)
 	}
 
 	if !created {

--- a/internal/handlers/tigris/msg_delete.go
+++ b/internal/handlers/tigris/msg_delete.go
@@ -37,11 +37,9 @@ func (h *Handler) MsgDelete(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 		return nil, lazyerrors.Error(err)
 	}
 
-	common.Ignored(document, h.L, "comment") // TODO https://github.com/FerretDB/FerretDB/issues/849
 	if err := common.Unimplemented(document, "let"); err != nil {
 		return nil, err
 	}
-	common.Ignored(document, h.L, "ordered") // TODO https://github.com/FerretDB/FerretDB/issues/848
 	common.Ignored(document, h.L, "writeConcern")
 
 	var deletes *types.Array
@@ -104,6 +102,10 @@ func (h *Handler) MsgDelete(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 				fmt.Sprintf("collection name has invalid type %s", common.AliasFromType(collectionParam)),
 			)
 		}
+
+		common.Ignored(document, h.L, "comment")
+
+		common.Ignored(filter, h.L, "$comment")
 
 		resDocs := make([]*types.Document, 0, 16)
 

--- a/internal/handlers/tigris/msg_delete.go
+++ b/internal/handlers/tigris/msg_delete.go
@@ -157,30 +157,31 @@ func (h *Handler) MsgDelete(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 	// process every delete filter
 	for i := 0; i < deletes.Len(); i++ {
 		err := processQuery(i)
-		if err != nil {
-			switch err.(type) {
+		switch err.(type) {
+		case nil:
+			continue
+
+		case *common.CommandError:
 			// command errors should be return immediately
-			case *common.CommandError:
-				return nil, err
+			return nil, err
 
+		default:
 			// write errors and others require to be handled in array
-			default:
-				delErrors.Append(err, int32(i))
+			delErrors.Append(err, int32(i))
 
-				// Delete statements in the `deletes` field are not transactional.
-				// It means that we run each delete statement separately.
-				// If `ordered` is set as `true`, we don't execute the remaining statements
-				// after the first failure.
-				// If `ordered` is set as `false`,  we execute all the statements and return
-				// the list of errors corresponding to the failed statements.
-				if !ordered {
-					continue
-				}
+			// Delete statements in the `deletes` field are not transactional.
+			// It means that we run each delete statement separately.
+			// If `ordered` is set as `true`, we don't execute the remaining statements
+			// after the first failure.
+			// If `ordered` is set as `false`, we execute all the statements and return
+			// the list of errors corresponding to the failed statements.
+			if !ordered {
+				continue
 			}
-
-			// send response if ordered is true
-			break
 		}
+
+		// send response if ordered is true
+		break
 	}
 
 	var replyDoc *types.Document

--- a/internal/handlers/tigris/msg_delete.go
+++ b/internal/handlers/tigris/msg_delete.go
@@ -106,6 +106,7 @@ func (h *Handler) MsgDelete(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 		}
 
 		resDocs := make([]*types.Document, 0, 16)
+
 		return respondWithStack(func() error {
 			// fetch current items from collection
 			fetchedDocs, err := h.db.QueryDocuments(ctx, fp)


### PR DESCRIPTION
## Readiness checklist

* [x] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [x] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
