### PR TITLE
fix: `docker-compose`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,10 @@ services:
     container_name: ferretdb_debian
     volumes:
       - ./build/deb:/deb
+    depends_on: 
+      - mongodb
+      - postgres
+      - tigris
   centos:
     build:
       context: ./build/deps
@@ -59,6 +63,10 @@ services:
     container_name: ferretdb_centos
     volumes:
       - ./build/rpm:/rpm
+    depends_on: 
+      - mongodb
+      - postgres
+      - tigris
 
   # for documentation
   markdownlint:


### PR DESCRIPTION
# Description

Let **docker-compose** wait for database services to start using `depends_on` keywords.