### PR TITLE
Make embedded FerretDB's address configurable

### DIFF
--- a/ferretdb/ferretdb.go
+++ b/ferretdb/ferretdb.go
@@ -31,6 +31,9 @@ import (
 
 // Config represents FerretDB configuration.
 type Config struct {
+	// Listen address; defaults to "127.0.0.1:27017".
+	ListenAddr string
+
 	// Handler to use; one of `pg` or `tigris` (if enabled at compile-time).
 	Handler string
 
@@ -54,12 +57,15 @@ type FerretDB struct {
 
 // New creates a new instance of embeddable FerretDB implementation.
 func New(config *Config) (*FerretDB, error) {
-	f := &FerretDB{
-		config:     config,
-		listenAddr: "127.0.0.1:27017",
+	listenAddr := config.ListenAddr
+	if listenAddr == "" {
+		listenAddr = "127.0.0.1:27017"
 	}
 
-	return f, nil
+	return &FerretDB{
+		config:     config,
+		listenAddr: listenAddr,
+	}, nil
 }
 
 // Run runs FerretDB until ctx is done.

--- a/ferretdb/ferretdb_test.go
+++ b/ferretdb/ferretdb_test.go
@@ -22,6 +22,7 @@ import (
 
 func Example() {
 	f, err := New(&Config{
+		ListenAddr:    "127.0.0.1:17027",
 		Handler:       "pg",
 		PostgreSQLURL: "postgres://postgres@127.0.0.1:5432/ferretdb",
 	})
@@ -42,5 +43,5 @@ func Example() {
 	//
 	// mongo.Connect(ctx, options.Client().ApplyURI(uri)
 
-	// Output: mongodb://127.0.0.1:27017/
+	// Output: mongodb://127.0.0.1:17027/
 }

--- a/integration/embedded_test.go
+++ b/integration/embedded_test.go
@@ -36,7 +36,7 @@ func TestEmbedded(t *testing.T) {
 	t.Parallel()
 
 	f, err := ferretdb.New(&ferretdb.Config{
-		ListenAddr:    "127.0.0.1:0",
+		ListenAddr:    "127.0.0.1:65432",
 		Handler:       "pg",
 		PostgreSQLURL: testutil.PostgreSQLURL(t, nil),
 	})

--- a/integration/embedded_test.go
+++ b/integration/embedded_test.go
@@ -36,6 +36,7 @@ func TestEmbedded(t *testing.T) {
 	t.Parallel()
 
 	f, err := ferretdb.New(&ferretdb.Config{
+		ListenAddr:    "127.0.0.1:0",
 		Handler:       "pg",
 		PostgreSQLURL: testutil.PostgreSQLURL(t, nil),
 	})


### PR DESCRIPTION
# Description

That also fixes ports conflicts when tests are run in parallel.

## Readiness checklist

* [x] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [x] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [x] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
