### PR TITLE
Use single transaction per `msg_update` request

### DIFF
--- a/internal/handlers/pg/msg_findandmodify.go
+++ b/internal/handlers/pg/msg_findandmodify.go
@@ -160,7 +160,10 @@ func (h *Handler) MsgFindAndModify(ctx context.Context, msg *wire.OpMsg) (*wire.
 					return nil, err
 				}
 
-				_, err = h.update(ctx, &sqlParam, upsert)
+				err = h.pgPool.InTransaction(ctx, func(tx pgx.Tx) error {
+					_, err = h.update(ctx, tx, &sqlParam, upsert)
+					return err
+				})
 				if err != nil {
 					return nil, err
 				}
@@ -171,7 +174,10 @@ func (h *Handler) MsgFindAndModify(ctx context.Context, msg *wire.OpMsg) (*wire.
 					must.NoError(upsert.Set("_id", must.NotFail(resDocs[0].Get("_id"))))
 				}
 
-				_, err = h.update(ctx, &sqlParam, upsert)
+				err = h.pgPool.InTransaction(ctx, func(tx pgx.Tx) error {
+					_, err = h.update(ctx, tx, &sqlParam, upsert)
+					return err
+				})
 				if err != nil {
 					return nil, err
 				}
@@ -289,7 +295,10 @@ func (h *Handler) upsert(ctx context.Context, docs []*types.Document, params *up
 		}
 	}
 
-	_, err := h.update(ctx, params.sqlParam, upsert)
+	err := h.pgPool.InTransaction(ctx, func(tx pgx.Tx) error {
+		_, err := h.update(ctx, tx, params.sqlParam, upsert)
+		return err
+	})
 	if err != nil {
 		return nil, false, err
 	}

--- a/internal/handlers/pg/msg_update.go
+++ b/internal/handlers/pg/msg_update.go
@@ -244,18 +244,7 @@ func (h *Handler) MsgUpdate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 }
 
 // update updates documents by _id.
-func (h *Handler) update(ctx context.Context, sp *pgdb.SQLParam, doc *types.Document) (int64, error) {
+func (h *Handler) update(ctx context.Context, tx pgx.Tx, sp *pgdb.SQLParam, doc *types.Document) (int64, error) {
 	id := must.NotFail(doc.Get("_id"))
-
-	var rowsUpdated int64
-	err := h.pgPool.InTransaction(ctx, func(tx pgx.Tx) error {
-		var err error
-		rowsUpdated, err = pgdb.SetDocumentByID(ctx, tx, sp, id, doc)
-		return err
-	})
-	if err != nil {
-		return 0, err
-	}
-
-	return rowsUpdated, nil
+	return pgdb.SetDocumentByID(ctx, tx, sp, id, doc)
 }


### PR DESCRIPTION
# Description

This PR refs #1203.

This PR didn't fix the tests, but I consider it an improvement, so please review.
Next step (after this PR is merged): the exact change for `h.insert`. 

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
