### PR TITLE
Use single transaction per `msg_findandmodify` request 

### DIFF
--- a/integration/findandmodify_compat_test.go
+++ b/integration/findandmodify_compat_test.go
@@ -122,25 +122,6 @@ func TestFindAndModifyCompatErrors(t *testing.T) {
 	testFindAndModifyCompat(t, testCases)
 }
 
-func TestFindAndModifyCompatNonExistingCollection(t *testing.T) {
-	t.Parallel()
-
-	ctx, targetCollections, compatCollections := setup.SetupCompat(t)
-
-	var targetRes, compatRes bson.D
-	var targetErr, compatErr error
-
-	targetErr = targetCollections[0].Database().Collection("doesnotexist").FindOneAndUpdate(
-		ctx, bson.D{}, bson.D{{"$set", bson.E{"foo", "bar"}}},
-	).Decode(&targetRes)
-	compatErr = compatCollections[0].Database().Collection("doesnotexist").FindOneAndUpdate(
-		ctx, bson.D{}, bson.D{{"$set", bson.E{"foo", "bar"}}},
-	).Decode(&compatRes)
-
-	require.Equal(t, targetErr, compatErr)
-	require.Equal(t, targetRes, compatRes)
-}
-
 func TestFindAndModifyCompatUpdate(t *testing.T) {
 	testCases := map[string]findAndModifyCompatTestCase{
 		"Replace": {

--- a/integration/findandmodify_test.go
+++ b/integration/findandmodify_test.go
@@ -196,3 +196,15 @@ func TestFindAndModifyUpsertComplex(t *testing.T) {
 		})
 	}
 }
+
+func TestFindAndModifyNonExistingCollection(t *testing.T) {
+	t.Parallel()
+
+	ctx, collection := setup.Setup(t)
+
+	err := collection.FindOneAndUpdate(
+		ctx, bson.D{}, bson.D{{"$set", bson.E{"foo", "bar"}}},
+	).Err()
+
+	require.Equal(t, mongo.ErrNoDocuments, err)
+}

--- a/integration/findandmodify_test.go
+++ b/integration/findandmodify_test.go
@@ -202,9 +202,11 @@ func TestFindAndModifyNonExistingCollection(t *testing.T) {
 
 	ctx, collection := setup.Setup(t)
 
+	var actual bson.D
 	err := collection.FindOneAndUpdate(
 		ctx, bson.D{}, bson.D{{"$set", bson.E{"foo", "bar"}}},
-	).Err()
+	).Decode(&actual)
 
-	require.Equal(t, mongo.ErrNoDocuments, err)
+	assert.Equal(t, mongo.ErrNoDocuments, err)
+	assert.Nil(t, actual)
 }

--- a/internal/clientconn/conn.go
+++ b/internal/clientconn/conn.go
@@ -131,11 +131,11 @@ func (c *conn) run(ctx context.Context) (err error) {
 	}()
 
 	defer func() {
-		if p := recover(); p != nil {
+		/*if p := recover(); p != nil {
 			// Log human-readable stack trace there (included in the error level automatically).
 			c.l.DPanicf("%v\n(err = %v)", p, err)
 			err = errors.New("panic")
-		}
+		}*/
 
 		if err == nil {
 			err = ctx.Err()
@@ -452,9 +452,8 @@ func (c *conn) logResponse(who string, resHeader *wire.MsgHeader, resBody wire.M
 	if resHeader.OpCode == wire.OpCodeMsg {
 		doc := must.NotFail(resBody.(*wire.OpMsg).Document())
 
-		ok := must.NotFail(doc.Get("ok"))
-
-		if ok.(float64) != 1 {
+		ok, _ := doc.Get("ok")
+		if f, _ := ok.(float64); f != 1 {
 			if closeConn {
 				level = zap.ErrorLevel
 			} else {

--- a/internal/handlers/pg/msg_findandmodify.go
+++ b/internal/handlers/pg/msg_findandmodify.go
@@ -72,8 +72,10 @@ func (h *Handler) MsgFindAndModify(ctx context.Context, msg *wire.OpMsg) (*wire.
 
 	// This is not very optimal as we need to fetch everything from the database to have a proper sort.
 	// We might consider rewriting it later.
-	resDocs := make([]*types.Document, 0, 16)
+	var reply wire.OpMsg
 	err = h.pgPool.InTransaction(ctx, func(tx pgx.Tx) error {
+		resDocs := make([]*types.Document, 0, 16)
+
 		fetchedChan, err := h.pgPool.QueryDocuments(ctx, tx, &sqlParam)
 		if err != nil {
 			return err
@@ -112,136 +114,129 @@ func (h *Handler) MsgFindAndModify(ctx context.Context, msg *wire.OpMsg) (*wire.
 			resDocs = append(resDocs, doc)
 		}
 
-		return nil
+		// findAndModify always works with a single document
+		if resDocs, err = common.LimitDocuments(resDocs, 1); err != nil {
+			return err
+		}
+
+		if params.Update != nil { // we have update part
+			var upsert *types.Document
+			var upserted bool
+
+			if params.Upsert { //  we have upsert flag
+				p := &upsertParams{
+					hasUpdateOperators: params.HasUpdateOperators,
+					query:              params.Query,
+					update:             params.Update,
+					sqlParam:           &sqlParam,
+				}
+				upsert, upserted, err = h.upsert(ctx, resDocs, p)
+				if err != nil {
+					return err
+				}
+			} else { // process update as usual
+				if len(resDocs) == 0 {
+					must.NoError(reply.SetSections(wire.OpMsgSection{
+						Documents: []*types.Document{must.NotFail(types.NewDocument(
+							"lastErrorObject", must.NotFail(types.NewDocument("n", int32(0), "updatedExisting", false)),
+							"value", types.Null,
+							"ok", float64(1),
+						))},
+					}))
+
+					return nil
+				}
+
+				if params.HasUpdateOperators {
+					upsert = resDocs[0].DeepCopy()
+					_, err = common.UpdateDocument(upsert, params.Update)
+					if err != nil {
+						return err
+					}
+
+					_, err = h.update(ctx, tx, &sqlParam, upsert)
+
+					if err != nil {
+						return err
+					}
+				} else {
+					upsert = params.Update
+
+					if !upsert.Has("_id") {
+						must.NoError(upsert.Set("_id", must.NotFail(resDocs[0].Get("_id"))))
+					}
+
+					_, err = h.update(ctx, tx, &sqlParam, upsert)
+
+					if err != nil {
+						return err
+					}
+				}
+
+			}
+
+			var resultDoc *types.Document
+			if params.ReturnNewDocument || len(resDocs) == 0 {
+				resultDoc = upsert
+			} else {
+				resultDoc = resDocs[0]
+			}
+
+			lastErrorObject := must.NotFail(types.NewDocument(
+				"n", int32(1),
+				"updatedExisting", len(resDocs) > 0,
+			))
+
+			if upserted {
+				must.NoError(lastErrorObject.Set("upserted", must.NotFail(resultDoc.Get("_id"))))
+			}
+
+			must.NoError(reply.SetSections(wire.OpMsgSection{
+				Documents: []*types.Document{must.NotFail(types.NewDocument(
+					"lastErrorObject", lastErrorObject,
+					"value", resultDoc,
+					"ok", float64(1),
+				))},
+			}))
+
+			return nil
+		}
+
+		if params.Remove {
+			if len(resDocs) == 0 {
+				must.NoError(reply.SetSections(wire.OpMsgSection{
+					Documents: []*types.Document{must.NotFail(types.NewDocument(
+						"lastErrorObject", must.NotFail(types.NewDocument("n", int32(0))),
+						"ok", float64(1),
+					))},
+				}))
+
+				return nil
+			}
+
+			_, err = h.delete(ctx, &sqlParam, resDocs)
+			if err != nil {
+				return err
+			}
+
+			must.NoError(reply.SetSections(wire.OpMsgSection{
+				Documents: []*types.Document{must.NotFail(types.NewDocument(
+					"lastErrorObject", must.NotFail(types.NewDocument("n", int32(1))),
+					"value", resDocs[0],
+					"ok", float64(1),
+				))},
+			}))
+			return nil
+		}
+
+		return lazyerrors.New("bad flags combination")
 	})
 
 	if err != nil {
 		return nil, err
 	}
 
-	// findAndModify always works with a single document
-	if resDocs, err = common.LimitDocuments(resDocs, 1); err != nil {
-		return nil, err
-	}
-
-	if params.Update != nil { // we have update part
-		var upsert *types.Document
-		var upserted bool
-
-		if params.Upsert { //  we have upsert flag
-			p := &upsertParams{
-				hasUpdateOperators: params.HasUpdateOperators,
-				query:              params.Query,
-				update:             params.Update,
-				sqlParam:           &sqlParam,
-			}
-			upsert, upserted, err = h.upsert(ctx, resDocs, p)
-			if err != nil {
-				return nil, err
-			}
-		} else { // process update as usual
-			if len(resDocs) == 0 {
-				var reply wire.OpMsg
-				must.NoError(reply.SetSections(wire.OpMsgSection{
-					Documents: []*types.Document{must.NotFail(types.NewDocument(
-						"lastErrorObject", must.NotFail(types.NewDocument("n", int32(0), "updatedExisting", false)),
-						"value", types.Null,
-						"ok", float64(1),
-					))},
-				}))
-
-				return &reply, nil
-			}
-
-			if params.HasUpdateOperators {
-				upsert = resDocs[0].DeepCopy()
-				_, err = common.UpdateDocument(upsert, params.Update)
-				if err != nil {
-					return nil, err
-				}
-
-				err = h.pgPool.InTransaction(ctx, func(tx pgx.Tx) error {
-					_, err = h.update(ctx, tx, &sqlParam, upsert)
-					return err
-				})
-				if err != nil {
-					return nil, err
-				}
-			} else {
-				upsert = params.Update
-
-				if !upsert.Has("_id") {
-					must.NoError(upsert.Set("_id", must.NotFail(resDocs[0].Get("_id"))))
-				}
-
-				err = h.pgPool.InTransaction(ctx, func(tx pgx.Tx) error {
-					_, err = h.update(ctx, tx, &sqlParam, upsert)
-					return err
-				})
-				if err != nil {
-					return nil, err
-				}
-			}
-		}
-
-		var resultDoc *types.Document
-		if params.ReturnNewDocument || len(resDocs) == 0 {
-			resultDoc = upsert
-		} else {
-			resultDoc = resDocs[0]
-		}
-
-		lastErrorObject := must.NotFail(types.NewDocument(
-			"n", int32(1),
-			"updatedExisting", len(resDocs) > 0,
-		))
-
-		if upserted {
-			must.NoError(lastErrorObject.Set("upserted", must.NotFail(resultDoc.Get("_id"))))
-		}
-
-		var reply wire.OpMsg
-		must.NoError(reply.SetSections(wire.OpMsgSection{
-			Documents: []*types.Document{must.NotFail(types.NewDocument(
-				"lastErrorObject", lastErrorObject,
-				"value", resultDoc,
-				"ok", float64(1),
-			))},
-		}))
-
-		return &reply, nil
-	}
-
-	if params.Remove {
-		if len(resDocs) == 0 {
-			var reply wire.OpMsg
-			must.NoError(reply.SetSections(wire.OpMsgSection{
-				Documents: []*types.Document{must.NotFail(types.NewDocument(
-					"lastErrorObject", must.NotFail(types.NewDocument("n", int32(0))),
-					"ok", float64(1),
-				))},
-			}))
-
-			return &reply, nil
-		}
-
-		_, err = h.delete(ctx, &sqlParam, resDocs)
-		if err != nil {
-			return nil, err
-		}
-
-		var reply wire.OpMsg
-		must.NoError(reply.SetSections(wire.OpMsgSection{
-			Documents: []*types.Document{must.NotFail(types.NewDocument(
-				"lastErrorObject", must.NotFail(types.NewDocument("n", int32(1))),
-				"value", resDocs[0],
-				"ok", float64(1),
-			))},
-		}))
-		return &reply, nil
-	}
-
-	return nil, lazyerrors.New("bad flags combination")
+	return &reply, nil
 }
 
 // upsertParams represent parameters for Handler.upsert method.


### PR DESCRIPTION
# Description

This PR closes #1203.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added tests for new functionality or bugfixes.
* [ ] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [ ] I ensured that the title is good enough for the changelog.
* [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [ ] I marked all done items in this checklist.
