### PR TITLE
Fix running `pg` and `tigris` tests in parallel

### DIFF
--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestCreateTigris(t *testing.T) {
-	setup.SkipForMongoWithReason(t, "Tigris-specific schema is used")
 	setup.SkipForPostgresWithReason(t, "Tigris-specific schema is used")
 
 	t.Parallel()

--- a/integration/findandmodify_compat_test.go
+++ b/integration/findandmodify_compat_test.go
@@ -162,13 +162,13 @@ func TestFindAndModifyCompatUpdate(t *testing.T) {
 				{"new", true},
 			},
 		},
-		"UpdateNotExistedIdInQuery": {
+		"NotExistedIdInQuery": {
 			command: bson.D{
 				{"query", bson.D{{"_id", "no-such-id"}}},
 				{"update", bson.D{{"v", int32(43)}}},
 			},
 		},
-		"UpdateNotExistedIdNotInQuery": {
+		"NotExistedIdNotInQuery": {
 			command: bson.D{
 				{"query", bson.D{{"$and", bson.A{
 					bson.D{{"v", bson.D{{"$gt", 0}}}},

--- a/integration/setup/common.go
+++ b/integration/setup/common.go
@@ -85,17 +85,6 @@ func SkipForPostgresWithReason(tb testing.TB, reason string) {
 	}
 }
 
-// SkipForMongoWithReason skips the current test for mongodb handler.
-//
-// Ideally, this function should not be used. It is allowed to use it in Tigris-specific tests only.
-func SkipForMongoWithReason(tb testing.TB, reason string) {
-	tb.Helper()
-
-	if *handlerF == "mongodb" {
-		tb.Skipf("Skipping for Mongo: %s", reason)
-	}
-}
-
 // setupListener starts in-process FerretDB server that runs until ctx is done,
 // and returns listening port number.
 func setupListener(tb testing.TB, ctx context.Context, logger *zap.Logger) int {

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -34,10 +34,10 @@ import (
 //
 // TODO Add option to use read-only user. https://github.com/FerretDB/FerretDB/issues/1025
 type SetupOpts struct {
-	// Database to use. If empty, temporary test-specific database is created.
+	// Database to use. If empty, temporary test-specific database is created and dropped after test.
 	DatabaseName string
 
-	// Collection to use. If empty, temporary test-specific collection is created.
+	// Collection to use. If empty, temporary test-specific collection is created and dropped after test.
 	// Most tests should keep this empty.
 	CollectionName string
 

--- a/integration/setup/setup_compat.go
+++ b/integration/setup/setup_compat.go
@@ -36,7 +36,7 @@ import (
 //
 // TODO Add option to use read-only user. https://github.com/FerretDB/FerretDB/issues/1025
 type SetupCompatOpts struct {
-	// Database to use. If empty, temporary test-specific database is created.
+	// Database to use. If empty, temporary test-specific database is created and dropped after test.
 	// Most tests should keep this empty.
 	DatabaseName string
 

--- a/integration/setup/setup_compat.go
+++ b/integration/setup/setup_compat.go
@@ -37,16 +37,14 @@ import (
 // TODO Add option to use read-only user. https://github.com/FerretDB/FerretDB/issues/1025
 type SetupCompatOpts struct {
 	// Database to use. If empty, temporary test-specific database is created.
+	// Most tests should keep this empty.
 	DatabaseName string
-
-	// If true, database is nor dropped after test.
-	// Most tests should keep this false.
-	KeepData bool
 
 	// Data providers.
 	Providers []shareddata.Provider
 
 	ownDatabase        bool
+	databaseName       string
 	baseCollectionName string
 }
 
@@ -65,12 +63,22 @@ func SetupCompatWithOpts(tb testing.TB, opts *SetupCompatOpts) *SetupCompatResul
 
 	startup()
 
+	// skip tests for MongoDB as soon as possible
+	compatPort := *compatPortF
+	if compatPort == 0 {
+		tb.Skip("compatibility tests require second system")
+	}
+
 	if opts == nil {
 		opts = new(SetupCompatOpts)
 	}
 
+	opts.databaseName = opts.DatabaseName
 	if opts.DatabaseName == "" {
-		opts.DatabaseName = testutil.DatabaseName(tb)
+		// When we use `task all` to run `pg` and `tigris` compat tests in parallel,
+		// they both use the same MongoDB instance.
+		// Add the handler's name to prevent the usage of the same database.
+		opts.databaseName = testutil.DatabaseName(tb) + "_" + *handlerF
 		opts.ownDatabase = true
 	}
 
@@ -91,11 +99,6 @@ func SetupCompatWithOpts(tb testing.TB, opts *SetupCompatOpts) *SetupCompatResul
 
 	// register cleanup function after setupListener registers its own to preserve full logs
 	tb.Cleanup(cancel)
-
-	compatPort := *compatPortF
-	if compatPort == 0 {
-		tb.Skip("compatibility tests require second system")
-	}
 
 	targetCollections := setupCompatCollections(tb, ctx, setupClient(tb, ctx, targetPort), opts)
 	compatCollections := setupCompatCollections(tb, ctx, setupClient(tb, ctx, compatPort), opts)
@@ -125,7 +128,7 @@ func SetupCompat(tb testing.TB) (context.Context, []*mongo.Collection, []*mongo.
 func setupCompatCollections(tb testing.TB, ctx context.Context, client *mongo.Client, opts *SetupCompatOpts) []*mongo.Collection {
 	tb.Helper()
 
-	database := client.Database(opts.DatabaseName)
+	database := client.Database(opts.databaseName)
 
 	if opts.ownDatabase {
 		// drop remnants of the previous failed run
@@ -145,10 +148,10 @@ func setupCompatCollections(tb testing.TB, ctx context.Context, client *mongo.Cl
 	collections := make([]*mongo.Collection, 0, len(opts.Providers))
 	for _, provider := range opts.Providers {
 		collectionName := opts.baseCollectionName + "_" + provider.Name()
-		if opts.KeepData {
+		if !opts.ownDatabase {
 			collectionName = strings.ToLower(provider.Name())
 		}
-		fullName := opts.DatabaseName + "." + collectionName
+		fullName := opts.databaseName + "." + collectionName
 
 		if *targetPortF == 0 && !slices.Contains(provider.Handlers(), *handlerF) {
 			tb.Logf(
@@ -187,7 +190,7 @@ func setupCompatCollections(tb testing.TB, ctx context.Context, client *mongo.Cl
 		require.NoError(tb, err, "%s: handler %q, collection %s", provider.Name(), *handlerF, fullName)
 		require.Len(tb, res.InsertedIDs, len(docs))
 
-		if !opts.KeepData {
+		if opts.ownDatabase {
 			// delete collection unless test failed
 			tb.Cleanup(func() {
 				if tb.Failed() {

--- a/integration/shareddata_test.go
+++ b/integration/shareddata_test.go
@@ -31,7 +31,6 @@ func TestEnvData(t *testing.T) {
 
 		setup.SetupCompatWithOpts(t, &setup.SetupCompatOpts{
 			DatabaseName: "test",
-			KeepData:     true,
 			Providers:    shareddata.AllProviders(),
 		})
 	})

--- a/integration/update_field_compat_test.go
+++ b/integration/update_field_compat_test.go
@@ -161,18 +161,18 @@ func TestUpdateFieldCompatUnset(t *testing.T) {
 		"Nested": {
 			update: bson.D{{"$unset", bson.D{{"v", bson.D{{"array", ""}}}}}},
 		},
-		"DotNotationDocument": {
+		"DotDocument": {
 			update: bson.D{{"$unset", bson.D{{"v.foo", ""}}}},
 		},
-		"DotNotationDocumentNonExisting": {
+		"DotDocumentNonExisting": {
 			update:     bson.D{{"$unset", bson.D{{"foo.bar", ""}}}},
 			resultType: emptyResult,
 		},
-		"DotNotationArrayField": {
+		"DotArrayField": {
 			update:        bson.D{{"$unset", bson.D{{"v.array.0", ""}}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"DotNotationArrayNonExisting": {
+		"DotArrayNonExisting": {
 			update:     bson.D{{"$unset", bson.D{{"foo.0.baz", int32(1)}}}},
 			resultType: emptyResult,
 		},

--- a/internal/util/testutil/db.go
+++ b/internal/util/testutil/db.go
@@ -104,7 +104,7 @@ func CollectionName(tb testing.TB) string {
 	collectionNamesM.Lock()
 	defer collectionNamesM.Unlock()
 
-	// it maybe exactly the same if `go test -count=X` is used
+	// it may be exactly the same if `go test -count=X` is used
 	current := stack()
 	if another, ok := collectionNames[name]; ok && !bytes.Equal(current, another) {
 		tb.Logf("Collection name %q already used by another test:\n%s", name, another)


### PR DESCRIPTION
## Readiness checklist

* [x] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [x] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [x] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
