### PR TITLE
add error cases for query logical

### DIFF
--- a/integration/query_logical_test.go
+++ b/integration/query_logical_test.go
@@ -43,9 +43,13 @@ func TestQueryLogical(t *testing.T) {
 		// $and
 		"AndZero": {
 			filter: bson.D{{
-				"$and", bson.A{},
+				"$and", bson.A{"v"},
 			}},
-			skip: "https://github.com/FerretDB/FerretDB/issues/962",
+			expectedErr: mongo.CommandError{
+				Code:    2,
+				Name:    "BadValue",
+				Message: "$or/$and/$nor entries need to be full objects",
+			},
 		},
 		"AndOne": {
 			filter: bson.D{{
@@ -111,15 +115,23 @@ func TestQueryLogical(t *testing.T) {
 					true,
 				},
 			}},
-			skip: "https://github.com/FerretDB/FerretDB/issues/962",
+			expectedErr: mongo.CommandError{
+				Code:    2,
+				Name:    "BadValue",
+				Message: "$or/$and/$nor entries need to be full objects",
+			},
 		},
 
 		// $or
 		"OrZero": {
 			filter: bson.D{{
-				"$or", bson.A{},
+				"$or", bson.A{"v"},
 			}},
-			skip: "https://github.com/FerretDB/FerretDB/issues/962",
+			expectedErr: mongo.CommandError{
+				Code:    2,
+				Name:    "BadValue",
+				Message: "$or/$and/$nor entries need to be full objects",
+			},
 		},
 		"OrOne": {
 			filter: bson.D{{
@@ -169,15 +181,23 @@ func TestQueryLogical(t *testing.T) {
 					true,
 				},
 			}},
-			skip: "https://github.com/FerretDB/FerretDB/issues/962",
+			expectedErr: mongo.CommandError{
+				Code:    2,
+				Name:    "BadValue",
+				Message: "$or/$and/$nor entries need to be full objects",
+			},
 		},
 
 		// $nor
 		"NorZero": {
 			filter: bson.D{{
-				"$nor", bson.A{},
+				"$nor", bson.A{"v"},
 			}},
-			skip: "https://github.com/FerretDB/FerretDB/issues/962",
+			expectedErr: mongo.CommandError{
+				Code:    2,
+				Name:    "BadValue",
+				Message: "$or/$and/$nor entries need to be full objects",
+			},
 		},
 		"NorOne": {
 			filter: bson.D{{
@@ -215,7 +235,11 @@ func TestQueryLogical(t *testing.T) {
 					true,
 				},
 			}},
-			skip: "https://github.com/FerretDB/FerretDB/issues/962",
+			expectedErr: mongo.CommandError{
+				Code:    2,
+				Name:    "BadValue",
+				Message: "$or/$and/$nor entries need to be full objects",
+			},
 		},
 
 		// $not


### PR DESCRIPTION
# Description

This PR closes #962 by adding `$or/$and/$nor entries need to be full objects` error cases. Maybe. I do not fully understand the scope of the issue, happy to make adjustments where necessary.

## Readiness checklist

* [x] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [ ] I marked all done items in this checklist.
