### PR TITLE
Fix CLI flags for Tigris

### DIFF
--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -68,6 +68,16 @@ var cli struct {
 	} `embed:"" prefix:"test-"`
 }
 
+// The tigrisFlags struct represents flags that are used specifically for a "tigris" handler.
+//
+// See main_tigris.go.
+var tigrisFlags struct {
+	TigrisURL          string `default:"127.0.0.1:8081" help:"Tigris URL for 'tigris' handler."`
+	TigrisClientID     string `default:""               help:"Tigris Client ID."`
+	TigrisClientSecret string `default:""               help:"Tigris Client secret."`
+	TigrisToken        string `default:""               help:"Tigris token."`
+}
+
 // Additional variables for the kong parsers.
 var (
 	logLevels = []string{
@@ -94,14 +104,6 @@ var (
 		},
 		kong.DefaultEnvars("FERRETDB"),
 	}
-)
-
-// Tigris parameters that are set at main_tigris.go.
-var (
-	tigrisClientID     string
-	tigrisClientSecret string
-	tigrisToken        string
-	tigrisURL          string
 )
 
 func main() {
@@ -217,10 +219,10 @@ func run() {
 
 		PostgreSQLURL: cli.PostgresURL,
 
-		TigrisClientID:     tigrisClientID,
-		TigrisClientSecret: tigrisClientSecret,
-		TigrisToken:        tigrisToken,
-		TigrisURL:          tigrisURL,
+		TigrisClientID:     tigrisFlags.TigrisClientID,
+		TigrisClientSecret: tigrisFlags.TigrisClientSecret,
+		TigrisToken:        tigrisFlags.TigrisToken,
+		TigrisURL:          tigrisFlags.TigrisURL,
 	})
 	if err != nil {
 		logger.Fatal(err.Error())

--- a/cmd/ferretdb/main_tigris.go
+++ b/cmd/ferretdb/main_tigris.go
@@ -20,15 +20,6 @@ import (
 	"github.com/alecthomas/kong"
 )
 
-// The tigrisFlags struct represents flags that
-// are used specifically for a "tigris" handler.
-var tigrisFlags struct {
-	TigrisURL          string `default:"http://127.0.0.1:8081/" help:"Tigris URL for 'tigris' handler."`
-	TigrisClientID     string `default:""                       help:"Tigris Client ID."`
-	TigrisClientSecret string `default:""                       help:"Tigris Client secret."`
-	TigrisToken        string `default:""                       help:"Tigris token."`
-}
-
 // init adds "tigris" handler flags when "ferretdb_tigris" build tag is provided.
 func init() {
 	cli.Plugins = kong.Plugins{&tigrisFlags}

--- a/internal/handlers/pg/msg_explain.go
+++ b/internal/handlers/pg/msg_explain.go
@@ -61,11 +61,9 @@ func (h *Handler) MsgExplain(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg,
 		return nil, lazyerrors.Error(err)
 	}
 
-	if explain.Has("filter") {
-		sp.Filter, err = common.GetRequiredParam[*types.Document](explain, "filter")
-		if err != nil {
-			return nil, lazyerrors.Error(err)
-		}
+	sp.Filter, err = common.GetOptionalParam[*types.Document](explain, "filter", nil)
+	if err != nil {
+		return nil, lazyerrors.Error(err)
 	}
 
 	var queryPlanner *types.Array


### PR DESCRIPTION
# Description

That fixes `task run-tigris`.

## Readiness checklist

* [ ] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [x] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [x] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
