### PR TITLE
Tweak supported wire protocol versions

### DIFF
--- a/integration/commands_replication_test.go
+++ b/integration/commands_replication_test.go
@@ -26,11 +26,11 @@ import (
 	"github.com/FerretDB/FerretDB/integration/setup"
 )
 
-func TestCommandsReplicationIsMaster(t *testing.T) {
+func TestCommandsReplication(t *testing.T) {
 	t.Parallel()
 	ctx, collection := setup.Setup(t)
 
-	for _, command := range []string{"ismaster", "isMaster"} {
+	for _, command := range []string{"ismaster", "isMaster", "hello"} {
 		command := command
 		t.Run(command, func(t *testing.T) {
 			t.Parallel()
@@ -42,23 +42,24 @@ func TestCommandsReplicationIsMaster(t *testing.T) {
 			m := actual.Map()
 			t.Log(m)
 
+			delete(m, "ismaster")
 			delete(m, "connectionId")
 			delete(m, "logicalSessionTimeoutMinutes")
 			delete(m, "topologyVersion")
+			delete(m, "isWritablePrimary")
 
 			assert.InDelta(t, time.Now().Unix(), m["localTime"].(primitive.DateTime).Time().Unix(), 2)
 			delete(m, "localTime")
 
 			maxWireVersion := m["maxWireVersion"].(int32)
-			assert.True(t, maxWireVersion == 0 || maxWireVersion == 17)
+			assert.Equal(t, int32(17), maxWireVersion)
 			delete(m, "maxWireVersion")
 
 			minWireVersion := m["minWireVersion"].(int32)
-			assert.True(t, minWireVersion == 0 || minWireVersion == 17)
+			assert.True(t, minWireVersion == 0 || minWireVersion == 14)
 			delete(m, "minWireVersion")
 
 			expected := bson.M{
-				"ismaster":            true,
 				"maxBsonObjectSize":   int32(16777216),
 				"maxMessageSizeBytes": int32(48000000),
 				"maxWriteBatchSize":   int32(100000),
@@ -69,42 +70,4 @@ func TestCommandsReplicationIsMaster(t *testing.T) {
 			assert.Equal(t, expected, m)
 		})
 	}
-}
-
-func TestCommandsReplicationHello(t *testing.T) {
-	t.Parallel()
-	ctx, collection := setup.Setup(t)
-
-	var actual bson.D
-	err := collection.Database().RunCommand(ctx, bson.D{{"hello", 1}}).Decode(&actual)
-	require.NoError(t, err)
-
-	m := actual.Map()
-	t.Log(m)
-
-	delete(m, "connectionId")
-	delete(m, "logicalSessionTimeoutMinutes")
-	delete(m, "topologyVersion")
-
-	assert.InDelta(t, time.Now().Unix(), m["localTime"].(primitive.DateTime).Time().Unix(), 2)
-	delete(m, "localTime")
-
-	maxWireVersion := m["maxWireVersion"].(int32)
-	assert.True(t, maxWireVersion == 0 || maxWireVersion == 17)
-	delete(m, "maxWireVersion")
-
-	minWireVersion := m["minWireVersion"].(int32)
-	assert.True(t, minWireVersion == 0 || minWireVersion == 17)
-	delete(m, "minWireVersion")
-
-	expected := bson.M{
-		"isWritablePrimary":   true,
-		"maxBsonObjectSize":   int32(16777216),
-		"maxMessageSizeBytes": int32(48000000),
-		"maxWriteBatchSize":   int32(100000),
-		"ok":                  float64(1),
-		"readOnly":            false,
-	}
-
-	assert.Equal(t, expected, m)
 }

--- a/internal/handlers/common/common.go
+++ b/internal/handlers/common/common.go
@@ -16,9 +16,9 @@
 package common
 
 const (
-	// Minimal supported wire protocol version.
+	// MinWireVersion is the minimal supported wire protocol version.
 	MinWireVersion = int32(14) // 5.1
 
-	// Maximal supported wire protocol version.
+	// MaxWireVersion is the maximal supported wire protocol version.
 	MaxWireVersion = int32(17)
 )

--- a/internal/handlers/common/common.go
+++ b/internal/handlers/common/common.go
@@ -14,3 +14,11 @@
 
 // Package common provides common code for all handlers.
 package common
+
+const (
+	// Minimal supported wire protocol version.
+	MinWireVersion = int32(14) // 5.1
+
+	// Maximal supported wire protocol version.
+	MaxWireVersion = int32(17)
+)

--- a/internal/handlers/pg/cmd_query.go
+++ b/internal/handlers/pg/cmd_query.go
@@ -41,8 +41,8 @@ func (h *Handler) CmdQuery(ctx context.Context, query *wire.OpQuery) (*wire.OpRe
 					"localTime", time.Now(),
 					// logicalSessionTimeoutMinutes
 					// connectionId
-					"minWireVersion", int32(17),
-					"maxWireVersion", int32(17),
+					"minWireVersion", common.MinWireVersion,
+					"maxWireVersion", common.MaxWireVersion,
 					"readOnly", false,
 					"ok", float64(1),
 				))},

--- a/internal/handlers/pg/msg_hello.go
+++ b/internal/handlers/pg/msg_hello.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/FerretDB/FerretDB/internal/handlers/common"
 	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
 	"github.com/FerretDB/FerretDB/internal/util/must"
@@ -41,8 +42,8 @@ func (h *Handler) MsgHello(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, e
 			"localTime", time.Now(),
 			// logicalSessionTimeoutMinutes
 			// connectionId
-			"minWireVersion", int32(17),
-			"maxWireVersion", int32(17),
+			"minWireVersion", common.MinWireVersion,
+			"maxWireVersion", common.MaxWireVersion,
 			"readOnly", false,
 			"ok", float64(1),
 		))},

--- a/internal/handlers/pg/msg_ismaster.go
+++ b/internal/handlers/pg/msg_ismaster.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/FerretDB/FerretDB/internal/handlers/common"
 	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
 	"github.com/FerretDB/FerretDB/internal/util/must"
@@ -41,8 +42,8 @@ func (h *Handler) MsgIsMaster(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg
 			"localTime", time.Now(),
 			// logicalSessionTimeoutMinutes
 			// connectionId
-			"minWireVersion", int32(17),
-			"maxWireVersion", int32(17),
+			"minWireVersion", common.MinWireVersion,
+			"maxWireVersion", common.MaxWireVersion,
 			"readOnly", false,
 			"ok", float64(1),
 		))},

--- a/internal/handlers/tigris/cmd_query.go
+++ b/internal/handlers/tigris/cmd_query.go
@@ -41,8 +41,8 @@ func (h *Handler) CmdQuery(ctx context.Context, query *wire.OpQuery) (*wire.OpRe
 					"localTime", time.Now(),
 					// logicalSessionTimeoutMinutes
 					// connectionId
-					"minWireVersion", int32(17),
-					"maxWireVersion", int32(17),
+					"minWireVersion", common.MinWireVersion,
+					"maxWireVersion", common.MaxWireVersion,
 					"readOnly", false,
 					"ok", float64(1),
 				))},

--- a/internal/handlers/tigris/msg_hello.go
+++ b/internal/handlers/tigris/msg_hello.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/FerretDB/FerretDB/internal/handlers/common"
 	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/util/must"
 	"github.com/FerretDB/FerretDB/internal/wire"
@@ -40,8 +41,8 @@ func (h *Handler) MsgHello(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, e
 			"localTime", time.Now(),
 			// logicalSessionTimeoutMinutes
 			// connectionId
-			"minWireVersion", int32(17),
-			"maxWireVersion", int32(17),
+			"minWireVersion", common.MinWireVersion,
+			"maxWireVersion", common.MaxWireVersion,
 			"readOnly", false,
 			"ok", float64(1),
 		))},

--- a/internal/handlers/tigris/msg_ismaster.go
+++ b/internal/handlers/tigris/msg_ismaster.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/FerretDB/FerretDB/internal/handlers/common"
 	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
 	"github.com/FerretDB/FerretDB/internal/util/must"
@@ -41,8 +42,8 @@ func (h *Handler) MsgIsMaster(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg
 			"localTime", time.Now(),
 			// logicalSessionTimeoutMinutes
 			// connectionId
-			"minWireVersion", int32(17),
-			"maxWireVersion", int32(17),
+			"minWireVersion", common.MinWireVersion,
+			"maxWireVersion", common.MaxWireVersion,
 			"readOnly", false,
 			"ok", float64(1),
 		))},


### PR DESCRIPTION
We don't actively test with 5.1, but that allows us to support some software that wasn't updated for 6.0 yet.