### PR TITLE
Skip `pjson` fuzzing of invalid documents for now

### DIFF
--- a/internal/handlers/pg/pjson/pjson.go
+++ b/internal/handlers/pg/pjson/pjson.go
@@ -77,8 +77,8 @@ func checkConsumed(dec *json.Decoder, r *bytes.Reader) error {
 	return nil
 }
 
-// frompjson converts pjsontype value to matching built-in or types' package value.
-func frompjson(v pjsontype) any {
+// fromPJSON converts pjsontype value to matching built-in or types' package value.
+func fromPJSON(v pjsontype) any {
 	switch v := v.(type) {
 	case *documentType:
 		return pointer.To(types.Document(*v))
@@ -111,8 +111,8 @@ func frompjson(v pjsontype) any {
 	panic(fmt.Sprintf("not reached: %T", v)) // for go-sumtype to work
 }
 
-// topjson converts built-in or types' package value to pjsontype value.
-func topjson(v any) pjsontype {
+// toPJSON converts built-in or types' package value to pjsontype value.
+func toPJSON(v any) pjsontype {
 	switch v := v.(type) {
 	case *types.Document:
 		return pointer.To(documentType(*v))
@@ -220,7 +220,7 @@ func Unmarshal(data []byte) (any, error) {
 		return nil, lazyerrors.Error(err)
 	}
 
-	return frompjson(res), nil
+	return fromPJSON(res), nil
 }
 
 // Marshal encodes given built-in or types' package value into pjson.
@@ -229,7 +229,7 @@ func Marshal(v any) ([]byte, error) {
 		panic("v is nil")
 	}
 
-	b, err := topjson(v).MarshalJSON()
+	b, err := toPJSON(v).MarshalJSON()
 	if err != nil {
 		return nil, lazyerrors.Error(err)
 	}


### PR DESCRIPTION
# Description

Refs #1273.

## Readiness checklist

* [ ] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
