### PR TITLE
Fix a typo in the `types` package docs

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -20,7 +20,7 @@
 //  2. As they are used for logging - `fjson` package.
 //  3. As they are used in the wire protocol implementation - `bson` package.
 //  4. As they are used to store data in PostgreSQL - `pjson` package.
-//  5. As they are used to store data in PostgreSQL - `tjson` package.
+//  5. As they are used to store data in Tigris - `tjson` package.
 //
 // The reason for that is a separation of concerns: to avoid method names clashes, to simplify type asserts,
 // to make refactorings and optimizations easier, etc.


### PR DESCRIPTION
# Description

I noticed this typo while reviewing https://github.com/FerretDB/FerretDB/pull/1291 (the typo is not relevant to the PRs, I was just checking the places where `tjson` is mentioned). As the main PR was already merged, this is a separate one to fix the typo.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added tests for new functionality or bugfixes.
* [ ] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
