### PR TITLE
Fix `tjson` schema unmarshalling

### DIFF
--- a/internal/handlers/tigris/tjson/schema.go
+++ b/internal/handlers/tigris/tjson/schema.go
@@ -73,12 +73,6 @@ type Schema struct {
 	CollectionType string `json:"collection_type,omitempty"`
 }
 
-func newSchema() *Schema {
-	return &Schema{
-		Properties: map[string]*Schema{},
-	}
-}
-
 // Schemas for scalar types.
 var (
 	doubleSchema = &Schema{
@@ -255,6 +249,10 @@ func (s *Schema) addDocumentProperties() {
 		if _, ok := s.Properties[special]; ok {
 			return
 		}
+	}
+
+	if s.Properties == nil {
+		s.Properties = map[string]*Schema{}
 	}
 
 	s.Properties["$k"] = &Schema{Type: Array, Items: stringSchema}

--- a/internal/handlers/tigris/tjson/schema_test.go
+++ b/internal/handlers/tigris/tjson/schema_test.go
@@ -68,6 +68,25 @@ func TestSchemaMarshalUnmarshal(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestSchemaUnmarshal(t *testing.T) {
+	var actual Schema
+	err := actual.Unmarshal([]byte(`{"properties": {"foo": {"type": "object"}}}`))
+	assert.NoError(t, err)
+	expected := &Schema{
+		Type: Object,
+		Properties: map[string]*Schema{
+			"$k": {Type: Array, Items: stringSchema},
+			"foo": {
+				Type: Object,
+				Properties: map[string]*Schema{
+					"$k": {Type: Array, Items: stringSchema},
+				},
+			},
+		},
+	}
+	assert.Equal(t, expected, &actual)
+}
+
 func TestSchemaEqual(t *testing.T) {
 	t.Parallel()
 

--- a/internal/handlers/tigris/tjson/tjson_test.go
+++ b/internal/handlers/tigris/tjson/tjson_test.go
@@ -247,7 +247,7 @@ func fuzzJSON(f *testing.F, testCases []testCase) {
 			t.Skip()
 		}
 
-		s := newSchema()
+		var s Schema
 
 		err := s.Unmarshal([]byte(schema))
 		if err != nil {
@@ -258,7 +258,7 @@ func fuzzJSON(f *testing.F, testCases []testCase) {
 		// We can't compare it with MarshalJSON() result directly.
 		// Instead, we compare with round-trip result.
 
-		val, err := Unmarshal([]byte(j), s)
+		val, err := Unmarshal([]byte(j), &s)
 		if err != nil {
 			t.Skip()
 		}
@@ -273,7 +273,7 @@ func fuzzJSON(f *testing.F, testCases []testCase) {
 
 		// test Unmarshal
 		{
-			actualV, err := Unmarshal([]byte(j), s)
+			actualV, err := Unmarshal([]byte(j), &s)
 			require.NoError(t, err)
 			assertEqual(t, v, toTJSON(actualV))
 		}


### PR DESCRIPTION
# Description

Found by fuzzing.

## Readiness checklist

* [x] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
