### PR TITLE
Fix syntax highlighting

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,6 +1,6 @@
 ---
 # https://github.com/DavidAnson/markdownlint
-# https://github.com/igorshubovych/markdownlint-cli
+# https://github.com/DavidAnson/markdownlint-cli2
 # https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
 
 default: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -393,11 +393,12 @@ tasks:
     cmds:
       - docker-compose run --rm docusaurus build
 
+  # see https://github.com/DavidAnson/markdownlint-cli2#command-line for the reason we use double-quotes
   docs-fmt:
     desc: "Format and lint documentation"
     cmds:
-      - docker-compose run --rm markdownlint --fix --dot "**/*.md" "#CHANGELOG.md" "#website/node_modules/"
-      - docker-compose run --rm textlint --fix --rule one-sentence-per-line '**/*.md' '.github/**/*.md'
+      - docker-compose run --rm markdownlint "**/*.md" "#CHANGELOG.md" "#node_modules"
+      - docker-compose run --rm textlint --fix --rule one-sentence-per-line "**/*.md" ".github/**/*.md"
 
   docs-dev:
     desc: "Start documentation development server"

--- a/website/docs/understanding_ferretdb.md
+++ b/website/docs/understanding_ferretdb.md
@@ -25,14 +25,13 @@ Documents are self-describing records containing both data types and a descripti
 They are similar to rows in relational databases.
 Here is an example of a single document:
 
-```json
+```js
 {
     first: "Thomas",
     last: "Edison",
     invention: "Lightbulb",
     birth: 1847
 }
-
 ```
 
 The above data is stored in a single document.
@@ -44,7 +43,7 @@ However, there are a few restrictions, which you can find  [here](https://docs.f
 
 For complex documents, you can nest objects (subdocuments) inside a document.
 
-```json
+```js
 {
   name: {
     first: "Thomas",
@@ -65,7 +64,7 @@ If a collection does not exist, FerretDB creates a new one when you insert docum
 A collection may contain one or more documents.
 For example, the following collection contains three documents.
 
-```json
+```js
 {
   Scientists: [
     {
@@ -85,7 +84,6 @@ For example, the following collection contains three documents.
     }
   ]
 }
-
 ```
 
 ## Indexing


### PR DESCRIPTION
# Description

Those documents are not valid JSON.

## Readiness checklist

* [ ] I added tests for new functionality or bugfixes.
* [ ] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
