### PR TITLE
Cleanup compat tests

### DIFF
--- a/integration/query_compat_test.go
+++ b/integration/query_compat_test.go
@@ -33,24 +33,6 @@ type queryCompatTestCase struct {
 	resultType compatTestCaseResultType // defaults to nonEmptyResult
 }
 
-func TestQueryCompat(t *testing.T) {
-	t.Parallel()
-
-	testCases := map[string]queryCompatTestCase{
-		"Empty": {
-			filter: bson.D{},
-		},
-		"IDString": {
-			filter: bson.D{{"_id", "string"}},
-		},
-		"IDObjectID": {
-			filter: bson.D{{"_id", primitive.NilObjectID}},
-		},
-	}
-
-	testQueryCompat(t, testCases)
-}
-
 // testQueryCompat tests query compatibility test cases.
 func testQueryCompat(t *testing.T, testCases map[string]queryCompatTestCase) {
 	t.Helper()
@@ -125,4 +107,22 @@ func testQueryCompat(t *testing.T, testCases map[string]queryCompatTestCase) {
 			}
 		})
 	}
+}
+
+func TestQueryCompat(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]queryCompatTestCase{
+		"Empty": {
+			filter: bson.D{},
+		},
+		"IDString": {
+			filter: bson.D{{"_id", "string"}},
+		},
+		"IDObjectID": {
+			filter: bson.D{{"_id", primitive.NilObjectID}},
+		},
+	}
+
+	testQueryCompat(t, testCases)
 }

--- a/integration/update_compat_test.go
+++ b/integration/update_compat_test.go
@@ -28,34 +28,6 @@ import (
 	"github.com/FerretDB/FerretDB/integration/setup"
 )
 
-func TestUpdateCompat(t *testing.T) {
-	t.Parallel()
-
-	testCases := map[string]updateCompatTestCase{
-		"UpdateEmptyDocument": {
-			update:     bson.D{},
-			resultType: emptyResult,
-		},
-
-		"ReplaceSimple": {
-			replace: bson.D{{"v", "foo"}},
-		},
-		"ReplaceEmpty": {
-			replace:       bson.D{{"v", ""}},
-			skipForTigris: "TODO",
-		},
-		"ReplaceNull": {
-			replace:       bson.D{{"v", nil}},
-			skipForTigris: "TODO",
-		},
-		"ReplaceEmptyDocument": {
-			replace: bson.D{},
-		},
-	}
-
-	testUpdateCompat(t, testCases)
-}
-
 // updateCompatTestCase describes update compatibility test case.
 type updateCompatTestCase struct {
 	update        bson.D                   // required if replace is nil
@@ -164,4 +136,32 @@ func testUpdateCompat(t *testing.T, testCases map[string]updateCompatTestCase) {
 			}
 		})
 	}
+}
+
+func TestUpdateCompat(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]updateCompatTestCase{
+		"UpdateEmptyDocument": {
+			update:     bson.D{},
+			resultType: emptyResult,
+		},
+
+		"ReplaceSimple": {
+			replace: bson.D{{"v", "foo"}},
+		},
+		"ReplaceEmpty": {
+			replace:       bson.D{{"v", ""}},
+			skipForTigris: "TODO",
+		},
+		"ReplaceNull": {
+			replace:       bson.D{{"v", nil}},
+			skipForTigris: "TODO",
+		},
+		"ReplaceEmptyDocument": {
+			replace: bson.D{},
+		},
+	}
+
+	testUpdateCompat(t, testCases)
 }

--- a/internal/handlers/common/error.go
+++ b/internal/handlers/common/error.go
@@ -191,16 +191,16 @@ func formatBitwiseOperatorErr(err error, operator string, maskValue any) error {
 // CheckError checks error type and returns properly translated error.
 func CheckError(err error) error {
 	var ve *types.ValidationError
-	if errors.As(err, &ve) {
-		switch ve.Code() {
-		case types.ErrBadID:
-			return NewWriteErrorMsg(ErrInvalidID, err.Error())
-		case types.ErrValidation:
-			return NewErrorMsg(ErrBadValue, err.Error())
-		default:
-			panic(fmt.Sprintf("Unknown error code: %v", ve.Code()))
-		}
+	if !errors.As(err, &ve) {
+		return lazyerrors.Error(err)
 	}
 
-	return lazyerrors.Error(err)
+	switch ve.Code() {
+	case types.ErrValidation:
+		return NewErrorMsg(ErrBadValue, err.Error())
+	case types.ErrBadID:
+		return NewWriteErrorMsg(ErrInvalidID, err.Error())
+	default:
+		panic(fmt.Sprintf("Unknown error code: %v", ve.Code()))
+	}
 }

--- a/internal/types/document_validation.go
+++ b/internal/types/document_validation.go
@@ -28,7 +28,7 @@ type ValidationErrorCode int
 
 const (
 	// ErrValidation indicates that document is invalid.
-	ErrValidation ValidationErrorCode = iota
+	ErrValidation ValidationErrorCode = iota + 1
 
 	// ErrBadID indicates that _id field is invalid.
 	ErrBadID


### PR DESCRIPTION
# Description

This PR tweak compatibility tests to make them look a bit closer to each other.

## Readiness checklist

* [ ] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
