### PR TITLE
Fix ignore patterns for tools

### DIFF
--- a/.textlintignore
+++ b/.textlintignore
@@ -1,2 +1,4 @@
+# https://textlint.github.io/docs/ignore.html
+# node_modules are excluded by default.
+
 CHANGELOG.md
-website/node_modules/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -397,7 +397,7 @@ tasks:
   docs-fmt:
     desc: "Format and lint documentation"
     cmds:
-      - docker-compose run --rm markdownlint "**/*.md" "#CHANGELOG.md" "#node_modules"
+      - docker-compose run --rm markdownlint "**/*.md" "#CHANGELOG.md" "#**/node_modules"
       - docker-compose run --rm textlint --fix --rule one-sentence-per-line "**/*.md" ".github/**/*.md"
 
   docs-dev:


### PR DESCRIPTION
# Description

Even if `node_modules` directory is present on the host for any reason, it should be ignored by linters.

## Readiness checklist

* [ ] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
