### PR TITLE
Add missing locks when update settings table

### DIFF
--- a/.github/workflows/conform-pr.yml
+++ b/.github/workflows/conform-pr.yml
@@ -8,29 +8,27 @@ on:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
     # List all types to make it easier to enable new ones when they are needed.
     types:
-      # - assigned
-      # - unassigned
+      - assigned
+      - unassigned
       - labeled
-      - unlabeled # if GitHub Actions stuck, add and remove "no ci" label to force rebuild
+      - unlabeled
       - opened
       - edited
       # - closed
       - reopened
       - synchronize
-      # - converted_to_draft
-      # - ready_for_review
+      - converted_to_draft
+      - ready_for_review
       # - locked
-      # - unlocked
-      # - review_requested
-      # - review_request_removed
-      # - auto_merge_enabled
-      # - auto_merge_disabled
+      - unlocked
+      - review_requested
+      - review_request_removed
+      - auto_merge_enabled
+      - auto_merge_disabled
 
-# Stop pending and in-progress jobs of this workflow.
-# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value
+# Do not run this workflow in parallel for any PR change.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.head_ref }}
 
 env:
   GOPATH: /home/runner/go

--- a/integration/.golangci-new.yml
+++ b/integration/.golangci-new.yml
@@ -144,3 +144,7 @@ issues:
   max-same-issues: 0
   exclude-use-default: false
   new-from-rev: origin/main
+  exclude-rules:
+    # that's a valid usage of bson.D
+    - linters: [govet]
+      text: "composites: go.mongodb.org/mongo-driver/bson/primitive.E struct literal uses unkeyed fields"

--- a/integration/commands_administration_test.go
+++ b/integration/commands_administration_test.go
@@ -21,7 +21,6 @@ import (
 	"runtime"
 	"sort"
 	"strconv"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -963,8 +962,10 @@ func TestCommandsAdministrationServerStatusStress(t *testing.T) {
 			// In both cases, we create a collection without a schema.
 			err := db.CreateCollection(ctx, collName, &opts)
 			if err != nil {
-				if strings.Contains(err.Error(), `support for field "validator" is not implemented yet`) ||
-					strings.Contains(err.Error(), `unknown top level operator: $tigrisSchemaString`) {
+				if errorTextContains(err,
+					`support for field "validator" is not implemented yet`,
+					`unknown top level operator: $tigrisSchemaString`,
+				) {
 					err = db.CreateCollection(ctx, collName)
 				}
 			}

--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -31,8 +31,6 @@ import (
 )
 
 func TestCreateStress(t *testing.T) {
-	t.Parallel()
-
 	ctx, collection := setup.Setup(t) // no providers there, we will create collections concurrently
 	db := collection.Database()
 
@@ -121,8 +119,6 @@ func TestCreateStress(t *testing.T) {
 }
 
 func TestCreateStressSameCollection(t *testing.T) {
-	t.Parallel()
-
 	ctx, collection := setup.Setup(t) // no providers there, we will create collection from the test
 	db := collection.Database()
 

--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -133,6 +133,7 @@ func TestCreateStressSameCollection(t *testing.T) {
 	start := make(chan struct{})
 
 	var created atomic.Int32 // number of successful attempts to create a collection
+
 	var wg sync.WaitGroup
 	for i := 0; i < collNum; i++ {
 		wg.Add(1)

--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -32,8 +32,6 @@ import (
 )
 
 func TestCreateStress(t *testing.T) {
-	setup.SkipForPostgresWithReason(t, "https://github.com/FerretDB/FerretDB/issues/1206")
-
 	t.Parallel()
 
 	ctx, collection := setup.Setup(t) // no providers there, we will create collections concurrently
@@ -103,10 +101,6 @@ func TestCreateStress(t *testing.T) {
 	colls, err := db.ListCollectionNames(ctx, bson.D{})
 	require.NoError(t, err)
 
-	// TODO https://github.com/FerretDB/FerretDB/issues/1206
-	// Without SkipForPostgres this test would fail.
-	// Even though all the collections are created as separate tables in the database,
-	// the settings table doesn't store all of them because of concurrency issues.
 	require.Len(t, colls, collNum)
 
 	// check that all collections were created, and we can query them

--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -199,8 +199,6 @@ func TestCreateStressSameCollection(t *testing.T) {
 
 	wg.Wait()
 
-	require.Equal(t, int32(1), created.Load(), "Only one attempt to create a collection should succeed")
-
 	colls, err := db.ListCollectionNames(ctx, bson.D{})
 	require.NoError(t, err)
 
@@ -215,6 +213,10 @@ func TestCreateStressSameCollection(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, bson.D{{"_id", "foo_1"}, {"v", "bar"}}, doc)
 	})
+
+	setup.SkipForTigrisWithReason(t, "In case of Tigris, CreateOrUpdate is called, "+
+		"and it's not possible to check the number of creation attempts as some of them might be updates.")
+	require.Equal(t, int32(1), created.Load(), "Only one attempt to create a collection should succeed")
 }
 
 func TestCreateTigris(t *testing.T) {

--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -17,7 +17,6 @@ package integration
 import (
 	"fmt"
 	"runtime"
-	"strings"
 	"sync"
 	"testing"
 
@@ -74,8 +73,10 @@ func TestCreateStress(t *testing.T) {
 			// In both cases, we create a collection without a schema.
 			err := db.CreateCollection(ctx, collName, &opts)
 			if err != nil {
-				if strings.Contains(err.Error(), `support for field "validator" is not implemented yet`) ||
-					strings.Contains(err.Error(), `unknown top level operator: $tigrisSchemaString`) {
+				if errorTextContains(err,
+					`support for field "validator" is not implemented yet`,
+					`unknown top level operator: $tigrisSchemaString`,
+				) {
 					err = db.CreateCollection(ctx, collName)
 				}
 

--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -170,21 +170,22 @@ func TestCreateStressSameCollection(t *testing.T) {
 				) {
 					err = db.CreateCollection(ctx, collName)
 				}
-
-				if err == nil {
-					created.Add(1)
-				} else {
-					AssertEqualError(t,
-						mongo.CommandError{
-							Code:    48,
-							Name:    "NamespaceExists",
-							Message: `Collection testcreatestresssamecollection.stress_same_collection already exists.`,
-						},
-						err)
-				}
 			}
 
-			_, err = db.Collection(collName).InsertOne(ctx, bson.D{{"_id", "foo"}, {"v", "bar"}})
+			if err == nil {
+				created.Add(1)
+			} else {
+				AssertEqualError(t,
+					mongo.CommandError{
+						Code:    48,
+						Name:    "NamespaceExists",
+						Message: `Collection testcreatestresssamecollection.stress_same_collection already exists.`,
+					},
+					err)
+			}
+
+			id := fmt.Sprintf("foo_%d", i)
+			_, err = db.Collection(collName).InsertOne(ctx, bson.D{{"_id", id}, {"v", "bar"}})
 
 			assert.NoError(t, err)
 		}(i)
@@ -210,9 +211,9 @@ func TestCreateStressSameCollection(t *testing.T) {
 		t.Parallel()
 
 		var doc bson.D
-		err := db.Collection(collName).FindOne(ctx, bson.D{{"_id", "foo"}}).Decode(&doc)
+		err := db.Collection(collName).FindOne(ctx, bson.D{{"_id", "foo_1"}}).Decode(&doc)
 		require.NoError(t, err)
-		require.Equal(t, bson.D{{"_id", "foo"}, {"v", "bar"}}, doc)
+		require.Equal(t, bson.D{{"_id", "foo_1"}, {"v", "bar"}}, doc)
 	})
 }
 

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -17,6 +17,7 @@ package integration
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -318,4 +319,17 @@ func FindAll(t testing.TB, ctx context.Context, collection *mongo.Collection) []
 	require.NoError(t, err)
 
 	return FetchAll(t, ctx, cursor)
+}
+
+// errorTextContains returns true if the error message contains at least one element of the given text slice.
+// This function should be used to highlight the places where we do not have proper error checks yet
+// but compare texts instead.
+func errorTextContains(err error, texts ...string) bool {
+	for _, text := range texts {
+		if strings.Contains(err.Error(), text) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/handlers/pg/msg_listdatabases.go
+++ b/internal/handlers/pg/msg_listdatabases.go
@@ -75,7 +75,12 @@ func (h *Handler) MsgListDatabases(ctx context.Context, msg *wire.OpMsg) (*wire.
 				// We use COALESCE to scan this null value as 0 in this case.
 				// Even though we run the query in a transaction, the current isolation level doesn't guarantee
 				// that the table is not deleted (see https://www.postgresql.org/docs/14/transaction-iso.html).
-				err = tx.QueryRow(ctx, "SELECT COALESCE(pg_total_relation_size($1), 0)", fullName).Scan(&tableSize)
+				// PgPool (not a transaction) is used on purpose here. In this case, transaction doesn't lock
+				// relations, and it's possible that the table/schema is deleted between the moment we get the list of tables
+				// and the moment we get the size of the table. In this case, we might receive an error from the database,
+				// and transaction will be interrupted. Such errors are not critical, we can just ignore them, and
+				// we don't need to interrupt the whole transaction.
+				err = h.PgPool.QueryRow(ctx, "SELECT COALESCE(pg_total_relation_size($1), 0)", fullName).Scan(&tableSize)
 				if err == nil {
 					sizeOnDisk += tableSize
 					continue
@@ -84,8 +89,8 @@ func (h *Handler) MsgListDatabases(ctx context.Context, msg *wire.OpMsg) (*wire.
 				var pgErr *pgconn.PgError
 				if errors.As(err, &pgErr) {
 					switch pgErr.Code {
-					case pgerrcode.UndefinedTable:
-						// Table was deleted after we got the list of tables, just ignore it
+					case pgerrcode.UndefinedTable, pgerrcode.InvalidSchemaName:
+						// Table or schema was deleted after we got the list of tables, just ignore it
 						continue
 					}
 				}

--- a/internal/handlers/pg/msg_listdatabases.go
+++ b/internal/handlers/pg/msg_listdatabases.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgerrcode"
-
 	"github.com/jackc/pgx/v4"
 
 	"github.com/FerretDB/FerretDB/internal/handlers/common"

--- a/internal/handlers/pg/pgdb/collections.go
+++ b/internal/handlers/pg/pgdb/collections.go
@@ -111,10 +111,6 @@ func CreateCollection(ctx context.Context, tx pgx.Tx, db, collection string) err
 	}
 
 	err = setTableInSettings(ctx, tx, db, collection, table)
-	if errors.Is(err, ErrAlreadyExist) {
-		return ErrAlreadyExist
-	}
-
 	if err != nil {
 		return lazyerrors.Error(err)
 	}

--- a/internal/handlers/pg/pgdb/collections.go
+++ b/internal/handlers/pg/pgdb/collections.go
@@ -46,7 +46,7 @@ func Collections(ctx context.Context, tx pgx.Tx, db string) ([]string, error) {
 		return nil, ErrSchemaNotExist
 	}
 
-	settings, err := getSettingsTable(ctx, tx, db)
+	settings, err := getSettingsTable(ctx, tx, db, false)
 	if err != nil {
 		return nil, lazyerrors.Error(err)
 	}
@@ -110,7 +110,7 @@ func CreateCollection(ctx context.Context, tx pgx.Tx, db, collection string) err
 		return ErrAlreadyExist
 	}
 
-	settings, err := getSettingsTable(ctx, tx, db)
+	settings, err := getSettingsTable(ctx, tx, db, false)
 	if err != nil {
 		return lazyerrors.Error(err)
 	}
@@ -125,11 +125,7 @@ func CreateCollection(ctx context.Context, tx pgx.Tx, db, collection string) err
 		return nil
 	}
 
-	// TODO keep "collections" sorted after each update
-	collections.Set(collection, table)
-	settings.Set("collections", collections)
-
-	err = updateSettingsTable(ctx, tx, db, settings)
+	table, err = setTableInSettings(ctx, tx, db, collection)
 	if err != nil {
 		return lazyerrors.Error(err)
 	}

--- a/internal/handlers/pg/pgdb/collections.go
+++ b/internal/handlers/pg/pgdb/collections.go
@@ -110,22 +110,11 @@ func CreateCollection(ctx context.Context, tx pgx.Tx, db, collection string) err
 		return ErrAlreadyExist
 	}
 
-	settings, err := getSettingsTable(ctx, tx, db, false)
-	if err != nil {
-		return lazyerrors.Error(err)
-	}
-
-	collectionsDoc := must.NotFail(settings.Get("collections"))
-	collections, ok := collectionsDoc.(*types.Document)
-	if !ok {
-		return lazyerrors.Errorf("expected document but got %[1]T: %[1]v", collectionsDoc)
-	}
-
-	if collections.Has(collection) {
-		return nil
-	}
-
 	err = setTableInSettings(ctx, tx, db, collection, table)
+	if errors.Is(err, ErrAlreadyExist) {
+		return ErrAlreadyExist
+	}
+
 	if err != nil {
 		return lazyerrors.Error(err)
 	}

--- a/internal/handlers/pg/pgdb/collections.go
+++ b/internal/handlers/pg/pgdb/collections.go
@@ -125,7 +125,7 @@ func CreateCollection(ctx context.Context, tx pgx.Tx, db, collection string) err
 		return nil
 	}
 
-	table, err = setTableInSettings(ctx, tx, db, collection)
+	err = setTableInSettings(ctx, tx, db, collection, table)
 	if err != nil {
 		return lazyerrors.Error(err)
 	}

--- a/internal/handlers/pg/pgdb/collections.go
+++ b/internal/handlers/pg/pgdb/collections.go
@@ -111,6 +111,10 @@ func CreateCollection(ctx context.Context, tx pgx.Tx, db, collection string) err
 	}
 
 	err = setTableInSettings(ctx, tx, db, collection, table)
+	if errors.Is(err, ErrAlreadyExist) {
+		return ErrAlreadyExist
+	}
+
 	if err != nil {
 		return lazyerrors.Error(err)
 	}

--- a/internal/handlers/pg/pgdb/settings.go
+++ b/internal/handlers/pg/pgdb/settings.go
@@ -16,6 +16,7 @@ package pgdb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"hash/fnv"
 
@@ -128,8 +129,9 @@ func getTableName(ctx context.Context, tx pgx.Tx, db, collection string) (string
 	}
 
 	tableName := formatCollectionName(collection)
+
 	err = setTableInSettings(ctx, tx, db, collection, tableName)
-	if err != nil {
+	if err != nil && !errors.Is(err, ErrAlreadyExist) {
 		return "", lazyerrors.Error(err)
 	}
 

--- a/internal/handlers/pg/pgdb/settings.go
+++ b/internal/handlers/pg/pgdb/settings.go
@@ -176,6 +176,7 @@ func getSettingsTable(ctx context.Context, tx pgx.Tx, db string) (*types.Documen
 
 // updateSettingsTable updates FerretDB settings table.
 func updateSettingsTable(ctx context.Context, tx pgx.Tx, db string, settings *types.Document) error {
+	// TODO delete this method as it's not atomic
 	sql := fmt.Sprintf(`UPDATE %s SET settings = $1`, pgx.Identifier{db, settingsTableName}.Sanitize())
 	_, err := tx.Exec(ctx, sql, must.NotFail(pjson.Marshal(settings)))
 	return err

--- a/internal/handlers/pg/pgdb/settings.go
+++ b/internal/handlers/pg/pgdb/settings.go
@@ -16,7 +16,6 @@ package pgdb
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"hash/fnv"
 
@@ -131,7 +130,7 @@ func getTableName(ctx context.Context, tx pgx.Tx, db, collection string) (string
 	tableName := formatCollectionName(collection)
 
 	err = setTableInSettings(ctx, tx, db, collection, tableName)
-	if err != nil && !errors.Is(err, ErrAlreadyExist) {
+	if err != nil {
 		return "", lazyerrors.Error(err)
 	}
 
@@ -188,7 +187,7 @@ func setTableInSettings(ctx context.Context, tx pgx.Tx, db, collection, table st
 	collections := must.NotFail(settings.Get("collections")).(*types.Document)
 
 	if collections.Has(collection) {
-		return ErrAlreadyExist
+		panic("collection already exists in settings")
 	}
 
 	collections.Set(collection, table)

--- a/internal/handlers/pg/pgdb/settings.go
+++ b/internal/handlers/pg/pgdb/settings.go
@@ -127,7 +127,8 @@ func getTableName(ctx context.Context, tx pgx.Tx, db, collection string) (string
 		return must.NotFail(collections.Get(collection)).(string), nil
 	}
 
-	tableName, err := setTableInSettings(ctx, tx, db, collection)
+	tableName := formatCollectionName(collection)
+	err = setTableInSettings(ctx, tx, db, collection, tableName)
 	if err != nil {
 		return "", lazyerrors.Error(err)
 	}
@@ -175,31 +176,37 @@ func getSettingsTable(ctx context.Context, tx pgx.Tx, db string, lock bool) (*ty
 // setTableInSettings sets the table name for given collection in settings table.
 // As it's not possible to modify the settings table with a single operator (the data need to be retrieved first),
 // explicit lock is used to prevent concurrent modifications.
-func setTableInSettings(ctx context.Context, tx pgx.Tx, db, collection string) (string, error) {
+func setTableInSettings(ctx context.Context, tx pgx.Tx, db, collection, table string) error {
 	settings, err := getSettingsTable(ctx, tx, db, true)
 	if err != nil {
-		return "", lazyerrors.Error(err)
+		return lazyerrors.Error(err)
 	}
 
 	collectionsDoc := must.NotFail(settings.Get("collections"))
 
 	collections, ok := collectionsDoc.(*types.Document)
 	if !ok {
-		return "", lazyerrors.Errorf("expected document but got %[1]T: %[1]v", collectionsDoc)
+		return lazyerrors.Errorf("expected document but got %[1]T: %[1]v", collectionsDoc)
 	}
 
-	tableName := formatCollectionName(collection)
-	collections.Set(collection, tableName)
+	if collections.Has(collection) {
+		oldName := must.NotFail(collections.Get(collection)).(string)
+		if oldName != table {
+			panic(fmt.Sprintf("table name mismatch: old name %v, new name %v", oldName, table))
+		}
+	} else {
+		collections.Set(collection, table)
+	}
 	settings.Set("collections", collections)
 
 	sql := fmt.Sprintf(`UPDATE %s SET settings = $1`, pgx.Identifier{db, settingsTableName}.Sanitize())
 
 	_, err = tx.Exec(ctx, sql, must.NotFail(pjson.Marshal(settings)))
 	if err != nil {
-		return "", lazyerrors.Error(err)
+		return lazyerrors.Error(err)
 	}
 
-	return tableName, nil
+	return nil
 }
 
 // removeTableFromSettings removes collection from FerretDB settings table.

--- a/internal/handlers/pg/pgdb/settings.go
+++ b/internal/handlers/pg/pgdb/settings.go
@@ -16,6 +16,7 @@ package pgdb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"hash/fnv"
 
@@ -130,7 +131,7 @@ func getTableName(ctx context.Context, tx pgx.Tx, db, collection string) (string
 	tableName := formatCollectionName(collection)
 
 	err = setTableInSettings(ctx, tx, db, collection, tableName)
-	if err != nil {
+	if err != nil && !errors.Is(err, ErrAlreadyExist) {
 		return "", lazyerrors.Error(err)
 	}
 
@@ -187,7 +188,7 @@ func setTableInSettings(ctx context.Context, tx pgx.Tx, db, collection, table st
 	collections := must.NotFail(settings.Get("collections")).(*types.Document)
 
 	if collections.Has(collection) {
-		panic("collection already exists in settings")
+		return ErrAlreadyExist
 	}
 
 	collections.Set(collection, table)

--- a/internal/handlers/pg/pgdb/settings.go
+++ b/internal/handlers/pg/pgdb/settings.go
@@ -183,10 +183,7 @@ func setTableInSettings(ctx context.Context, tx pgx.Tx, db, collection, table st
 		return lazyerrors.Error(err)
 	}
 
-	collections, ok := must.NotFail(settings.Get("collections")).(*types.Document)
-	if !ok {
-		return lazyerrors.Errorf("invalid settings document")
-	}
+	collections := must.NotFail(settings.Get("collections")).(*types.Document)
 
 	if collections.Has(collection) {
 		return ErrAlreadyExist
@@ -215,10 +212,7 @@ func removeTableFromSettings(ctx context.Context, tx pgx.Tx, db, collection stri
 		return lazyerrors.Error(err)
 	}
 
-	collections, ok := must.NotFail(settings.Get("collections")).(*types.Document)
-	if !ok {
-		return lazyerrors.Errorf("invalid settings document")
-	}
+	collections := must.NotFail(settings.Get("collections")).(*types.Document)
 
 	if !collections.Has(collection) {
 		return ErrTableNotExist

--- a/internal/handlers/tigris/msg_create.go
+++ b/internal/handlers/tigris/msg_create.go
@@ -90,6 +90,12 @@ func (h *Handler) MsgCreate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 			return nil, common.NewCommandError(common.ErrBadValue, err)
 		}
 
+		// Tigris returns Code_ABORTED if concurrent create collection request is detected.
+		if tigrisdb.IsAborted(err) {
+			msg := fmt.Sprintf("Collection %s.%s already exists.", db, collection)
+			return nil, common.NewCommandErrorMsg(common.ErrNamespaceExists, msg)
+		}
+
 		return nil, lazyerrors.Error(err)
 	default:
 		return nil, lazyerrors.Error(err)

--- a/internal/handlers/tigris/tigrisdb/errors.go
+++ b/internal/handlers/tigris/tigrisdb/errors.go
@@ -29,6 +29,7 @@ const (
 	errInvalidArgument = api.Code_INVALID_ARGUMENT
 	errNotFound        = api.Code_NOT_FOUND
 	errAlreadyExists   = api.Code_ALREADY_EXISTS
+	errAborted         = api.Code_ABORTED
 )
 
 // IsInvalidArgument returns true if the error's code is errInvalidArgument.
@@ -59,6 +60,16 @@ func IsAlreadyExists(err error) bool {
 	}
 
 	return driverErr.Code == errAlreadyExists
+}
+
+// IsAborted returns true if the error's code is errAborted.
+func IsAborted(err error) bool {
+	var driverErr *driver.Error
+	if !errors.As(err, &driverErr) {
+		panic(fmt.Sprintf("unexpected error type %#v", err))
+	}
+
+	return driverErr.Code == errAborted
 }
 
 // isOtherCreationInFlight returns true if an attempt to create the database with the given name is already in progress.


### PR DESCRIPTION
# Description

Closes #1206.

Note: I didn't refactor how the settings table is used (as it's not in the scope of the task), I only fixed the exact problem with missing locks.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added tests for new functionality or bugfixes.
* [ ] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
