### PR TITLE
Fix information about `delete`'s `comment` argument inside "supported commands" reference

### DIFF
--- a/website/docs/reference/supported_commands.md
+++ b/website/docs/reference/supported_commands.md
@@ -13,7 +13,7 @@ sidebar_position: 1
 |                   | `authorizedCollections` | ⚠️     | Ignored                                                   |
 | `delete`          |                         | ✅     | Basic command is fully supported                          |
 |                   | `deletes`               | ✅     |                                                           |
-|                   | `comment`               | ⚠️     | Ignored                                                   |
+|                   | `comment`               | ⚠️     | Ignored in Tigris                                         |
 |                   | `let`                   | ⚠️     | Unimplemented                                             |
 |                   | `ordered`               | ✅     |                                                           |
 |                   | `writeConcern`          | ⚠️     | Ignored                                                   |


### PR DESCRIPTION
# Description

Small fix.
<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added tests for new functionality or bugfixes.
* [ ] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
