### PR TITLE
Disable CockroachDB on GitHub Actions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,7 +38,7 @@ jobs:
           - {name: "PostgreSQL", task: "pg"}
           - {name: "Tigris", task: "tigris"}
           - {name: "Tigris main", task: "tigris", tigris_dockerfile: "tigris_main"}
-          - {name: "CockroachDB", task: "cockroach"}
+          # - {name: "CockroachDB", task: "cockroach"} TODO https://github.com/FerretDB/FerretDB/issues/1523
           - {name: "MongoDB", task: "mongodb"}
 
     steps:


### PR DESCRIPTION
# Description

As we don't have plans to support CockroachDB soon, let's disable it running on CI.

I also created a ticket to add basic support #1523.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added tests for new functionality or bugfixes.
* [ ] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
