### PR TITLE
Add placeholder for testing scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,11 @@ vendor/
 # trivy cache
 .cache/
 
-# packages, build artifacts
+# packages, build artifacts, temporary files
 *.deb
 *.rpm
 *.tar
+*.js
 website/build/
 tmp/
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -298,7 +298,7 @@ tasks:
     cmds:
       - >
         docker-compose exec mongodb mongosh mongodb://host.docker.internal:27017/test?heartbeatFrequencyMS=300000
-        --verbose --eval 'disableTelemetry()' --shell
+        --verbose --eval 'disableTelemetry()' --shell /mongosh/test.js
 
   mongo:
     desc: "Run legacy `mongo` shell"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,8 @@ services:
     environment:
       # Always UTC+05:45. Set to catch timezone problems.
       - TZ=Asia/Kathmandu
+    volumes:
+      - ./build/mongosh:/mongosh
 
   trivy:
     build:


### PR DESCRIPTION
# Description

Testing scripts could be put into `build/mongosh/test.js` to be executed by `task mongosh`.

## Readiness checklist

* [ ] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
