### PR TITLE
Move array query tests to compat tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,7 +38,7 @@ jobs:
           - {name: "PostgreSQL", task: "pg"}
           - {name: "Tigris", task: "tigris"}
           - {name: "Tigris main", task: "tigris", tigris_dockerfile: "tigris_main"}
-          - {name: "CockroachDB", task: "cockroach"}
+          # - {name: "CockroachDB", task: "cockroach"} TODO https://github.com/FerretDB/FerretDB/issues/1523
           - {name: "MongoDB", task: "mongodb"}
 
     steps:

--- a/integration/basic_test.go
+++ b/integration/basic_test.go
@@ -61,6 +61,8 @@ func TestFindNothing(t *testing.T) {
 	ctx, collection := setup.Setup(t)
 
 	var doc bson.D
+
+	// FindOne sets limit parameter to 1, Find leaves it unset.
 	err := collection.FindOne(ctx, bson.D{}).Decode(&doc)
 	require.Equal(t, mongo.ErrNoDocuments, err)
 	assert.Equal(t, bson.D(nil), doc)

--- a/integration/basic_test.go
+++ b/integration/basic_test.go
@@ -60,16 +60,8 @@ func TestFindNothing(t *testing.T) {
 	t.Parallel()
 	ctx, collection := setup.Setup(t)
 
-	cursor, err := collection.Find(ctx, bson.D{})
-	require.NoError(t, err)
-
-	var docs []bson.D
-	err = cursor.All(ctx, &docs)
-	require.NoError(t, err)
-	assert.Equal(t, []bson.D(nil), docs)
-
 	var doc bson.D
-	err = collection.FindOne(ctx, bson.D{}).Decode(&doc)
+	err := collection.FindOne(ctx, bson.D{}).Decode(&doc)
 	require.Equal(t, mongo.ErrNoDocuments, err)
 	assert.Equal(t, bson.D(nil), doc)
 }

--- a/integration/query_array_compat_test.go
+++ b/integration/query_array_compat_test.go
@@ -22,122 +22,104 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-func TestQueryArrayCompat(t *testing.T) {
+func TestQueryArrayCompatSize(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]queryCompatTestCase{
-		"AllString": {
-			filter:        bson.D{{"v", bson.D{{"$all", bson.A{"foo"}}}}},
+		"float64": {
+			filter:        bson.D{{"v", bson.D{{"$size", float64(2)}}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"AllStringRepeated": {
-			filter:        bson.D{{"v", bson.D{{"$all", bson.A{"foo", "foo", "foo"}}}}},
+		"int32": {
+			filter:        bson.D{{"v", bson.D{{"$size", int32(2)}}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"AllStringEmpty": {
-			filter:        bson.D{{"v", bson.D{{"$all", bson.A{""}}}}},
+		"int64": {
+			filter:        bson.D{{"v", bson.D{{"$size", int64(2)}}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"AllWhole": {
-			filter:        bson.D{{"v", bson.D{{"$all", bson.A{int32(42)}}}}},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-		"AllWholeNotFound": {
-			filter:     bson.D{{"v", bson.D{{"$all", bson.A{int32(44)}}}}},
+		"InvalidUse": {
+			filter:     bson.D{{"$size", 2}},
 			resultType: emptyResult,
 		},
-		"AllZero": {
-			filter:        bson.D{{"v", bson.D{{"$all", bson.A{math.Copysign(0, +1)}}}}},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-		"AllDouble": {
-			filter:        bson.D{{"v", bson.D{{"$all", bson.A{42.13}}}}},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-		"AllDoubleMax": {
-			filter:        bson.D{{"v", bson.D{{"$all", bson.A{math.MaxFloat64}}}}},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-		"AllDoubleMin": {
-			filter:        bson.D{{"v", bson.D{{"$all", bson.A{math.SmallestNonzeroFloat64}}}}},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-		"AllMultiAll": {
-			filter:        bson.D{{"v", bson.D{{"$all", bson.A{"foo", 42}}}}},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-		"AllMultiAllWithNil": {
-			filter:        bson.D{{"v", bson.D{{"$all", bson.A{"foo", nil}}}}},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-		"AllEmpty": {
-			filter:     bson.D{{"v", bson.D{{"$all", bson.A{}}}}},
+		"NotFound": {
+			filter:     bson.D{{"v", bson.D{{"$size", 4}}}},
 			resultType: emptyResult,
 		},
-		"AllNotFound": {
-			filter:     bson.D{{"v", bson.D{{"$all", bson.A{"hello"}}}}},
-			resultType: emptyResult,
+		"Zero": {
+			filter:        bson.D{{"v", bson.D{{"$size", 0}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"$allNeedsAnArrayInt": {
-			filter:     bson.D{{"v", bson.D{{"$all", 1}}}},
-			resultType: emptyResult,
-		},
-		"$allNeedsAnArrayNil": {
-			filter:     bson.D{{"v", bson.D{{"$all", nil}}}},
-			resultType: emptyResult,
-		},
-		"DotNotationPositionIndexGreaterThanArrayLength": {
+	}
+
+	testQueryCompat(t, testCases)
+}
+
+func TestQueryArrayCompatDotNotation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]queryCompatTestCase{
+		"PositionIndexGreaterThanArrayLength": {
 			filter:     bson.D{{"v.5", bson.D{{"$type", "double"}}}},
 			resultType: emptyResult,
 		},
-		"DotNotationPositionIndexAtTheEndOfArray": {
+		"PositionIndexAtTheEndOfArray": {
 			filter:        bson.D{{"v.1", bson.D{{"$type", "double"}}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"DotNotationPositionTypeNull": {
+		"PositionTypeNull": {
 			filter:        bson.D{{"v.1", bson.D{{"$type", "double"}}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"DotNotationPositionRegex": {
+		"PositionRegex": {
 			filter:        bson.D{{"v.1", primitive.Regex{Pattern: "foo"}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"DotNotationNoSuchFieldPosition": {
+		"NoSuchFieldPosition": {
 			filter:     bson.D{{"v.some.0", bson.A{42}}},
 			resultType: emptyResult,
 		},
-		"DotNotationField": {
+		"Field": {
 			filter:        bson.D{{"v.array", int32(42)}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"DotNotationFieldPosition": {
+		"FieldPosition": {
 			filter:        bson.D{{"v.array.0", int32(42)}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"DotNotationFieldPositionQuery": {
+		"FieldPositionQuery": {
 			filter:        bson.D{{"v.array.0", bson.D{{"$gte", int32(42)}}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"DotNotationFieldPositionQueryNonArray": {
+		"FieldPositionQueryNonArray": {
 			filter:     bson.D{{"v.document.0", bson.D{{"$lt", int32(42)}}}},
 			resultType: emptyResult,
 		},
-		"DotNotationFieldPositionField": {
+		"FieldPositionField": {
 			filter:     bson.D{{"v.array.2.foo", "bar"}},
 			resultType: emptyResult,
 		},
-		"ElemMatchDoubleTarget": {
+	}
+
+	testQueryCompat(t, testCases)
+}
+
+func TestQueryArrayCompatElemMatch(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]queryCompatTestCase{
+		"DoubleTarget": {
 			filter: bson.D{
 				{"_id", "double"},
 				{"v", bson.D{{"$elemMatch", bson.D{{"$gt", int32(0)}}}}},
 			},
 			resultType: emptyResult,
 		},
-		"ElemMatchGtZero": {
+		"GtZero": {
 			filter:        bson.D{{"v", bson.D{{"$elemMatch", bson.D{{"$gt", int32(0)}}}}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"ElemMatchGtZeroWithTypeArray": {
+		"GtZeroWithTypeArray": {
 			filter: bson.D{
 				{"v", bson.D{
 					{"$elemMatch", bson.D{
@@ -148,7 +130,7 @@ func TestQueryArrayCompat(t *testing.T) {
 			},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"ElemMatchGtZeroWithTypeString": {
+		"GtZeroWithTypeString": {
 			filter: bson.D{
 				{"v", bson.D{
 					{"$elemMatch", bson.D{
@@ -159,7 +141,7 @@ func TestQueryArrayCompat(t *testing.T) {
 			},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"ElemMatchGtLt": {
+		"GtLt": {
 			filter: bson.D{
 				{"v", bson.D{
 					{"$elemMatch", bson.D{
@@ -170,53 +152,107 @@ func TestQueryArrayCompat(t *testing.T) {
 			},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"EqualityOne": {
+	}
+
+	testQueryCompat(t, testCases)
+}
+
+func TestQueryArrayCompatEquality(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]queryCompatTestCase{
+		"One": {
 			filter:        bson.D{{"v", bson.A{int32(42)}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"EqualityTwo": {
+		"Two": {
 			filter:     bson.D{{"v", bson.A{42, "foo"}}},
 			resultType: emptyResult,
 		},
-		"EqualityThree": {
+		"Three": {
 			filter:        bson.D{{"v", bson.A{int32(42), "foo", nil}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"EqualityThree-reverse": {
+		"Three-reverse": {
 			filter:        bson.D{{"v", bson.A{nil, "foo", int32(42)}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"EqualityEmpty": {
+		"Empty": {
 			filter:        bson.D{{"v", bson.A{}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"EqualityNull": {
+		"Null": {
 			filter:        bson.D{{"v", bson.A{nil}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"SizeFloat64": {
-			filter:        bson.D{{"v", bson.D{{"$size", float64(2)}}}},
+	}
+
+	testQueryCompat(t, testCases)
+}
+
+func TestQueryArrayCompatAll(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]queryCompatTestCase{
+		"String": {
+			filter:        bson.D{{"v", bson.D{{"$all", bson.A{"foo"}}}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"SizeInt32": {
-			filter:        bson.D{{"v", bson.D{{"$size", int32(2)}}}},
+		"StringRepeated": {
+			filter:        bson.D{{"v", bson.D{{"$all", bson.A{"foo", "foo", "foo"}}}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"SizeInt64": {
-			filter:        bson.D{{"v", bson.D{{"$size", int64(2)}}}},
+		"StringEmpty": {
+			filter:        bson.D{{"v", bson.D{{"$all", bson.A{""}}}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"SizeInvalidUse": {
-			filter:     bson.D{{"$size", 2}},
+		"Whole": {
+			filter:        bson.D{{"v", bson.D{{"$all", bson.A{int32(42)}}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"WholeNotFound": {
+			filter:     bson.D{{"v", bson.D{{"$all", bson.A{int32(44)}}}}},
 			resultType: emptyResult,
 		},
-		"SizeNotFound": {
-			filter:     bson.D{{"v", bson.D{{"$size", 4}}}},
+		"Zero": {
+			filter:        bson.D{{"v", bson.D{{"$all", bson.A{math.Copysign(0, +1)}}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"Double": {
+			filter:        bson.D{{"v", bson.D{{"$all", bson.A{42.13}}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"DoubleMax": {
+			filter:        bson.D{{"v", bson.D{{"$all", bson.A{math.MaxFloat64}}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"DoubleMin": {
+			filter:        bson.D{{"v", bson.D{{"$all", bson.A{math.SmallestNonzeroFloat64}}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"MultiAll": {
+			filter:        bson.D{{"v", bson.D{{"$all", bson.A{"foo", 42}}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"MultiAllWithNil": {
+			filter:        bson.D{{"v", bson.D{{"$all", bson.A{"foo", nil}}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"Empty": {
+			filter:     bson.D{{"v", bson.D{{"$all", bson.A{}}}}},
 			resultType: emptyResult,
 		},
-		"SizeZero": {
-			filter:        bson.D{{"v", bson.D{{"$size", 0}}}},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		"NotFound": {
+			filter:     bson.D{{"v", bson.D{{"$all", bson.A{"hello"}}}}},
+			resultType: emptyResult,
+		},
+		"$allNeedsAnArrayInt": {
+			filter:     bson.D{{"v", bson.D{{"$all", 1}}}},
+			resultType: emptyResult,
+		},
+		"$allNeedsAnArrayNil": {
+			filter:     bson.D{{"v", bson.D{{"$all", nil}}}},
+			resultType: emptyResult,
 		},
 	}
 

--- a/integration/query_array_compat_test.go
+++ b/integration/query_array_compat_test.go
@@ -1,0 +1,260 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"math"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestQueryArrayCompatSize(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]queryCompatTestCase{
+		"float64": {
+			filter:        bson.D{{"v", bson.D{{"$size", float64(2)}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"int32": {
+			filter:        bson.D{{"v", bson.D{{"$size", int32(2)}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"int64": {
+			filter:        bson.D{{"v", bson.D{{"$size", int64(2)}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"InvalidUse": {
+			filter:     bson.D{{"$size", 2}},
+			resultType: emptyResult,
+		},
+		"NotFound": {
+			filter:     bson.D{{"v", bson.D{{"$size", 4}}}},
+			resultType: emptyResult,
+		},
+		"Zero": {
+			filter:        bson.D{{"v", bson.D{{"$size", 0}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+	}
+
+	testQueryCompat(t, testCases)
+}
+
+func TestQueryArrayCompatDotNotation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]queryCompatTestCase{
+		"PositionIndexGreaterThanArrayLength": {
+			filter:     bson.D{{"v.5", bson.D{{"$type", "double"}}}},
+			resultType: emptyResult,
+		},
+		"PositionIndexAtTheEndOfArray": {
+			filter:        bson.D{{"v.1", bson.D{{"$type", "double"}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"PositionTypeNull": {
+			filter:        bson.D{{"v.1", bson.D{{"$type", "double"}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"PositionRegex": {
+			filter:        bson.D{{"v.1", primitive.Regex{Pattern: "foo"}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"NoSuchFieldPosition": {
+			filter:     bson.D{{"v.some.0", bson.A{42}}},
+			resultType: emptyResult,
+		},
+		"Field": {
+			filter:        bson.D{{"v.array", int32(42)}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"FieldPosition": {
+			filter:        bson.D{{"v.array.0", int32(42)}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"FieldPositionQuery": {
+			filter:        bson.D{{"v.array.0", bson.D{{"$gte", int32(42)}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"FieldPositionQueryNonArray": {
+			filter:     bson.D{{"v.document.0", bson.D{{"$lt", int32(42)}}}},
+			resultType: emptyResult,
+		},
+		"FieldPositionField": {
+			filter:     bson.D{{"v.array.2.foo", "bar"}},
+			resultType: emptyResult,
+		},
+	}
+
+	testQueryCompat(t, testCases)
+}
+
+func TestQueryArrayCompatElemMatch(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]queryCompatTestCase{
+		"DoubleTarget": {
+			filter: bson.D{
+				{"_id", "double"},
+				{"v", bson.D{{"$elemMatch", bson.D{{"$gt", int32(0)}}}}},
+			},
+			resultType: emptyResult,
+		},
+		"GtZero": {
+			filter:        bson.D{{"v", bson.D{{"$elemMatch", bson.D{{"$gt", int32(0)}}}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"GtZeroWithTypeArray": {
+			filter: bson.D{
+				{"v", bson.D{
+					{"$elemMatch", bson.D{
+						{"$gt", int32(0)},
+					}},
+					{"$type", "array"},
+				}},
+			},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"GtZeroWithTypeString": {
+			filter: bson.D{
+				{"v", bson.D{
+					{"$elemMatch", bson.D{
+						{"$gt", int32(0)},
+					}},
+					{"$type", "string"},
+				}},
+			},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"GtLt": {
+			filter: bson.D{
+				{"v", bson.D{
+					{"$elemMatch", bson.D{
+						{"$gt", int32(0)},
+						{"$lt", int32(43)},
+					}},
+				}},
+			},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+	}
+
+	testQueryCompat(t, testCases)
+}
+
+func TestQueryArrayCompatEquality(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]queryCompatTestCase{
+		"One": {
+			filter:        bson.D{{"v", bson.A{int32(42)}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"Two": {
+			filter:     bson.D{{"v", bson.A{42, "foo"}}},
+			resultType: emptyResult,
+		},
+		"Three": {
+			filter:        bson.D{{"v", bson.A{int32(42), "foo", nil}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"Three-reverse": {
+			filter:        bson.D{{"v", bson.A{nil, "foo", int32(42)}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"Empty": {
+			filter:        bson.D{{"v", bson.A{}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"Null": {
+			filter:        bson.D{{"v", bson.A{nil}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+	}
+
+	testQueryCompat(t, testCases)
+}
+
+func TestQueryArrayCompatAll(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]queryCompatTestCase{
+		"String": {
+			filter:        bson.D{{"v", bson.D{{"$all", bson.A{"foo"}}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"StringRepeated": {
+			filter:        bson.D{{"v", bson.D{{"$all", bson.A{"foo", "foo", "foo"}}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"StringEmpty": {
+			filter:        bson.D{{"v", bson.D{{"$all", bson.A{""}}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"Whole": {
+			filter:        bson.D{{"v", bson.D{{"$all", bson.A{int32(42)}}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"WholeNotFound": {
+			filter:     bson.D{{"v", bson.D{{"$all", bson.A{int32(44)}}}}},
+			resultType: emptyResult,
+		},
+		"Zero": {
+			filter:        bson.D{{"v", bson.D{{"$all", bson.A{math.Copysign(0, +1)}}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"Double": {
+			filter:        bson.D{{"v", bson.D{{"$all", bson.A{42.13}}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"DoubleMax": {
+			filter:        bson.D{{"v", bson.D{{"$all", bson.A{math.MaxFloat64}}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"DoubleMin": {
+			filter:        bson.D{{"v", bson.D{{"$all", bson.A{math.SmallestNonzeroFloat64}}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"MultiAll": {
+			filter:        bson.D{{"v", bson.D{{"$all", bson.A{"foo", 42}}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"MultiAllWithNil": {
+			filter:        bson.D{{"v", bson.D{{"$all", bson.A{"foo", nil}}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"Empty": {
+			filter:     bson.D{{"v", bson.D{{"$all", bson.A{}}}}},
+			resultType: emptyResult,
+		},
+		"NotFound": {
+			filter:     bson.D{{"v", bson.D{{"$all", bson.A{"hello"}}}}},
+			resultType: emptyResult,
+		},
+		"$allNeedsAnArrayInt": {
+			filter:     bson.D{{"v", bson.D{{"$all", 1}}}},
+			resultType: emptyResult,
+		},
+		"$allNeedsAnArrayNil": {
+			filter:     bson.D{{"v", bson.D{{"$all", nil}}}},
+			resultType: emptyResult,
+		},
+	}
+
+	testQueryCompat(t, testCases)
+}

--- a/integration/query_array_compat_test.go
+++ b/integration/query_array_compat_test.go
@@ -15,11 +15,11 @@
 package integration
 
 import (
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"math"
 	"testing"
 
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 func TestQueryArrayCompatSize(t *testing.T) {

--- a/integration/query_array_compat_test.go
+++ b/integration/query_array_compat_test.go
@@ -68,7 +68,7 @@ func TestQueryArrayCompatDotNotation(t *testing.T) {
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
 		"PositionTypeNull": {
-			filter:        bson.D{{"v.1", bson.D{{"$type", "double"}}}},
+			filter:        bson.D{{"v.0", bson.D{{"$type", "null"}}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
 		"PositionRegex": {

--- a/integration/query_array_compat_test.go
+++ b/integration/query_array_compat_test.go
@@ -22,227 +22,59 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-func TestQueryArrayCompatSize(t *testing.T) {
+func TestQueryArrayCompat(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]queryCompatTestCase{
-		"float64": {
-			filter:        bson.D{{"v", bson.D{{"$size", float64(2)}}}},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-		"int32": {
-			filter:        bson.D{{"v", bson.D{{"$size", int32(2)}}}},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-		"int64": {
-			filter:        bson.D{{"v", bson.D{{"$size", int64(2)}}}},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-		"InvalidUse": {
-			filter:     bson.D{{"$size", 2}},
-			resultType: emptyResult,
-		},
-		"NotFound": {
-			filter:     bson.D{{"v", bson.D{{"$size", 4}}}},
-			resultType: emptyResult,
-		},
-		"Zero": {
-			filter:        bson.D{{"v", bson.D{{"$size", 0}}}},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-	}
-
-	testQueryCompat(t, testCases)
-}
-
-func TestQueryArrayCompatDotNotation(t *testing.T) {
-	t.Parallel()
-
-	testCases := map[string]queryCompatTestCase{
-		"PositionIndexGreaterThanArrayLength": {
-			filter:     bson.D{{"v.5", bson.D{{"$type", "double"}}}},
-			resultType: emptyResult,
-		},
-		"PositionIndexAtTheEndOfArray": {
-			filter:        bson.D{{"v.1", bson.D{{"$type", "double"}}}},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-		"PositionTypeNull": {
-			filter:        bson.D{{"v.1", bson.D{{"$type", "double"}}}},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-		"PositionRegex": {
-			filter:        bson.D{{"v.1", primitive.Regex{Pattern: "foo"}}},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-		"NoSuchFieldPosition": {
-			filter:     bson.D{{"v.some.0", bson.A{42}}},
-			resultType: emptyResult,
-		},
-		"Field": {
-			filter:        bson.D{{"v.array", int32(42)}},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-		"FieldPosition": {
-			filter:        bson.D{{"v.array.0", int32(42)}},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-		"FieldPositionQuery": {
-			filter:        bson.D{{"v.array.0", bson.D{{"$gte", int32(42)}}}},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-		"FieldPositionQueryNonArray": {
-			filter:     bson.D{{"v.document.0", bson.D{{"$lt", int32(42)}}}},
-			resultType: emptyResult,
-		},
-		"FieldPositionField": {
-			filter:     bson.D{{"v.array.2.foo", "bar"}},
-			resultType: emptyResult,
-		},
-	}
-
-	testQueryCompat(t, testCases)
-}
-
-func TestQueryArrayCompatElemMatch(t *testing.T) {
-	t.Parallel()
-
-	testCases := map[string]queryCompatTestCase{
-		"DoubleTarget": {
-			filter: bson.D{
-				{"_id", "double"},
-				{"v", bson.D{{"$elemMatch", bson.D{{"$gt", int32(0)}}}}},
-			},
-			resultType: emptyResult,
-		},
-		"GtZero": {
-			filter:        bson.D{{"v", bson.D{{"$elemMatch", bson.D{{"$gt", int32(0)}}}}}},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-		"GtZeroWithTypeArray": {
-			filter: bson.D{
-				{"v", bson.D{
-					{"$elemMatch", bson.D{
-						{"$gt", int32(0)},
-					}},
-					{"$type", "array"},
-				}},
-			},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-		"GtZeroWithTypeString": {
-			filter: bson.D{
-				{"v", bson.D{
-					{"$elemMatch", bson.D{
-						{"$gt", int32(0)},
-					}},
-					{"$type", "string"},
-				}},
-			},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-		"GtLt": {
-			filter: bson.D{
-				{"v", bson.D{
-					{"$elemMatch", bson.D{
-						{"$gt", int32(0)},
-						{"$lt", int32(43)},
-					}},
-				}},
-			},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-	}
-
-	testQueryCompat(t, testCases)
-}
-
-func TestQueryArrayCompatEquality(t *testing.T) {
-	t.Parallel()
-
-	testCases := map[string]queryCompatTestCase{
-		"One": {
-			filter:        bson.D{{"v", bson.A{int32(42)}}},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-		"Two": {
-			filter:     bson.D{{"v", bson.A{42, "foo"}}},
-			resultType: emptyResult,
-		},
-		"Three": {
-			filter:        bson.D{{"v", bson.A{int32(42), "foo", nil}}},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-		"Three-reverse": {
-			filter:        bson.D{{"v", bson.A{nil, "foo", int32(42)}}},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-		"Empty": {
-			filter:        bson.D{{"v", bson.A{}}},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-		"Null": {
-			filter:        bson.D{{"v", bson.A{nil}}},
-			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
-		},
-	}
-
-	testQueryCompat(t, testCases)
-}
-
-func TestQueryArrayCompatAll(t *testing.T) {
-	t.Parallel()
-
-	testCases := map[string]queryCompatTestCase{
-		"String": {
+		"AllString": {
 			filter:        bson.D{{"v", bson.D{{"$all", bson.A{"foo"}}}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"StringRepeated": {
+		"AllStringRepeated": {
 			filter:        bson.D{{"v", bson.D{{"$all", bson.A{"foo", "foo", "foo"}}}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"StringEmpty": {
+		"AllStringEmpty": {
 			filter:        bson.D{{"v", bson.D{{"$all", bson.A{""}}}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"Whole": {
+		"AllWhole": {
 			filter:        bson.D{{"v", bson.D{{"$all", bson.A{int32(42)}}}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"WholeNotFound": {
+		"AllWholeNotFound": {
 			filter:     bson.D{{"v", bson.D{{"$all", bson.A{int32(44)}}}}},
 			resultType: emptyResult,
 		},
-		"Zero": {
+		"AllZero": {
 			filter:        bson.D{{"v", bson.D{{"$all", bson.A{math.Copysign(0, +1)}}}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"Double": {
+		"AllDouble": {
 			filter:        bson.D{{"v", bson.D{{"$all", bson.A{42.13}}}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"DoubleMax": {
+		"AllDoubleMax": {
 			filter:        bson.D{{"v", bson.D{{"$all", bson.A{math.MaxFloat64}}}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"DoubleMin": {
+		"AllDoubleMin": {
 			filter:        bson.D{{"v", bson.D{{"$all", bson.A{math.SmallestNonzeroFloat64}}}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"MultiAll": {
+		"AllMultiAll": {
 			filter:        bson.D{{"v", bson.D{{"$all", bson.A{"foo", 42}}}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"MultiAllWithNil": {
+		"AllMultiAllWithNil": {
 			filter:        bson.D{{"v", bson.D{{"$all", bson.A{"foo", nil}}}}},
 			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
-		"Empty": {
+		"AllEmpty": {
 			filter:     bson.D{{"v", bson.D{{"$all", bson.A{}}}}},
 			resultType: emptyResult,
 		},
-		"NotFound": {
+		"AllNotFound": {
 			filter:     bson.D{{"v", bson.D{{"$all", bson.A{"hello"}}}}},
 			resultType: emptyResult,
 		},
@@ -253,6 +85,138 @@ func TestQueryArrayCompatAll(t *testing.T) {
 		"$allNeedsAnArrayNil": {
 			filter:     bson.D{{"v", bson.D{{"$all", nil}}}},
 			resultType: emptyResult,
+		},
+		"DotNotationPositionIndexGreaterThanArrayLength": {
+			filter:     bson.D{{"v.5", bson.D{{"$type", "double"}}}},
+			resultType: emptyResult,
+		},
+		"DotNotationPositionIndexAtTheEndOfArray": {
+			filter:        bson.D{{"v.1", bson.D{{"$type", "double"}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"DotNotationPositionTypeNull": {
+			filter:        bson.D{{"v.1", bson.D{{"$type", "double"}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"DotNotationPositionRegex": {
+			filter:        bson.D{{"v.1", primitive.Regex{Pattern: "foo"}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"DotNotationNoSuchFieldPosition": {
+			filter:     bson.D{{"v.some.0", bson.A{42}}},
+			resultType: emptyResult,
+		},
+		"DotNotationField": {
+			filter:        bson.D{{"v.array", int32(42)}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"DotNotationFieldPosition": {
+			filter:        bson.D{{"v.array.0", int32(42)}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"DotNotationFieldPositionQuery": {
+			filter:        bson.D{{"v.array.0", bson.D{{"$gte", int32(42)}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"DotNotationFieldPositionQueryNonArray": {
+			filter:     bson.D{{"v.document.0", bson.D{{"$lt", int32(42)}}}},
+			resultType: emptyResult,
+		},
+		"DotNotationFieldPositionField": {
+			filter:     bson.D{{"v.array.2.foo", "bar"}},
+			resultType: emptyResult,
+		},
+		"ElemMatchDoubleTarget": {
+			filter: bson.D{
+				{"_id", "double"},
+				{"v", bson.D{{"$elemMatch", bson.D{{"$gt", int32(0)}}}}},
+			},
+			resultType: emptyResult,
+		},
+		"ElemMatchGtZero": {
+			filter:        bson.D{{"v", bson.D{{"$elemMatch", bson.D{{"$gt", int32(0)}}}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"ElemMatchGtZeroWithTypeArray": {
+			filter: bson.D{
+				{"v", bson.D{
+					{"$elemMatch", bson.D{
+						{"$gt", int32(0)},
+					}},
+					{"$type", "array"},
+				}},
+			},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"ElemMatchGtZeroWithTypeString": {
+			filter: bson.D{
+				{"v", bson.D{
+					{"$elemMatch", bson.D{
+						{"$gt", int32(0)},
+					}},
+					{"$type", "string"},
+				}},
+			},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"ElemMatchGtLt": {
+			filter: bson.D{
+				{"v", bson.D{
+					{"$elemMatch", bson.D{
+						{"$gt", int32(0)},
+						{"$lt", int32(43)},
+					}},
+				}},
+			},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"EqualityOne": {
+			filter:        bson.D{{"v", bson.A{int32(42)}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"EqualityTwo": {
+			filter:     bson.D{{"v", bson.A{42, "foo"}}},
+			resultType: emptyResult,
+		},
+		"EqualityThree": {
+			filter:        bson.D{{"v", bson.A{int32(42), "foo", nil}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"EqualityThree-reverse": {
+			filter:        bson.D{{"v", bson.A{nil, "foo", int32(42)}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"EqualityEmpty": {
+			filter:        bson.D{{"v", bson.A{}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"EqualityNull": {
+			filter:        bson.D{{"v", bson.A{nil}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"SizeFloat64": {
+			filter:        bson.D{{"v", bson.D{{"$size", float64(2)}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"SizeInt32": {
+			filter:        bson.D{{"v", bson.D{{"$size", int32(2)}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"SizeInt64": {
+			filter:        bson.D{{"v", bson.D{{"$size", int64(2)}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
+		},
+		"SizeInvalidUse": {
+			filter:     bson.D{{"$size", 2}},
+			resultType: emptyResult,
+		},
+		"SizeNotFound": {
+			filter:     bson.D{{"v", bson.D{{"$size", 4}}}},
+			resultType: emptyResult,
+		},
+		"SizeZero": {
+			filter:        bson.D{{"v", bson.D{{"$size", 0}}}},
+			skipForTigris: "https://github.com/FerretDB/FerretDB/issues/908",
 		},
 	}
 

--- a/integration/query_array_test.go
+++ b/integration/query_array_test.go
@@ -247,6 +247,8 @@ func TestQueryArrayAll(t *testing.T) {
 	// Insert additional data to check more complicated cases:
 	// - a longer array of ints;
 	// - a field is called differently and needs to be found with the {$all: [null]} case.
+	// TODO Add "many-integers" to shareddata.Composites once more
+	// query tests are moved to compat, then move remaining tests to compat.
 	_, err := collection.InsertMany(ctx, []any{
 		bson.D{{"_id", "many-integers"}, {"customField", bson.A{42, 43, 45}}},
 	})

--- a/integration/query_array_test.go
+++ b/integration/query_array_test.go
@@ -50,31 +50,12 @@ func TestQueryArraySize(t *testing.T) {
 		expectedIDs []any
 		err         *mongo.CommandError
 	}{
-		"int32": {
-			filter:      bson.D{{"v", bson.D{{"$size", int32(2)}}}},
-			expectedIDs: []any{"array-two"},
-		},
-		"int64": {
-			filter:      bson.D{{"v", bson.D{{"$size", int64(2)}}}},
-			expectedIDs: []any{"array-two"},
-		},
-		"float64": {
-			filter:      bson.D{{"v", bson.D{{"$size", float64(2)}}}},
-			expectedIDs: []any{"array-two"},
-		},
-		"Zero": {
-			filter:      bson.D{{"v", bson.D{{"$size", 0}}}},
-			expectedIDs: []any{"array-empty"},
-		},
 		"NegativeZero": {
 			filter:      bson.D{{"v", bson.D{{"$size", math.Copysign(0, -1)}}}},
 			expectedIDs: []any{"array-empty"},
 		},
-		"NotFound": {
-			filter:      bson.D{{"v", bson.D{{"$size", 4}}}},
-			expectedIDs: []any{},
-		},
 		"InvalidType": {
+			// TODO: move to compat https://github.com/FerretDB/FerretDB/issues/1539
 			filter: bson.D{{"v", bson.D{{"$size", bson.D{{"$gt", 1}}}}}},
 			err: &mongo.CommandError{
 				Code:    2,
@@ -83,6 +64,7 @@ func TestQueryArraySize(t *testing.T) {
 			},
 		},
 		"NotWhole": {
+			// TODO: move to compat https://github.com/FerretDB/FerretDB/issues/1539
 			filter: bson.D{{"v", bson.D{{"$size", 2.1}}}},
 			err: &mongo.CommandError{
 				Code:    2,
@@ -99,6 +81,7 @@ func TestQueryArraySize(t *testing.T) {
 			},
 		},
 		"Infinity": {
+			// TODO: move to compat https://github.com/FerretDB/FerretDB/issues/1539
 			filter: bson.D{{"v", bson.D{{"$size", math.Inf(+1)}}}},
 			err: &mongo.CommandError{
 				Code:    2,
@@ -107,20 +90,12 @@ func TestQueryArraySize(t *testing.T) {
 			},
 		},
 		"Negative": {
+			// TODO: move to compat https://github.com/FerretDB/FerretDB/issues/1539
 			filter: bson.D{{"v", bson.D{{"$size", -1}}}},
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",
 				Message: `Failed to parse $size. Expected a non-negative number in: $size: -1`,
-			},
-		},
-		"InvalidUse": {
-			filter: bson.D{{"$size", 2}},
-			err: &mongo.CommandError{
-				Code: 2,
-				Name: "BadValue",
-				Message: `unknown top level operator: $size. ` +
-					`If you have a field name that starts with a '$' symbol, consider using $getField or $setField.`,
 			},
 		},
 	} {
@@ -155,50 +130,8 @@ func TestQueryArrayDotNotation(t *testing.T) {
 		expectedIDs []any
 		err         *mongo.CommandError
 	}{
-		"PositionIndexGreaterThanArrayLength": {
-			filter:      bson.D{{"v.5", bson.D{{"$type", "double"}}}},
-			expectedIDs: []any{},
-		},
-		"PositionIndexAtTheEndOfArray": {
-			filter:      bson.D{{"v.1", bson.D{{"$type", "double"}}}},
-			expectedIDs: []any{"array-two"},
-		},
-
-		"PositionTypeNull": {
-			filter:      bson.D{{"v.0", bson.D{{"$type", "null"}}}},
-			expectedIDs: []any{"array-null", "array-three-reverse"},
-		},
-		"PositionRegex": {
-			filter:      bson.D{{"v.1", primitive.Regex{Pattern: "foo"}}},
-			expectedIDs: []any{"array-three", "array-three-reverse"},
-		},
-
-		"NoSuchFieldPosition": {
-			filter:      bson.D{{"v.some.0", bson.A{42}}},
-			expectedIDs: []any{},
-		},
-		"Field": {
-			filter:      bson.D{{"v.array", int32(42)}},
-			expectedIDs: []any{"document-composite", "document-composite-reverse"},
-		},
-		"FieldPosition": {
-			filter:      bson.D{{"v.array.0", int32(42)}},
-			expectedIDs: []any{"document-composite", "document-composite-reverse"},
-		},
-		"FieldPositionQuery": {
-			filter:      bson.D{{"v.array.0", bson.D{{"$gte", int32(42)}}}},
-			expectedIDs: []any{"document-composite", "document-composite-reverse"},
-		},
-		"FieldPositionQueryNonArray": {
-			filter:      bson.D{{"v.document.0", bson.D{{"$lt", int32(42)}}}},
-			expectedIDs: []any{},
-		},
-		"FieldPositionField": {
-			filter:      bson.D{{"v.array.2.foo", "bar"}},
-			expectedIDs: []any{},
-		},
-
 		"FieldPositionQueryRegex": {
+			// TODO: move to compat https://github.com/FerretDB/FerretDB/issues/1540
 			filter: bson.D{{"v.array.0", bson.D{{"$lt", primitive.Regex{Pattern: "^$"}}}}},
 			err: &mongo.CommandError{
 				Code:    2,
@@ -238,52 +171,8 @@ func TestQueryElemMatchOperator(t *testing.T) {
 		expectedIDs []any
 		err         *mongo.CommandError
 	}{
-		"DoubleTarget": {
-			filter: bson.D{
-				{"_id", "double"},
-				{"v", bson.D{{"$elemMatch", bson.D{{"$gt", int32(0)}}}}},
-			},
-			expectedIDs: []any{},
-		},
-		"GtZero": {
-			filter:      bson.D{{"v", bson.D{{"$elemMatch", bson.D{{"$gt", int32(0)}}}}}},
-			expectedIDs: []any{"array", "array-three", "array-three-reverse", "array-two"},
-		},
-		"GtZeroWithTypeArray": {
-			filter: bson.D{
-				{"v", bson.D{
-					{"$elemMatch", bson.D{
-						{"$gt", int32(0)},
-					}},
-					{"$type", "array"},
-				}},
-			},
-			expectedIDs: []any{"array", "array-three", "array-three-reverse", "array-two"},
-		},
-		"GtZeroWithTypeString": {
-			filter: bson.D{
-				{"v", bson.D{
-					{"$elemMatch", bson.D{
-						{"$gt", int32(0)},
-					}},
-					{"$type", "string"},
-				}},
-			},
-			expectedIDs: []any{"array-three", "array-three-reverse"},
-		},
-		"GtLt": {
-			filter: bson.D{
-				{"v", bson.D{
-					{"$elemMatch", bson.D{
-						{"$gt", int32(0)},
-						{"$lt", int32(43)},
-					}},
-				}},
-			},
-			expectedIDs: []any{"array", "array-three", "array-three-reverse", "array-two"},
-		},
-
 		"UnexpectedFilterString": {
+			// TODO move to compat https://github.com/FerretDB/FerretDB/issues/1541
 			filter: bson.D{{"v", bson.D{{"$elemMatch", "foo"}}}},
 			err: &mongo.CommandError{
 				Code:    2,
@@ -292,6 +181,7 @@ func TestQueryElemMatchOperator(t *testing.T) {
 			},
 		},
 		"WhereInsideElemMatch": {
+			// TODO move to compat https://github.com/FerretDB/FerretDB/issues/1542
 			filter: bson.D{{"v", bson.D{{"$elemMatch", bson.D{{"$where", "123"}}}}}},
 			err: &mongo.CommandError{
 				Code:    2,
@@ -300,6 +190,7 @@ func TestQueryElemMatchOperator(t *testing.T) {
 			},
 		},
 		"TextInsideElemMatch": {
+			// TODO move to compat https://github.com/FerretDB/FerretDB/issues/1542
 			filter: bson.D{{"v", bson.D{{"$elemMatch", bson.D{{"$text", "123"}}}}}},
 			err: &mongo.CommandError{
 				Code:    2,
@@ -308,6 +199,7 @@ func TestQueryElemMatchOperator(t *testing.T) {
 			},
 		},
 		"GtField": {
+			// TODO move to compat https://github.com/FerretDB/FerretDB/issues/1541
 			filter: bson.D{{"v", bson.D{
 				{
 					"$elemMatch",
@@ -344,57 +236,6 @@ func TestQueryElemMatchOperator(t *testing.T) {
 	}
 }
 
-func TestArrayEquality(t *testing.T) {
-	setup.SkipForTigris(t)
-
-	t.Parallel()
-	ctx, collection := setup.Setup(t, shareddata.Composites)
-
-	for name, tc := range map[string]struct {
-		array       bson.A
-		expectedIDs []any
-	}{
-		"One": {
-			array:       bson.A{int32(42)},
-			expectedIDs: []any{"array"},
-		},
-		"Two": {
-			array:       bson.A{42, "foo"},
-			expectedIDs: []any{},
-		},
-		"Three": {
-			array:       bson.A{int32(42), "foo", nil},
-			expectedIDs: []any{"array-three"},
-		},
-		"Three-reverse": {
-			array:       bson.A{nil, "foo", int32(42)},
-			expectedIDs: []any{"array-three-reverse"},
-		},
-		"Empty": {
-			array:       bson.A{},
-			expectedIDs: []any{"array-empty"},
-		},
-		"Null": {
-			array:       bson.A{nil},
-			expectedIDs: []any{"array-null"},
-		},
-	} {
-		name, tc := name, tc
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			filter := bson.D{{"v", tc.array}}
-			cursor, err := collection.Find(ctx, filter, options.Find().SetSort(bson.D{{"_id", 1}}))
-			require.NoError(t, err)
-
-			var actual []bson.D
-			err = cursor.All(ctx, &actual)
-			require.NoError(t, err)
-			assert.Equal(t, tc.expectedIDs, CollectIDs(t, actual))
-		})
-	}
-}
-
 // TestQueryArrayAll covers the case where the $all operator is used on an array or scalar.
 func TestQueryArrayAll(t *testing.T) {
 	setup.SkipForTigris(t)
@@ -416,28 +257,6 @@ func TestQueryArrayAll(t *testing.T) {
 		expectedIDs []any
 		expectedErr *mongo.CommandError
 	}{
-		"String": {
-			filter:      bson.D{{"v", bson.D{{"$all", bson.A{"foo"}}}}},
-			expectedIDs: []any{"array-three", "array-three-reverse", "string"},
-			expectedErr: nil,
-		},
-		"StringRepeated": {
-			filter:      bson.D{{"v", bson.D{{"$all", bson.A{"foo", "foo", "foo"}}}}},
-			expectedIDs: []any{"array-three", "array-three-reverse", "string"},
-			expectedErr: nil,
-		},
-		"StringEmpty": {
-			filter:      bson.D{{"v", bson.D{{"$all", bson.A{""}}}}},
-			expectedIDs: []any{"string-empty"},
-			expectedErr: nil,
-		},
-		"Whole": {
-			filter: bson.D{{"v", bson.D{{"$all", bson.A{int32(42)}}}}},
-			expectedIDs: []any{
-				"array", "array-three", "array-three-reverse", "double-whole", "int32", "int64",
-			},
-			expectedErr: nil,
-		},
 		"WholeInTheMiddle": {
 			filter:      bson.D{{"customField", bson.D{{"$all", bson.A{int32(43)}}}}},
 			expectedIDs: []any{"many-integers"},
@@ -445,30 +264,6 @@ func TestQueryArrayAll(t *testing.T) {
 		"WholeTwoRepeated": {
 			filter:      bson.D{{"customField", bson.D{{"$all", bson.A{int32(42), int32(43), int32(43), int32(42)}}}}},
 			expectedIDs: []any{"many-integers"},
-		},
-		"WholeNotFound": {
-			filter:      bson.D{{"v", bson.D{{"$all", bson.A{int32(44)}}}}},
-			expectedIDs: []any{},
-		},
-		"Zero": {
-			filter:      bson.D{{"v", bson.D{{"$all", bson.A{math.Copysign(0, +1)}}}}},
-			expectedIDs: []any{"double-negative-zero", "double-zero", "int32-zero", "int64-zero"},
-			expectedErr: nil,
-		},
-		"Double": {
-			filter:      bson.D{{"v", bson.D{{"$all", bson.A{42.13}}}}},
-			expectedIDs: []any{"array-two", "double"},
-			expectedErr: nil,
-		},
-		"DoubleMax": {
-			filter:      bson.D{{"v", bson.D{{"$all", bson.A{math.MaxFloat64}}}}},
-			expectedIDs: []any{"double-max"},
-			expectedErr: nil,
-		},
-		"DoubleMin": {
-			filter:      bson.D{{"v", bson.D{{"$all", bson.A{math.SmallestNonzeroFloat64}}}}},
-			expectedIDs: []any{"double-smallest"},
-			expectedErr: nil,
 		},
 		"Nil": {
 			filter: bson.D{{"v", bson.D{{"$all", bson.A{nil}}}}},
@@ -484,56 +279,14 @@ func TestQueryArrayAll(t *testing.T) {
 			},
 			expectedErr: nil,
 		},
-
-		"MultiAll": {
-			filter:      bson.D{{"v", bson.D{{"$all", bson.A{"foo", 42}}}}},
-			expectedIDs: []any{"array-three", "array-three-reverse"},
-			expectedErr: nil,
-		},
-		"MultiAllWithNil": {
-			filter:      bson.D{{"v", bson.D{{"$all", bson.A{"foo", nil}}}}},
-			expectedIDs: []any{"array-three", "array-three-reverse"},
-			expectedErr: nil,
-		},
-
-		"Empty": {
-			filter:      bson.D{{"v", bson.D{{"$all", bson.A{}}}}},
-			expectedIDs: []any{},
-			expectedErr: nil,
-		},
-
-		"NotFound": {
-			filter:      bson.D{{"v", bson.D{{"$all", bson.A{"hello"}}}}},
-			expectedIDs: []any{},
-			expectedErr: nil,
-		},
-
 		"NaN": {
 			filter:      bson.D{{"v", bson.D{{"$all", bson.A{math.NaN()}}}}},
 			expectedIDs: []any{"array-two", "double-nan"},
 			expectedErr: nil,
 		},
 
-		"$allNeedsAnArrayInt": {
-			filter:      bson.D{{"v", bson.D{{"$all", 1}}}},
-			expectedIDs: nil,
-			expectedErr: &mongo.CommandError{
-				Code:    2,
-				Message: "$all needs an array",
-				Name:    "BadValue",
-			},
-		},
 		"$allNeedsAnArrayNan": {
 			filter:      bson.D{{"v", bson.D{{"$all", math.NaN()}}}},
-			expectedIDs: nil,
-			expectedErr: &mongo.CommandError{
-				Code:    2,
-				Message: "$all needs an array",
-				Name:    "BadValue",
-			},
-		},
-		"$allNeedsAnArrayNil": {
-			filter:      bson.D{{"v", bson.D{{"$all", nil}}}},
 			expectedIDs: nil,
 			expectedErr: &mongo.CommandError{
 				Code:    2,

--- a/integration/query_compat_test.go
+++ b/integration/query_compat_test.go
@@ -113,6 +113,21 @@ func TestQueryCompat(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]queryCompatTestCase{
+		"BadSortValue": {
+			filter:     bson.D{},
+			sort:       bson.D{{"v", 11}},
+			resultType: emptyResult,
+		},
+		"BadSortZeroValue": {
+			filter:     bson.D{},
+			sort:       bson.D{{"v", 0}},
+			resultType: emptyResult,
+		},
+		"BadSortNullValue": {
+			filter:     bson.D{},
+			sort:       bson.D{{"v", nil}},
+			resultType: emptyResult,
+		},
 		"Empty": {
 			filter: bson.D{},
 		},
@@ -121,6 +136,10 @@ func TestQueryCompat(t *testing.T) {
 		},
 		"IDObjectID": {
 			filter: bson.D{{"_id", primitive.NilObjectID}},
+		},
+		"UnknownFilterOperator": {
+			filter:     bson.D{{"v", bson.D{{"$someUnknownOperator", 42}}}},
+			resultType: emptyResult,
 		},
 	}
 

--- a/integration/query_compat_test.go
+++ b/integration/query_compat_test.go
@@ -28,9 +28,10 @@ import (
 
 // queryCompatTestCase describes query compatibility test case.
 type queryCompatTestCase struct {
-	filter     bson.D                   // required
-	sort       bson.D                   // defaults to `bson.D{{"_id", 1}}`
-	resultType compatTestCaseResultType // defaults to nonEmptyResult
+	filter        bson.D                   // required
+	sort          bson.D                   // defaults to `bson.D{{"_id", 1}}`
+	resultType    compatTestCaseResultType // defaults to nonEmptyResult
+	skipForTigris string                   // skips test for Tigris if non-empty
 }
 
 // testQueryCompat tests query compatibility test cases.
@@ -45,6 +46,10 @@ func testQueryCompat(t *testing.T, testCases map[string]queryCompatTestCase) {
 		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Helper()
+
+			if tc.skipForTigris != "" {
+				setup.SkipForTigrisWithReason(t, tc.skipForTigris)
+			}
 
 			t.Parallel()
 

--- a/integration/query_test.go
+++ b/integration/query_test.go
@@ -30,18 +30,6 @@ import (
 	"github.com/FerretDB/FerretDB/integration/shareddata"
 )
 
-func TestQueryUnknownFilterOperator(t *testing.T) {
-	setup.SkipForTigris(t)
-
-	t.Parallel()
-	ctx, collection := setup.Setup(t, shareddata.Scalars)
-
-	filter := bson.D{{"v", bson.D{{"$someUnknownOperator", 42}}}}
-	errExpected := mongo.CommandError{Code: 2, Name: "BadValue", Message: "unknown operator: $someUnknownOperator"}
-	_, err := collection.Find(ctx, filter)
-	AssertEqualError(t, errExpected, err)
-}
-
 func TestQuerySort(t *testing.T) {
 	t.Skip("https://github.com/FerretDB/FerretDB/issues/457")
 
@@ -257,30 +245,6 @@ func TestQuerySortValue(t *testing.T) {
 				"int64-min",
 				"double-nan",
 				"null",
-			},
-		},
-		"BadSortValue": {
-			sort: bson.D{{"v", 11}},
-			err: &mongo.CommandError{
-				Code:    15975,
-				Name:    "Location15975",
-				Message: "$sort key ordering must be 1 (for ascending) or -1 (for descending)",
-			},
-		},
-		"BadSortZeroValue": {
-			sort: bson.D{{"v", 0}},
-			err: &mongo.CommandError{
-				Code:    15975,
-				Name:    "Location15975",
-				Message: "$sort key ordering must be 1 (for ascending) or -1 (for descending)",
-			},
-		},
-		"BadSortNullValue": {
-			sort: bson.D{{"v", nil}},
-			err: &mongo.CommandError{
-				Code:    15974,
-				Name:    "Location15974",
-				Message: "Illegal key in $sort specification: v: null",
 			},
 		},
 	} {


### PR DESCRIPTION
# Description

Closes #1450.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->
This is one of many PR to move query integration tests to compat tests. This PR moves array query tests to compat test.
The tests that were not moved were
* Requires additional test Bson in shareddata, and currently adding that is too painful because too many tests are failing. This will be done once more tests were moved to compat, that will make it easier.
* Nan and Negative Zero because they will be removed by https://github.com/FerretDB/FerretDB/pull/1401
* Others that were not moved have TODO with issue link attached.
## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added tests for new functionality or bugfixes.
* [ ] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
