### PR TITLE
Make default telemetry state a bit more clear

### DIFF
--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -58,7 +58,7 @@ var cli struct {
 
 	MetricsUUID bool `default:"false" help:"Add instance UUID to all metrics."`
 
-	Telemetry telemetry.Flag `default:"" help:"Enable or disable basic telemetry. See https://beacon.ferretdb.io."`
+	Telemetry telemetry.Flag `default:"undecided" help:"Enable or disable basic telemetry. See https://beacon.ferretdb.io."`
 
 	Handler string `default:"pg" help:"${help_handler}"`
 


### PR DESCRIPTION
# Description

Before:

```
--telemetry=                                                      Enable or disable basic telemetry. See https://beacon.ferretdb.io ($FERRETDB_TELEMETRY).
```

After:

```
--telemetry=undecided                                             Enable or disable basic telemetry. See https://beacon.ferretdb.io ($FERRETDB_TELEMETRY).
```

## Readiness checklist

* [ ] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
