### PR TITLE
Do not record partial files

### DIFF
--- a/internal/clientconn/listener.go
+++ b/internal/clientconn/listener.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"runtime/pprof"
 	"sync"
@@ -31,6 +30,7 @@ import (
 	"github.com/FerretDB/FerretDB/internal/handlers"
 	"github.com/FerretDB/FerretDB/internal/util/ctxutil"
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
+	"github.com/FerretDB/FerretDB/internal/wire"
 )
 
 // Listener accepts incoming client connections.
@@ -196,7 +196,7 @@ func acceptLoop(ctx context.Context, listener net.Listener, wg *sync.WaitGroup, 
 			logger.Info("Connection started", zap.String("conn", connID))
 
 			e = conn.run(runCtx)
-			if errors.Is(e, io.EOF) {
+			if errors.Is(e, wire.ErrZeroRead) {
 				logger.Info("Connection stopped", zap.String("conn", connID))
 			} else {
 				logger.Warn("Connection stopped", zap.String("conn", connID), zap.Error(e))

--- a/internal/wire/msg_body.go
+++ b/internal/wire/msg_body.go
@@ -17,6 +17,7 @@ package wire
 import (
 	"bufio"
 	"encoding"
+	"errors"
 	"fmt"
 	"io"
 
@@ -35,13 +36,16 @@ type MsgBody interface {
 
 //go-sumtype:decl MsgBody
 
+// ErrZeroRead is returned when zero bytes was read from connection,
+// indicating that connection was closed by the client.
+var ErrZeroRead = errors.New("zero bytes read")
+
 // ReadMessage reads from reader and returns wire header and body.
+//
+// Error is (possibly wrapped) ErrZeroRead if zero bytes was read.
 func ReadMessage(r *bufio.Reader) (*MsgHeader, MsgBody, error) {
 	var header MsgHeader
 	if err := header.readFrom(r); err != nil {
-		if err == io.EOF {
-			return nil, nil, err
-		}
 		return nil, nil, lazyerrors.Error(err)
 	}
 

--- a/internal/wire/msg_header.go
+++ b/internal/wire/msg_header.go
@@ -79,11 +79,14 @@ const (
 	MaxMsgLen = 48000000
 )
 
+// readFrom reads header.
+//
+// Error is ErrZeroRead if zero bytes was read.
 func (msg *MsgHeader) readFrom(r *bufio.Reader) error {
 	b := make([]byte, MsgHeaderLen)
 	if n, err := io.ReadFull(r, b); err != nil {
 		if err == io.EOF {
-			return err
+			return ErrZeroRead
 		}
 		return lazyerrors.Errorf("expected %d, read %d: %w", len(b), n, err)
 	}

--- a/internal/wire/records_test.go
+++ b/internal/wire/records_test.go
@@ -17,7 +17,6 @@ package wire
 import (
 	"bufio"
 	"errors"
-	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -68,11 +67,9 @@ func loadRecords(recordsPath string) ([]testCase, error) {
 
 		for {
 			header, body, err := ReadMessage(r)
-
-			if errors.Is(err, io.EOF) {
+			if errors.Is(err, ErrZeroRead) {
 				break
 			}
-
 			if err != nil {
 				return nil, lazyerrors.Errorf("%s: %w", path, err)
 			}


### PR DESCRIPTION
# Description

Ctrl+C can be used safely now.

## Readiness checklist

* [ ] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [x] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
