### PR TITLE
Downgrade min wire protocol version to 13 / 5.0

### DIFF
--- a/integration/commands_replication_test.go
+++ b/integration/commands_replication_test.go
@@ -56,7 +56,7 @@ func TestCommandsReplication(t *testing.T) {
 			delete(m, "maxWireVersion")
 
 			minWireVersion := m["minWireVersion"].(int32)
-			assert.True(t, minWireVersion == 0 || minWireVersion == 14)
+			assert.True(t, minWireVersion == 0 || minWireVersion == 13)
 			delete(m, "minWireVersion")
 
 			expected := bson.M{

--- a/integration/commands_replication_test.go
+++ b/integration/commands_replication_test.go
@@ -24,6 +24,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
 	"github.com/FerretDB/FerretDB/integration/setup"
+	"github.com/FerretDB/FerretDB/internal/handlers/common"
 )
 
 func TestCommandsReplication(t *testing.T) {
@@ -52,11 +53,11 @@ func TestCommandsReplication(t *testing.T) {
 			delete(m, "localTime")
 
 			maxWireVersion := m["maxWireVersion"].(int32)
-			assert.Equal(t, int32(17), maxWireVersion)
+			assert.Equal(t, common.MaxWireVersion, maxWireVersion)
 			delete(m, "maxWireVersion")
 
 			minWireVersion := m["minWireVersion"].(int32)
-			assert.True(t, minWireVersion == 0 || minWireVersion == 13)
+			assert.True(t, minWireVersion == 0 || minWireVersion == common.MinWireVersion)
 			delete(m, "minWireVersion")
 
 			expected := bson.M{

--- a/internal/handlers/common/common.go
+++ b/internal/handlers/common/common.go
@@ -17,7 +17,7 @@ package common
 
 const (
 	// MinWireVersion is the minimal supported wire protocol version.
-	MinWireVersion = int32(14) // 5.1
+	MinWireVersion = int32(13) // 5.0
 
 	// MaxWireVersion is the maximal supported wire protocol version.
 	MaxWireVersion = int32(17)


### PR DESCRIPTION
# Description

Requested by community.

## Readiness checklist

* [ ] I added tests for new functionality or bugfixes.
* [ ] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
