### PR TITLE
Fix `listIndexes` stub

### DIFF
--- a/internal/handlers/pg/msg_listindexes.go
+++ b/internal/handlers/pg/msg_listindexes.go
@@ -51,9 +51,7 @@ func (h *Handler) MsgListIndexes(ctx context.Context, msg *wire.OpMsg) (*wire.Op
 			"cursor", must.NotFail(types.NewDocument(
 				// TODO "ns" field
 				"id", int64(0),
-				"firstBatch", must.NotFail(types.NewArray(
-					firstBatch,
-				)),
+				"firstBatch", firstBatch,
 			)),
 			"ok", float64(1),
 		))},

--- a/internal/handlers/tigris/msg_listindexes.go
+++ b/internal/handlers/tigris/msg_listindexes.go
@@ -51,9 +51,7 @@ func (h *Handler) MsgListIndexes(ctx context.Context, msg *wire.OpMsg) (*wire.Op
 			"cursor", must.NotFail(types.NewDocument(
 				// TODO "ns" field
 				"id", int64(0),
-				"firstBatch", must.NotFail(types.NewArray(
-					firstBatch,
-				)),
+				"firstBatch", firstBatch,
 			)),
 			"ok", float64(1),
 		))},


### PR DESCRIPTION
# Description

There's an array inside the array by accident.

Also: should we send some message in response that this command is only a stub and the output is not relevant becuase we don't support indexes at this moment?

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added tests for new functionality or bugfixes.
* [ ] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
