### PR TITLE
Fix validation for documents with duplicate keys

### DIFF
--- a/internal/types/document_validation.go
+++ b/internal/types/document_validation.go
@@ -66,11 +66,12 @@ func (d *Document) ValidateData() error {
 	d.moveIDToTheFirstIndex()
 
 	keys := d.Keys()
+	values := d.Values()
 
 	duplicateChecker := make(map[string]struct{}, len(keys))
 	var idPresent bool
 
-	for _, key := range keys {
+	for i, key := range keys {
 		// Tests for this case are in `dance`.
 		if !utf8.ValidString(key) {
 			return newValidationError(ErrValidation, fmt.Errorf("invalid key: %q (not a valid UTF-8 string)", key))
@@ -95,7 +96,7 @@ func (d *Document) ValidateData() error {
 			idPresent = true
 		}
 
-		value := must.NotFail(d.Get(key))
+		value := values[i]
 
 		switch v := value.(type) {
 		case *Document:

--- a/internal/types/document_validation_test.go
+++ b/internal/types/document_validation_test.go
@@ -51,6 +51,10 @@ func TestDocumentValidateData(t *testing.T) {
 			doc:    must.NotFail(NewDocument("v.foo", "bar")),
 			reason: errors.New(`invalid key: "v.foo" (key must not contain '.' sign)`),
 		},
+		"DuplicateKeys": {
+			doc:    must.NotFail(NewDocument("_id", "1", "foo", "bar", "foo", "baz")),
+			reason: nil,
+		},
 		"Inf+": {
 			doc:    must.NotFail(NewDocument("v", math.Inf(1))),
 			reason: errors.New(`invalid value: { "v": +Inf } (infinity values are not allowed)`),

--- a/internal/types/document_validation_test.go
+++ b/internal/types/document_validation_test.go
@@ -53,7 +53,7 @@ func TestDocumentValidateData(t *testing.T) {
 		},
 		"DuplicateKeys": {
 			doc:    must.NotFail(NewDocument("_id", "1", "foo", "bar", "foo", "baz")),
-			reason: nil,
+			reason: errors.New(`invalid key: "foo" (duplicate keys are not allowed)`),
 		},
 		"Inf+": {
 			doc:    must.NotFail(NewDocument("v", math.Inf(1))),


### PR DESCRIPTION
# Description

It was wrong to use `types.Document.Get` in validation because `types.Document.Get` can't work with duplicate keys correctly.

Luckily, now `types.Document.Get` panics in case of duplicate keys, so with the help of dance tests, we were able to catch this problem.

In principle, in such cases, we should att unit tests to make sure that the code is covered.


<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [x] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
