### PR TITLE
Replace `docker-compose` with `docker compose`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ You can find a list of good issues for first-time contributors [there](https://g
 
 The supported way of contributing to FerretDB is to modify and run it on the host (Linux, macOS, or Windows)
 with PostgreSQL and other dependencies running inside Docker containers via Docker Compose.
-On Linux, `docker` (with `docker compose` subcommand a.k.a [Compose V2](https://docs.docker.com/compose/compose-v2/),
+On Linux, `docker` (with `docker compose` subcommand a.k.a. [Compose V2](https://docs.docker.com/compose/compose-v2/),
 not old `docker-compose` tool) should be installed on the host.
 On macOS and Windows, [Docker Desktop](https://www.docker.com/products/docker-desktop/) should be used.
 On Windows, it should be [configured to use WSL 2](https://docs.docker.com/desktop/windows/wsl/) without any distro;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,8 @@ You can find a list of good issues for first-time contributors [there](https://g
 
 The supported way of contributing to FerretDB is to modify and run it on the host (Linux, macOS, or Windows)
 with PostgreSQL and other dependencies running inside Docker containers via Docker Compose.
-On Linux, `docker` and `docker-compose` should be installed on the host.
+On Linux, `docker` (with `docker compose` subcommand a.k.a [Compose V2](https://docs.docker.com/compose/compose-v2/),
+not old `docker-compose` tool) should be installed on the host.
 On macOS and Windows, [Docker Desktop](https://www.docker.com/products/docker-desktop/) should be used.
 On Windows, it should be [configured to use WSL 2](https://docs.docker.com/desktop/windows/wsl/) without any distro;
 all commands should be run on the host.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ They are not suitable for most production use-cases because they keep all data i
    `postgres` container runs PostgreSQL that would store data.
    `ferretdb` runs FerretDB.
 
-2. Start services with `docker-compose up -d`.
+2. Start services with `docker compose up -d`.
 
 3. If you have `mongosh` installed, just run it to connect to FerretDB.
    If not, run the following command to run `mongosh` inside the temporary MongoDB container, attaching to the same Docker network:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -72,14 +72,14 @@ tasks:
   env-up-detach:
     cmds:
       - >
-        docker-compose up --always-recreate-deps --force-recreate --remove-orphans --renew-anon-volumes --timeout=0 --detach
-        --build
+        docker compose up --always-recreate-deps --force-recreate --remove-orphans --renew-anon-volumes --timeout=0 --detach
+        --build --pull=always
         {{.SERVICES}}
 
   env-up-detach-offline:
     cmds:
       - >
-        docker-compose up --always-recreate-deps --force-recreate --remove-orphans --renew-anon-volumes --timeout=0 --detach
+        docker compose up --always-recreate-deps --force-recreate --remove-orphans --renew-anon-volumes --timeout=0 --detach
         {{.SERVICES}}
 
   env-setup:
@@ -89,8 +89,8 @@ tasks:
 
   env-logs:
     cmds:
-      - docker-compose ps --all
-      - docker-compose logs --follow
+      - docker compose ps --all
+      - docker compose logs --follow
 
   env-up:
     desc: "Start development environment"
@@ -106,12 +106,12 @@ tasks:
   env-pull:
     desc: "Pull development environment's Docker images"
     cmds:
-      - docker-compose build --pull
+      - docker compose build --pull
 
   env-down:
     desc: "Stop development environment"
     cmds:
-      - docker-compose down --remove-orphans --timeout=0 --volumes
+      - docker compose down --remove-orphans --timeout=0 --volumes
 
   env-data:
     desc: "Fill `test` database with data for experiments"
@@ -291,7 +291,7 @@ tasks:
 
   security-trivy:
     cmds:
-      - docker-compose run --rm trivy filesystem . --ignorefile=./build/.trivyignore --cache-dir=./.cache/trivy --exit-code=1
+      - docker compose run --rm trivy filesystem . --ignorefile=./build/.trivyignore --cache-dir=./.cache/trivy --exit-code=1
 
   godocs:
     desc: "Serve godoc documentation at http://127.0.0.1:6060/pkg/github.com/FerretDB/FerretDB/?m=all"
@@ -301,20 +301,20 @@ tasks:
   psql:
     desc: "Run psql"
     cmds:
-      - docker-compose exec postgres psql -U postgres -d ferretdb
+      - docker compose exec postgres psql -U postgres -d ferretdb
 
   mongosh:
     desc: "Run MongoDB shell (`mongosh`)"
     cmds:
       - >
-        docker-compose exec mongodb mongosh mongodb://host.docker.internal:27017/test?heartbeatFrequencyMS=300000
+        docker compose exec mongodb mongosh mongodb://host.docker.internal:27017/test?heartbeatFrequencyMS=300000
         --verbose --eval 'disableTelemetry()' --shell /mongosh/test.js
 
   mongo:
     desc: "Run legacy `mongo` shell"
     cmds:
       - >
-        docker-compose exec mongodb mongo mongodb://host.docker.internal:27017/test?heartbeatFrequencyMS=300000
+        docker compose exec mongodb mongo mongodb://host.docker.internal:27017/test?heartbeatFrequencyMS=300000
         --verbose
 
   docker-init:
@@ -366,7 +366,7 @@ tasks:
     cmds:
       - ../bin/nfpm{{exeExt}} package --packager=deb --target=deb/ferretdb.deb
       - >
-        docker-compose run --rm debian /bin/sh -c
+        docker compose run --rm debian /bin/sh -c
         'dpkg -i /deb/ferretdb.deb && ferretdb --version'
     env:
       VERSION:
@@ -380,7 +380,7 @@ tasks:
     cmds:
       - ../bin/nfpm{{exeExt}} package --packager=rpm --target=rpm/ferretdb.rpm
       - >
-        docker-compose run --rm centos /bin/sh -c
+        docker compose run --rm centos /bin/sh -c
         'rpm -i /rpm/ferretdb.rpm && ferretdb --version'
     env:
       VERSION:
@@ -392,16 +392,16 @@ tasks:
     desc: "Format, lint and build documentation"
     deps: [docs-fmt]
     cmds:
-      - docker-compose run --rm docusaurus-docs build
+      - docker compose run --rm docusaurus-docs build
 
   # see https://github.com/DavidAnson/markdownlint-cli2#command-line for the reason we use double-quotes
   docs-fmt:
     desc: "Format and lint documentation"
     cmds:
-      - docker-compose run --rm textlint --fix --config build/.textlintrc "**/*.md" ".github/**/*.md"
-      - docker-compose run --rm markdownlint "**/*.md" "#CHANGELOG.md"
+      - docker compose run --rm textlint --fix --config build/.textlintrc "**/*.md" ".github/**/*.md"
+      - docker compose run --rm markdownlint "**/*.md" "#CHANGELOG.md"
 
   docs-dev:
     desc: "Start documentation development server"
     cmds:
-      - docker-compose run --rm --service-ports docusaurus-docs start --host=0.0.0.0
+      - docker compose run --rm --service-ports docusaurus-docs start --host=0.0.0.0

--- a/cmd/envtool/envtool.go
+++ b/cmd/envtool/envtool.go
@@ -168,9 +168,9 @@ func runCommand(command string, args []string, stdout io.Writer, logger *zap.Sug
 
 // printDiagnosticData prints diagnostic data and error template on stdout.
 func printDiagnosticData(setupError error, logger *zap.SugaredLogger) {
-	runCommand("docker-compose", []string{"ps", "--all"}, os.Stdout, logger)
+	runCommand("docker", []string{"compose", "ps", "--all"}, os.Stdout, logger)
 
-	runCommand("docker-compose", []string{"logs"}, os.Stdout, logger)
+	runCommand("docker", []string{"compose", "logs"}, os.Stdout, logger)
 
 	var buf bytes.Buffer
 
@@ -193,7 +193,7 @@ func printDiagnosticData(setupError error, logger *zap.SugaredLogger) {
 	buf.Reset()
 
 	var composeVersion string
-	if err := runCommand("docker-compose", []string{"version"}, &buf, logger); err != nil {
+	if err := runCommand("docker", []string{"compose", "version"}, &buf, logger); err != nil {
 		composeVersion = err.Error()
 	} else {
 		composeVersion = buf.String()

--- a/website/docs/quickstart_guide/docker.md
+++ b/website/docs/quickstart_guide/docker.md
@@ -40,7 +40,7 @@ They are not suitable for most production use-cases because they keep all data i
    `postgres` container runs PostgreSQL that would store data.
    `ferretdb` runs FerretDB.
 
-2. Start services with `docker-compose up -d`.
+2. Start services with `docker compose up -d`.
 
 3. If you have `mongosh` installed, just run it to connect to FerretDB.
    If not, run the following command to run `mongosh` inside the temporary MongoDB container, attaching to the same Docker network:


### PR DESCRIPTION
# Description

So we all use the same modern Docker Compose.

## Readiness checklist

* [ ] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
