### PR TITLE
Fix `.deb`/`.rpm` package testing

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -388,7 +388,7 @@ tasks:
     cmds:
       - ../bin/nfpm{{exeExt}} package --packager=deb --target=deb/ferretdb.deb
       - >
-        docker compose run --rm debian /bin/sh -c
+        docker compose run --rm ubuntu /bin/sh -c
         'dpkg -i /deb/ferretdb.deb && ferretdb --version'
     env:
       VERSION:
@@ -402,7 +402,7 @@ tasks:
     cmds:
       - ../bin/nfpm{{exeExt}} package --packager=rpm --target=rpm/ferretdb.rpm
       - >
-        docker compose run --rm centos /bin/sh -c
+        docker compose run --rm ubi /bin/sh -c
         'rpm -i /rpm/ferretdb.rpm && ferretdb --version'
     env:
       VERSION:

--- a/build/deps/centos7.Dockerfile
+++ b/build/deps/centos7.Dockerfile
@@ -1,1 +1,0 @@
-FROM centos:7.9.2009

--- a/build/deps/debian11.Dockerfile
+++ b/build/deps/debian11.Dockerfile
@@ -1,1 +1,0 @@
-FROM debian:11.5

--- a/build/deps/ubi9.Dockerfile
+++ b/build/deps/ubi9.Dockerfile
@@ -1,0 +1,1 @@
+FROM redhat/ubi9-minimal:9.1.0

--- a/build/deps/ubuntu2204.Dockerfile
+++ b/build/deps/ubuntu2204.Dockerfile
@@ -1,0 +1,1 @@
+FROM ubuntu:22.04

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
   centos:
     build:
       context: ./build/deps
-      dockerfile: centos7.Dockerfile
+      dockerfile: ubi9.Dockerfile
     container_name: ferretdb_centos
     volumes:
       - ./build/rpm:/rpm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,19 +65,19 @@ services:
     volumes:
       - .:/workdir
 
-  # for building .deb and .rpm packages
-  debian:
+  # for testing .deb and .rpm packages
+  ubuntu:
     build:
       context: ./build/deps
-      dockerfile: debian11.Dockerfile
-    container_name: ferretdb_debian
+      dockerfile: ubuntu2204.Dockerfile
+    container_name: ferretdb_ubuntu
     volumes:
       - ./build/deb:/deb
-  centos:
+  ubi:
     build:
       context: ./build/deps
       dockerfile: ubi9.Dockerfile
-    container_name: ferretdb_centos
+    container_name: ferretdb_ubi
     volumes:
       - ./build/rpm:/rpm
 


### PR DESCRIPTION
# Description

It was broken by switching runners to Ubuntu 22.04.

## Readiness checklist

* [ ] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
