### PR TITLE
Fix parsing of `OP_MSG` packets with multiple sections

### DIFF
--- a/internal/wire/op_msg_test.go
+++ b/internal/wire/op_msg_test.go
@@ -49,6 +49,7 @@ var msgTestCases = []testCase{{
 			))},
 		}},
 	},
+	command: "buildInfo",
 }, {
 	name:    "handshake6",
 	headerB: testutil.MustParseDumpFile("testdata", "handshake6_header.hex"),
@@ -105,6 +106,7 @@ var msgTestCases = []testCase{{
 			))},
 		}},
 	},
+	command: "version",
 }, {
 	name:      "import",
 	expectedB: testutil.MustParseDumpFile("testdata", "import.hex"),
@@ -144,6 +146,7 @@ var msgTestCases = []testCase{{
 			},
 		}},
 	},
+	command: "insert",
 }, {
 	name:      "msg_fuzz1",
 	expectedB: testutil.MustParseDumpFile("testdata", "msg_fuzz1.hex"),
@@ -249,7 +252,9 @@ var msgTestCases = []testCase{{
 		}},
 	},
 	err: `wire.OpMsg.Document: validation failed for ` +
-		`{ documents: [ { _id: ObjectId('637cfad88dc3cecde38e1e6b'), v: -0.0 } ] } with: -0 is not supported`,
+		`{ insert: "TestInsertSimple", ordered: true, $db: "testinsertsimple", ` +
+		`documents: [ { _id: ObjectId('637cfad88dc3cecde38e1e6b'), v: -0.0 } ] } ` +
+		`with: -0 is not supported`,
 }, {
 	name: "MultiSectionInsert",
 	expectedB: []byte{
@@ -306,6 +311,7 @@ var msgTestCases = []testCase{{
 			))},
 		}},
 	},
+	command: "insert",
 }, {
 	name: "MultiSectionUpdate",
 	expectedB: []byte{
@@ -385,6 +391,7 @@ var msgTestCases = []testCase{{
 			))},
 		}},
 	},
+	command: "update",
 }}
 
 func TestMsg(t *testing.T) {

--- a/internal/wire/wire_test.go
+++ b/internal/wire/wire_test.go
@@ -46,6 +46,7 @@ type testCase struct {
 	expectedB []byte
 	msgHeader *MsgHeader
 	msgBody   MsgBody
+	command   string // only for OpMsg
 	err       string // unwrapped
 }
 
@@ -77,23 +78,27 @@ func testMessages(t *testing.T, testCases []testCase) {
 				br := bytes.NewReader(tc.expectedB)
 				bufr := bufio.NewReader(br)
 				msgHeader, msgBody, err := ReadMessage(bufr)
-				if tc.err == "" {
-					assert.NoError(t, err)
-					assert.Equal(t, tc.msgHeader, msgHeader)
-					assert.Equal(t, tc.msgBody, msgBody)
-					assert.Zero(t, br.Len(), "not all br bytes were consumed")
-					assert.Zero(t, bufr.Buffered(), "not all bufr bytes were consumed")
-
-					require.NotNil(t, msgHeader)
-					require.NotNil(t, msgBody)
-					assert.NotPanics(t, func() { _ = msgHeader.String() })
-					assert.NotPanics(t, func() { _ = msgBody.String() })
-
+				if tc.err != "" {
+					require.Equal(t, tc.err, lastErr(err).Error())
 					return
 				}
 
-				require.Error(t, err)
-				require.Equal(t, tc.err, lastErr(err).Error())
+				assert.NoError(t, err)
+				assert.Equal(t, tc.msgHeader, msgHeader)
+				assert.Equal(t, tc.msgBody, msgBody)
+				assert.Zero(t, br.Len(), "not all br bytes were consumed")
+				assert.Zero(t, bufr.Buffered(), "not all bufr bytes were consumed")
+
+				require.NotNil(t, msgHeader)
+				require.NotNil(t, msgBody)
+				assert.NotPanics(t, func() { _ = msgHeader.String() })
+				assert.NotPanics(t, func() { _ = msgBody.String() })
+
+				if msg, ok := tc.msgBody.(*OpMsg); ok {
+					d, err := msg.Document()
+					require.NoError(t, err)
+					assert.Equal(t, tc.command, d.Command())
+				}
 			})
 
 			t.Run("WriteMessage", func(t *testing.T) {
@@ -149,6 +154,10 @@ func fuzzMessages(f *testing.F, testCases []testCase) {
 
 			assert.NotPanics(t, func() { _ = msgHeader.String() })
 			assert.NotPanics(t, func() { _ = msgBody.String() })
+
+			if msg, ok := msgBody.(*OpMsg); ok {
+				assert.NotPanics(t, func() { msg.Document() })
+			}
 
 			// remove random tail
 			expectedB = b[:len(b)-bufr.Buffered()-br.Len()]


### PR DESCRIPTION
# Description

Sections of kind 0 should be considered first.

Closes #1632.

## Readiness checklist

* [x] I added tests for new functionality or bugfixes.
* [x] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
