### PR TITLE
Add a compat test for maximum nested object depth

### DIFF
--- a/integration/insert_compat_test.go
+++ b/integration/insert_compat_test.go
@@ -122,7 +122,7 @@ func TestInsertCompat(t *testing.T) {
 	t.Parallel()
 
 	d := bson.D{}
-	var nestedObj = createNestedDocument(kDefaultMaxAllowableDepth+1, d)
+	nestedDoc := createNestedDocument(kDefaultMaxAllowableDepth+1, d)
 
 	testCases := map[string]insertCompatTestCase{
 		"InsertEmptyDocument": {
@@ -137,7 +137,7 @@ func TestInsertCompat(t *testing.T) {
 			resultType: emptyResult,
 		},
 		"InsertMaxAllowableDepth": {
-			insert:     nestedObj,
+			insert:     nestedDoc,
 			resultType: emptyResult,
 		},
 	}

--- a/integration/insert_compat_test.go
+++ b/integration/insert_compat_test.go
@@ -108,7 +108,8 @@ func testInsertCompat(t *testing.T, testCases map[string]insertCompatTestCase) {
 	}
 }
 
-const kDefaultMaxAllowableDepth = 200 // https://github.com/mongodb/mongo/blob/master/src/mongo/bson/bson_depth.h#L40
+// https://github.com/mongodb/mongo/blob/master/src/mongo/bson/bson_depth.h#L40
+const kDefaultMaxAllowableDepth = 200
 
 func createNestedDocument(i int, nestedDoc bson.D) bson.D {
 	if i == 0 {
@@ -121,8 +122,10 @@ func createNestedDocument(i int, nestedDoc bson.D) bson.D {
 func TestInsertCompat(t *testing.T) {
 	t.Parallel()
 
-	d := bson.D{}
-	nestedDoc := createNestedDocument(kDefaultMaxAllowableDepth+1, d)
+	const exceedsMaxAllowable = kDefaultMaxAllowableDepth + 1
+
+	nestedDoc := bson.D{}
+	nestedDoc = createNestedDocument(exceedsMaxAllowable, nestedDoc)
 
 	testCases := map[string]insertCompatTestCase{
 		"InsertEmptyDocument": {


### PR DESCRIPTION
# Description

This PR adds a compat test to check that we do not exceed the maximum nested object depth. 

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added tests for new functionality or bugfixes.
* [ ] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [ ] I marked all done items in this checklist.
