### PR TITLE
Add test script to show panic on a bad update path

### DIFF
--- a/build/legacy-mongo-shell/test.js
+++ b/build/legacy-mongo-shell/test.js
@@ -3,5 +3,14 @@
 (function() {
   'use strict';
 
+  const coll = db.test;
+
+  coll.drop();
+
+  coll.insert({_id: 1});
+
+  const expectedWriteError = coll.update({'_id': 1}, {$set: {'0..': 'val01'}});
+  assert.eq(expectedWriteError.hasWriteError(), true);
+
   print('test.js passed!');
 })();


### PR DESCRIPTION
# Description

See #1744.

This PR adds a test that shows that we panic [here](https://github.com/FerretDB/FerretDB/blob/v0.8.0/internal/types/path.go#L42) as expected but should probably return a `WriteError` instead just like MongoDB.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added unit tests for new functionality or bug fixes.
* [ ] I added integration tests for new functionality or bug fixes.
* [ ] I added compatibility tests for new functionality or bug fixes.
* [ ] I made spot refactorings.
* [ ] I updated user documentation.
* [ ] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [ ] I ensured that the title is good enough for the changelog.
* [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [ ] I marked all done items in this checklist.
