### PR TITLE
Skip incompatible tests on `arm64`

### DIFF
--- a/integration/query_bitwise_test.go
+++ b/integration/query_bitwise_test.go
@@ -16,6 +16,7 @@ package integration
 
 import (
 	"math"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,6 +31,10 @@ import (
 )
 
 func TestQueryBitwiseAllClear(t *testing.T) {
+	if runtime.GOARCH == "arm64" {
+		t.Skip("TODO https://github.com/FerretDB/FerretDB/issues/491")
+	}
+
 	setup.SkipForTigris(t)
 
 	t.Parallel()
@@ -199,6 +204,10 @@ func TestQueryBitwiseAllClear(t *testing.T) {
 }
 
 func TestQueryBitwiseAllSet(t *testing.T) {
+	if runtime.GOARCH == "arm64" {
+		t.Skip("TODO https://github.com/FerretDB/FerretDB/issues/491")
+	}
+
 	setup.SkipForTigris(t)
 
 	t.Parallel()
@@ -325,6 +334,10 @@ func TestQueryBitwiseAllSet(t *testing.T) {
 }
 
 func TestQueryBitwiseAnyClear(t *testing.T) {
+	if runtime.GOARCH == "arm64" {
+		t.Skip("TODO https://github.com/FerretDB/FerretDB/issues/491")
+	}
+
 	setup.SkipForTigris(t)
 
 	t.Parallel()
@@ -489,6 +502,10 @@ func TestQueryBitwiseAnyClear(t *testing.T) {
 }
 
 func TestQueryBitwiseAnySet(t *testing.T) {
+	if runtime.GOARCH == "arm64" {
+		t.Skip("TODO https://github.com/FerretDB/FerretDB/issues/491")
+	}
+
 	setup.SkipForTigris(t)
 
 	t.Parallel()


### PR DESCRIPTION
# Description

The problem was revealed after refactoring bitwise-related tests and more data test cases being added. This is what we already do in some other tests affected by the same reason.

Those tests will still run on CI.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added unit tests for new functionality or bug fixes.
* [ ] I added integration tests for new functionality or bug fixes.
* [ ] I added compatibility tests for new functionality or bug fixes.
* [ ] I made spot refactorings.
* [ ] I updated user documentation.
* [ ] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
