### PR TITLE
Fix links from docs to blog

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -42,12 +42,6 @@ const config = {
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl: 'https://github.com/FerretDB/FerretDB/tree/main/website',
         },
-        blog: {
-          blogTitle: 'FerretDB Blog',
-          showReadingTime: true,
-          authorsMapPath: 'authors.yml',
-          postsPerPage: 8,
-        },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
@@ -71,11 +65,11 @@ const config = {
             position: 'left',
             label: 'Documentation',
           },
-          // {
-          //   to: '/blog',
-          //   label: 'Blog',
-          //   position: 'left'
-          // },
+          {
+            href: 'https://blog.ferertdb.io/',
+            label: 'Blog',
+            position: 'left'
+          },
           {
             href: 'https://github.com/FerretDB/',
             label: 'GitHub',
@@ -119,10 +113,10 @@ const config = {
           {
             title: 'More',
             items: [
-              // {
-              //   label: 'Blog',
-              //   to: 'https://www.ferretdb.io/blog/',
-              // },
+              {
+                label: 'Blog',
+                to: 'https://blog.ferretdb.io/',
+              },
               {
                 label: 'GitHub',
                 href: 'https://github.com/FerretDB/',


### PR DESCRIPTION
# Description

Fix links from docs to blog.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added unit tests for new functionality or bug fixes.
* [ ] I added integration tests for new functionality or bug fixes.
* [ ] I added compatibility tests for new functionality or bug fixes.
* [ ] I made spot refactorings.
* [ ] I updated user documentation.
* [ ] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
