### PR TITLE
Retry transaction more times and log retries

### DIFF
--- a/internal/handlers/pg/pgdb/transactions.go
+++ b/internal/handlers/pg/pgdb/transactions.go
@@ -88,7 +88,7 @@ func (pgPool *Pool) InTransactionRetry(ctx context.Context, f func(pgx.Tx) error
 	// TODO use exponential backoff with jitter instead
 	// https://github.com/FerretDB/FerretDB/issues/1720
 	const (
-		retriesMax    = 20
+		retriesMax    = 30
 		retryDelayMin = 100 * time.Millisecond
 		retryDelayMax = 200 * time.Millisecond
 	)
@@ -104,7 +104,14 @@ func (pgPool *Pool) InTransactionRetry(ctx context.Context, f func(pgx.Tx) error
 			return nil
 		case errors.As(err, &tcErr):
 			deltaMS := rand.Int63n((retryDelayMax - retryDelayMin).Milliseconds())
-			ctxutil.Sleep(ctx, retryDelayMin+time.Duration(deltaMS)*time.Millisecond)
+			delay := retryDelayMin + time.Duration(deltaMS)*time.Millisecond
+
+			pgPool.Config().ConnConfig.Logger.Log(
+				ctx, pgx.LogLevelWarn, "transaction failed, retrying",
+				map[string]any{"err": err, "delay": delay},
+			)
+
+			ctxutil.Sleep(ctx, delay)
 		default:
 			return lazyerrors.Error(err)
 		}


### PR DESCRIPTION
# Description

Bumping `retriesMax` is a temporary workaround, not a real fix. But logging should improve diagnostics.

## Readiness checklist

* [ ] I added unit tests for new functionality or bug fixes.
* [ ] I added integration tests for new functionality or bug fixes.
* [ ] I added compatibility tests for new functionality or bug fixes.
* [x] I made spot refactorings.
* [ ] I updated user documentation.
* [x] I ran `task all`, and it passed.
* [ ] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
