### PR TITLE
Remove `ListenerOpts` from another `ListenerOpts`

### DIFF
--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -312,7 +312,7 @@ func run() {
 
 	l := clientconn.NewListener(&clientconn.NewListenerOpts{
 		Listener: clientconn.ListenerOpts{
-			Addr:        cli.Listen.Addr,
+			TCP:         cli.Listen.Addr,
 			Unix:        cli.Listen.Unix,
 			TLS:         cli.Listen.TLS,
 			TLSCertFile: cli.Listen.TLSCertFile,

--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -311,14 +311,13 @@ func run() {
 	defer h.Close()
 
 	l := clientconn.NewListener(&clientconn.NewListenerOpts{
-		Listener: clientconn.ListenerOpts{
-			TCP:         cli.Listen.Addr,
-			Unix:        cli.Listen.Unix,
-			TLS:         cli.Listen.TLS,
-			TLSCertFile: cli.Listen.TLSCertFile,
-			TLSKeyFile:  cli.Listen.TLSKeyFile,
-			TLSCAFile:   cli.Listen.TLSCAFile,
-		},
+		TCP:         cli.Listen.Addr,
+		Unix:        cli.Listen.Unix,
+		TLS:         cli.Listen.TLS,
+		TLSCertFile: cli.Listen.TLSCertFile,
+		TLSKeyFile:  cli.Listen.TLSKeyFile,
+		TLSCAFile:   cli.Listen.TLSCAFile,
+
 		ProxyAddr:      cli.ProxyAddr,
 		Mode:           clientconn.Mode(cli.Mode),
 		Metrics:        metrics,

--- a/ferretdb/ferretdb.go
+++ b/ferretdb/ferretdb.go
@@ -118,14 +118,13 @@ func New(config *Config) (*FerretDB, error) {
 	}
 
 	l := clientconn.NewListener(&clientconn.NewListenerOpts{
-		Listener: clientconn.ListenerOpts{
-			TCP:         config.Listener.TCP,
-			Unix:        config.Listener.Unix,
-			TLS:         config.Listener.TLS,
-			TLSCertFile: config.Listener.TLSCertFile,
-			TLSKeyFile:  config.Listener.TLSKeyFile,
-			TLSCAFile:   config.Listener.TLSCAFile,
-		},
+		TCP:         config.Listener.TCP,
+		Unix:        config.Listener.Unix,
+		TLS:         config.Listener.TLS,
+		TLSCertFile: config.Listener.TLSCertFile,
+		TLSKeyFile:  config.Listener.TLSKeyFile,
+		TLSCAFile:   config.Listener.TLSCAFile,
+
 		Mode:    clientconn.NormalMode,
 		Metrics: metrics,
 		Handler: h,

--- a/ferretdb/ferretdb.go
+++ b/ferretdb/ferretdb.go
@@ -58,7 +58,7 @@ type Config struct {
 type ListenerConfig struct {
 	// Listen TCP address.
 	// If empty, TCP listener is disabled.
-	Addr string
+	TCP string
 
 	// Listen Unix domain socket path.
 	// If empty, Unix listener is disabled.
@@ -87,10 +87,10 @@ type FerretDB struct {
 
 // New creates a new instance of embeddable FerretDB implementation.
 func New(config *Config) (*FerretDB, error) {
-	if config.Listener.Addr == "" &&
+	if config.Listener.TCP == "" &&
 		config.Listener.Unix == "" &&
 		config.Listener.TLS == "" {
-		return nil, errors.New("Listener Addr, Unix and TLS are empty")
+		return nil, errors.New("Listener TCP, Unix and TLS are empty")
 	}
 
 	p, err := state.NewProvider("")
@@ -119,7 +119,7 @@ func New(config *Config) (*FerretDB, error) {
 
 	l := clientconn.NewListener(&clientconn.NewListenerOpts{
 		Listener: clientconn.ListenerOpts{
-			Addr:        config.Listener.Addr,
+			TCP:         config.Listener.TCP,
 			Unix:        config.Listener.Unix,
 			TLS:         config.Listener.TLS,
 			TLSCertFile: config.Listener.TLSCertFile,
@@ -161,6 +161,7 @@ func (f *FerretDB) Run(ctx context.Context) error {
 // MongoDBURI returns MongoDB URI for this FerretDB instance.
 //
 // TCP's connection string is returned if both TCP and Unix listeners are enabled.
+// TLS is preferred over both.
 func (f *FerretDB) MongoDBURI() string {
 	var u *url.URL
 
@@ -172,21 +173,21 @@ func (f *FerretDB) MongoDBURI() string {
 
 		u = &url.URL{
 			Scheme:   "mongodb",
-			Host:     f.l.TLS().String(),
+			Host:     f.l.TLSAddr().String(),
 			Path:     "/",
 			RawQuery: q.Encode(),
 		}
-	case f.config.Listener.Addr != "":
+	case f.config.Listener.TCP != "":
 		u = &url.URL{
 			Scheme: "mongodb",
-			Host:   f.l.Addr().String(),
+			Host:   f.l.TCPAddr().String(),
 			Path:   "/",
 		}
 	case f.config.Listener.Unix != "":
 		// MongoDB really wants Unix socket path in the host part of the URI
 		u = &url.URL{
 			Scheme: "mongodb",
-			Host:   f.l.Unix().String(),
+			Host:   f.l.UnixAddr().String(),
 			Path:   "/",
 		}
 	}

--- a/ferretdb/ferretdb_test.go
+++ b/ferretdb/ferretdb_test.go
@@ -24,7 +24,7 @@ import (
 func Example_tcp() {
 	f, err := New(&Config{
 		Listener: ListenerConfig{
-			Addr: "127.0.0.1:17027",
+			TCP: "127.0.0.1:17027",
 		},
 		Handler:       "pg",
 		PostgreSQLURL: "postgres://127.0.0.1:5432/ferretdb",

--- a/integration/embedded_test.go
+++ b/integration/embedded_test.go
@@ -46,7 +46,7 @@ func TestEmbedded(t *testing.T) {
 		"TCP": {
 			config: &ferretdb.Config{
 				Listener: ferretdb.ListenerConfig{
-					Addr: "127.0.0.1:65432",
+					TCP: "127.0.0.1:65432",
 				},
 				Handler:       "pg",
 				PostgreSQLURL: testutil.PostgreSQLURL(t, nil),

--- a/integration/setup/common.go
+++ b/integration/setup/common.go
@@ -258,7 +258,7 @@ func setupListener(tb testing.TB, ctx context.Context, logger *zap.Logger) strin
 		fp := GetTLSFilesPaths(tb, ServerSide)
 		listenerOpts.TLSCertFile, listenerOpts.TLSKeyFile, listenerOpts.TLSCAFile = fp.Cert, fp.Key, fp.CA
 	} else {
-		listenerOpts.Addr = hostPort
+		listenerOpts.TCP = hostPort
 	}
 
 	l := clientconn.NewListener(&clientconn.NewListenerOpts{
@@ -295,11 +295,11 @@ func setupListener(tb testing.TB, ctx context.Context, logger *zap.Logger) strin
 
 	switch {
 	case tls:
-		opts.hostPort = l.TLS().String()
+		opts.hostPort = l.TLSAddr().String()
 	case listenUnix != "":
-		opts.unixSocketPath = l.Unix().String()
+		opts.unixSocketPath = l.UnixAddr().String()
 	default:
-		opts.hostPort = l.Addr().String()
+		opts.hostPort = l.TCPAddr().String()
 	}
 
 	uri := buildMongoDBURI(tb, ctx, opts)

--- a/internal/clientconn/listener.go
+++ b/internal/clientconn/listener.go
@@ -53,23 +53,19 @@ type Listener struct {
 
 // NewListenerOpts represents listener configuration.
 type NewListenerOpts struct {
-	Listener       ListenerOpts
-	ProxyAddr      string
-	Mode           Mode
-	Metrics        *connmetrics.ListenerMetrics
-	Handler        handlers.Interface
-	Logger         *zap.Logger
-	TestRecordsDir string // if empty, no records are created
-}
-
-// ListenerOpts represents listener configuration options.
-type ListenerOpts struct {
 	TCP         string
 	Unix        string
 	TLS         string
 	TLSCertFile string
 	TLSKeyFile  string
 	TLSCAFile   string
+
+	ProxyAddr      string
+	Mode           Mode
+	Metrics        *connmetrics.ListenerMetrics
+	Handler        handlers.Interface
+	Logger         *zap.Logger
+	TestRecordsDir string // if empty, no records are created
 }
 
 // NewListener returns a new listener, configured by the NewListenerOpts argument.
@@ -88,9 +84,9 @@ func NewListener(opts *NewListenerOpts) *Listener {
 func (l *Listener) Run(ctx context.Context) error {
 	logger := l.Logger.Named("listener")
 
-	if l.Listener.TCP != "" {
+	if l.TCP != "" {
 		var err error
-		if l.tcpListener, err = net.Listen("tcp", l.Listener.TCP); err != nil {
+		if l.tcpListener, err = net.Listen("tcp", l.TCP); err != nil {
 			return err
 		}
 
@@ -99,9 +95,9 @@ func (l *Listener) Run(ctx context.Context) error {
 		logger.Sugar().Infof("Listening on TCP %s ...", l.TCPAddr())
 	}
 
-	if l.Listener.Unix != "" {
+	if l.Unix != "" {
 		var err error
-		if l.unixListener, err = net.Listen("unix", l.Listener.Unix); err != nil {
+		if l.unixListener, err = net.Listen("unix", l.Unix); err != nil {
 			return err
 		}
 
@@ -110,13 +106,13 @@ func (l *Listener) Run(ctx context.Context) error {
 		logger.Sugar().Infof("Listening on Unix %s ...", l.UnixAddr())
 	}
 
-	if l.Listener.TLS != "" {
+	if l.TLS != "" {
 		var err error
 		if l.tlsListener, err = setupTLSListener(&setupTLSListenerOpts{
-			addr:     l.Listener.TLS,
-			certFile: l.Listener.TLSCertFile,
-			keyFile:  l.Listener.TLSKeyFile,
-			caFile:   l.Listener.TLSCAFile,
+			addr:     l.TLS,
+			certFile: l.TLSCertFile,
+			keyFile:  l.TLSKeyFile,
+			caFile:   l.TLSCAFile,
 		}); err != nil {
 			return err
 		}
@@ -145,7 +141,7 @@ func (l *Listener) Run(ctx context.Context) error {
 
 	var wg sync.WaitGroup
 
-	if l.Listener.TCP != "" {
+	if l.TCP != "" {
 		wg.Add(1)
 
 		go func() {
@@ -158,7 +154,7 @@ func (l *Listener) Run(ctx context.Context) error {
 		}()
 	}
 
-	if l.Listener.Unix != "" {
+	if l.Unix != "" {
 		wg.Add(1)
 
 		go func() {
@@ -171,7 +167,7 @@ func (l *Listener) Run(ctx context.Context) error {
 		}()
 	}
 
-	if l.Listener.TLS != "" {
+	if l.TLS != "" {
 		wg.Add(1)
 
 		go func() {


### PR DESCRIPTION
# Description

Spotted while working on making tests faster.

![image](https://user-images.githubusercontent.com/11512/213518056-e7faefa6-f607-48ab-a47b-6ee68a11c4a5.png)

## Readiness checklist

* [ ] I added unit tests for new functionality or bug fixes.
* [ ] I added integration tests for new functionality or bug fixes.
* [ ] I added compatibility tests for new functionality or bug fixes.
* [x] I made spot refactorings.
* [ ] I updated user documentation.
* [x] I ran `task all`, and it passed.
* [x] I added/updated comments for both exported and unexported top-level declarations (functions, types, etc).
* [ ] I checked comments rendering with `task godocs`.
* [x] I ensured that the title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
