### PR TITLE
Make proper port visible on blog development server

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -517,4 +517,4 @@ tasks:
   blog-dev:
     desc: "Start blog development server"
     cmds:
-      - docker compose run --rm --service-ports docusaurus-blog start --host=0.0.0.0
+      - docker compose run --rm --service-ports docusaurus-blog start --host=0.0.0.0 --port=3001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -192,7 +192,7 @@ services:
       dockerfile: docusaurus-docs.Dockerfile
     container_name: ferretdb_docusaurus-blog
     ports:
-      - 3001:3000
+      - 3001:3001
     volumes:
       - ./website/blog:/workdir/docusaurus-docs/blog:ro
       - ./website/static:/workdir/docusaurus-docs/static:ro


### PR DESCRIPTION
# Description

If you run `task blog-dev`, it shows you that the Docusaurus website is running on 3000 port, which is not true, as for blogs we use 3001:
```
task blog-dev
task: [blog-dev] docker compose run --rm --service-ports docusaurus-blog start --host=0.0.0.0
[INFO] Starting the development server...
[SUCCESS] Docusaurus website is running at: http://localhost:3000/

✔ Client
  Compiled successfully in 6.89s

client (webpack 5.75.0) compiled successfully
```

This is because the docusaurs container internally runs the website on 3000 and we just forward ports externally.

I've simply changed internal port to 3001, to make it straightforward and don't create confusion:

```
 task blog-dev
task: [blog-dev] docker compose run --rm --service-ports docusaurus-blog start --host=0.0.0.0 --port=3001
[INFO] Starting the development server...
[SUCCESS] Docusaurus website is running at: http://localhost:3001/
```

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changfes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [ ] I added/updated comments and checked rendering.
* [ ] I made spot refactorings.
* [ ] I updated user documentation.
* [ ] I ran `task all`, and it passed.
* [x] I ensured that PR title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
