### PR TITLE
Fix `InTransaction` helper's edge case

### DIFF
--- a/internal/handlers/pg/pgdb/transactions_test.go
+++ b/internal/handlers/pg/pgdb/transactions_test.go
@@ -1,0 +1,41 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgdb
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/FerretDB/FerretDB/internal/util/testutil"
+)
+
+func TestInTransaction(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Ctx(t)
+	pool := getPool(ctx, t)
+
+	assert.Panics(t, func() {
+		pool.InTransaction(ctx, func(pgx.Tx) error {
+			// We can't test `runtime.Goexit()`, but `panic(nil)` hangs the buggy code as well;
+			// see comments inside `InTransaction`.
+			//
+			//nolint:vet // we need it for testing
+			panic(nil)
+		})
+	})
+}


### PR DESCRIPTION
# Description

It hangs if `f` function panics.

## Readiness checklist

* [x] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [x] I added/updated comments and checked rendering.
* [x] I made spot refactorings.
* [ ] I updated user documentation.
* [x] I ran `task all`, and it passed.
* [x] I ensured that PR title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
