### PR TITLE
Unify reply code in handlers

### DIFF
--- a/internal/handlers/common/commonerrors.go
+++ b/internal/handlers/common/commonerrors.go
@@ -26,7 +26,7 @@ type (
 	WriteErrors = commonerrors.WriteErrors
 )
 
-// Deprecated: use commonerrors functions instead.
+// Deprecated: use commonerrors functions instead; do not add new functions there.
 var (
 	CheckError                     = commonerrors.CheckError
 	NewCommandError                = commonerrors.NewCommandError
@@ -36,7 +36,7 @@ var (
 	ProtocolError                  = commonerrors.ProtocolError
 )
 
-// Deprecated: use commonerrors constant instead.
+// Deprecated: use commonerrors constant instead; do not add new errors there.
 const (
 	ErrBadValue                   = commonerrors.ErrBadValue
 	ErrFailedToParse              = commonerrors.ErrFailedToParse

--- a/internal/handlers/common/getfreemonitoringstatus.go
+++ b/internal/handlers/common/getfreemonitoringstatus.go
@@ -25,7 +25,7 @@ import (
 	"github.com/FerretDB/FerretDB/internal/wire"
 )
 
-// GetFreeMonitoringStatus is a common implementation of the getFreeMonitoringStatus command.
+// GetFreeMonitoringStatus is a part of common implementation of the getFreeMonitoringStatus command.
 func GetFreeMonitoringStatus(ctx context.Context, msg *wire.OpMsg, state *state.State) (*wire.OpMsg, error) {
 	if state == nil {
 		panic("state cannot be equal to nil")
@@ -44,7 +44,6 @@ func GetFreeMonitoringStatus(ctx context.Context, msg *wire.OpMsg, state *state.
 	}
 
 	var reply wire.OpMsg
-
 	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{must.NotFail(types.NewDocument(
 			"state", telemetryState,

--- a/internal/handlers/common/setfreemonitoring.go
+++ b/internal/handlers/common/setfreemonitoring.go
@@ -27,7 +27,7 @@ import (
 	"github.com/FerretDB/FerretDB/internal/wire"
 )
 
-// SetFreeMonitoring is a common implementation of the setFreeMonitoring command.
+// SetFreeMonitoring is a part of common implementation of the setFreeMonitoring command.
 func SetFreeMonitoring(ctx context.Context, msg *wire.OpMsg, provider *state.Provider) (*wire.OpMsg, error) {
 	if provider == nil {
 		panic("provider cannot be equal to nil")
@@ -75,7 +75,6 @@ func SetFreeMonitoring(ctx context.Context, msg *wire.OpMsg, provider *state.Pro
 	}
 
 	var reply wire.OpMsg
-
 	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{must.NotFail(types.NewDocument(
 			"ok", float64(1),

--- a/internal/handlers/common/validate.go
+++ b/internal/handlers/common/validate.go
@@ -25,7 +25,7 @@ import (
 	"github.com/FerretDB/FerretDB/internal/wire"
 )
 
-// Validate is a common implementation of the validate command.
+// Validate is a part of a common implementation of the validate command.
 func Validate(ctx context.Context, msg *wire.OpMsg, l *zap.Logger) (*wire.OpMsg, error) {
 	document, err := msg.Document()
 	if err != nil {

--- a/internal/handlers/dummy/dummy.go
+++ b/internal/handlers/dummy/dummy.go
@@ -41,13 +41,13 @@ func notImplemented(command string) error {
 //   - setFreeMonitoringStatus;
 //   - whatsmyuri.
 type Handler struct {
-	l *zap.Logger
+	L *zap.Logger
 }
 
 // New returns a new handler.
 func New(l *zap.Logger) (handlers.Interface, error) {
 	return &Handler{
-		l: l,
+		L: l,
 	}, nil
 }
 

--- a/internal/handlers/dummy/msg_validate.go
+++ b/internal/handlers/dummy/msg_validate.go
@@ -23,5 +23,5 @@ import (
 
 // MsgValidate implements HandlerInterface.
 func (h *Handler) MsgValidate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error) {
-	return common.Validate(ctx, msg, h.l)
+	return common.Validate(ctx, msg, h.L)
 }

--- a/internal/handlers/pg/msg_collstats.go
+++ b/internal/handlers/pg/msg_collstats.go
@@ -54,7 +54,7 @@ func (h *Handler) MsgCollStats(ctx context.Context, msg *wire.OpMsg) (*wire.OpMs
 	}
 
 	var reply wire.OpMsg
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{must.NotFail(types.NewDocument(
 			"ns", db+"."+collection,
 			"count", stats.CountRows,
@@ -65,10 +65,7 @@ func (h *Handler) MsgCollStats(ctx context.Context, msg *wire.OpMsg) (*wire.OpMs
 			"scaleFactor", int32(1),
 			"ok", float64(1),
 		))},
-	})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/pg/msg_count.go
+++ b/internal/handlers/pg/msg_count.go
@@ -89,7 +89,7 @@ func (h *Handler) MsgCount(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, e
 
 	sp.Filter = filter
 
-	resDocs := make([]*types.Document, 0, 16)
+	var resDocs []*types.Document
 	err = dbPool.InTransaction(ctx, func(tx pgx.Tx) error {
 		resDocs, err = h.fetchAndFilterDocs(ctx, tx, &sp)
 		return err
@@ -104,15 +104,12 @@ func (h *Handler) MsgCount(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, e
 	}
 
 	var reply wire.OpMsg
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{must.NotFail(types.NewDocument(
 			"n", int32(len(resDocs)),
 			"ok", float64(1),
 		))},
-	})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/pg/msg_createindexes.go
+++ b/internal/handlers/pg/msg_createindexes.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/FerretDB/FerretDB/internal/handlers/common"
 	"github.com/FerretDB/FerretDB/internal/types"
-	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
 	"github.com/FerretDB/FerretDB/internal/util/must"
 	"github.com/FerretDB/FerretDB/internal/wire"
 )
@@ -36,14 +35,11 @@ func (h *Handler) MsgCreateIndexes(ctx context.Context, msg *wire.OpMsg) (*wire.
 	common.Ignored(document, h.L, "writeConcern", "commitQuorum", "comment")
 
 	var reply wire.OpMsg
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{must.NotFail(types.NewDocument(
 			"ok", float64(1),
 		))},
-	})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/pg/msg_datasize.go
+++ b/internal/handlers/pg/msg_datasize.go
@@ -86,12 +86,9 @@ func (h *Handler) MsgDataSize(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg
 	)
 
 	var reply wire.OpMsg
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{must.NotFail(types.NewDocument(pairs...))},
-	})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/pg/msg_dbstats.go
+++ b/internal/handlers/pg/msg_dbstats.go
@@ -58,7 +58,7 @@ func (h *Handler) MsgDBStats(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg,
 	}
 
 	var reply wire.OpMsg
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{must.NotFail(types.NewDocument(
 			"db", db,
 			"collections", stats.CountTables,
@@ -73,10 +73,7 @@ func (h *Handler) MsgDBStats(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg,
 			"scaleFactor", scale,
 			"ok", float64(1),
 		))},
-	})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/pg/msg_delete.go
+++ b/internal/handlers/pg/msg_delete.go
@@ -135,13 +135,9 @@ func (h *Handler) MsgDelete(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 	replyDoc.Set("n", deleted)
 
 	var reply wire.OpMsg
-
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{replyDoc},
-	})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/pg/msg_distinct.go
+++ b/internal/handlers/pg/msg_distinct.go
@@ -51,7 +51,7 @@ func (h *Handler) MsgDistinct(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg
 		Comment:    dp.Comment,
 	}
 
-	resDocs := make([]*types.Document, 0, 16)
+	var resDocs []*types.Document
 	err = dbPool.InTransaction(ctx, func(tx pgx.Tx) error {
 		resDocs, err = h.fetchAndFilterDocs(ctx, tx, &sp)
 		return err
@@ -67,12 +67,12 @@ func (h *Handler) MsgDistinct(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg
 	}
 
 	var reply wire.OpMsg
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{must.NotFail(types.NewDocument(
 			"values", distinct,
 			"ok", float64(1),
 		))},
-	})
+	}))
 
 	if err != nil {
 		return nil, lazyerrors.Error(err)

--- a/internal/handlers/pg/msg_drop.go
+++ b/internal/handlers/pg/msg_drop.go
@@ -68,16 +68,13 @@ func (h *Handler) MsgDrop(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, er
 	}
 
 	var reply wire.OpMsg
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{must.NotFail(types.NewDocument(
 			"nIndexesWas", int32(1), // TODO
 			"ns", db+"."+collection,
 			"ok", float64(1),
 		))},
-	})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/pg/msg_dropdatabase.go
+++ b/internal/handlers/pg/msg_dropdatabase.go
@@ -65,12 +65,9 @@ func (h *Handler) MsgDropDatabase(ctx context.Context, msg *wire.OpMsg) (*wire.O
 	res.Set("ok", float64(1))
 
 	var reply wire.OpMsg
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{res},
-	})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/pg/msg_explain.go
+++ b/internal/handlers/pg/msg_explain.go
@@ -98,7 +98,7 @@ func (h *Handler) MsgExplain(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg,
 	cmd.Set("$db", sp.DB)
 
 	var reply wire.OpMsg
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{must.NotFail(types.NewDocument(
 			"queryPlanner", queryPlanner,
 			"explainVersion", "1",
@@ -107,9 +107,7 @@ func (h *Handler) MsgExplain(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg,
 			"serverInfo", serverInfo,
 			"ok", float64(1),
 		))},
-	})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
+
 	return &reply, nil
 }

--- a/internal/handlers/pg/msg_find.go
+++ b/internal/handlers/pg/msg_find.go
@@ -68,7 +68,7 @@ func (h *Handler) MsgFind(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, er
 		}
 	}
 
-	resDocs := make([]*types.Document, 0, 16)
+	var resDocs []*types.Document
 	err = dbPool.InTransaction(ctx, func(tx pgx.Tx) error {
 		resDocs, err = h.fetchAndFilterDocs(ctx, tx, &sp)
 		return err
@@ -96,7 +96,7 @@ func (h *Handler) MsgFind(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, er
 	}
 
 	var reply wire.OpMsg
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{must.NotFail(types.NewDocument(
 			"cursor", must.NotFail(types.NewDocument(
 				"firstBatch", firstBatch,
@@ -105,10 +105,7 @@ func (h *Handler) MsgFind(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, er
 			)),
 			"ok", float64(1),
 		))},
-	})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/pg/msg_getlog.go
+++ b/internal/handlers/pg/msg_getlog.go
@@ -141,10 +141,9 @@ func (h *Handler) MsgGetLog(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 	}
 
 	var reply wire.OpMsg
-	err = reply.SetSections(wire.OpMsgSection{Documents: []*types.Document{resDoc}})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	must.NoError(reply.SetSections(wire.OpMsgSection{
+		Documents: []*types.Document{resDoc},
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/pg/msg_getparameter.go
+++ b/internal/handlers/pg/msg_getparameter.go
@@ -52,7 +52,6 @@ func (h *Handler) MsgGetParameter(ctx context.Context, msg *wire.OpMsg) (*wire.O
 		"ok", float64(1),
 	))
 
-	var reply wire.OpMsg
 	resDoc := resDB
 	if !showDetails || !allParameters {
 		resDoc, err = selectUnit(document, resDB, showDetails, allParameters)
@@ -61,10 +60,10 @@ func (h *Handler) MsgGetParameter(ctx context.Context, msg *wire.OpMsg) (*wire.O
 		}
 	}
 
-	err = reply.SetSections(wire.OpMsgSection{Documents: []*types.Document{resDoc}})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	var reply wire.OpMsg
+	must.NoError(reply.SetSections(wire.OpMsgSection{
+		Documents: []*types.Document{resDoc},
+	}))
 
 	common.Ignored(document, h.L, "comment")
 

--- a/internal/handlers/pg/msg_hello.go
+++ b/internal/handlers/pg/msg_hello.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/FerretDB/FerretDB/internal/handlers/common"
 	"github.com/FerretDB/FerretDB/internal/types"
-	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
 	"github.com/FerretDB/FerretDB/internal/util/must"
 	"github.com/FerretDB/FerretDB/internal/wire"
 )
@@ -28,7 +27,7 @@ import (
 // MsgHello implements HandlerInterface.
 func (h *Handler) MsgHello(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error) {
 	var reply wire.OpMsg
-	err := reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{must.NotFail(types.NewDocument(
 			"isWritablePrimary", true,
 			// topologyVersion
@@ -43,10 +42,7 @@ func (h *Handler) MsgHello(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, e
 			"readOnly", false,
 			"ok", float64(1),
 		))},
-	})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/pg/msg_insert.go
+++ b/internal/handlers/pg/msg_insert.go
@@ -86,13 +86,9 @@ func (h *Handler) MsgInsert(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 	replyDoc.Set("n", inserted)
 
 	var reply wire.OpMsg
-
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{replyDoc},
-	})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/pg/msg_ismaster.go
+++ b/internal/handlers/pg/msg_ismaster.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/FerretDB/FerretDB/internal/handlers/common"
 	"github.com/FerretDB/FerretDB/internal/types"
-	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
 	"github.com/FerretDB/FerretDB/internal/util/must"
 	"github.com/FerretDB/FerretDB/internal/wire"
 )
@@ -28,7 +27,7 @@ import (
 // MsgIsMaster implements HandlerInterface.
 func (h *Handler) MsgIsMaster(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error) {
 	var reply wire.OpMsg
-	err := reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{must.NotFail(types.NewDocument(
 			"ismaster", true, // only lowercase
 			// topologyVersion
@@ -43,10 +42,7 @@ func (h *Handler) MsgIsMaster(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg
 			"readOnly", false,
 			"ok", float64(1),
 		))},
-	})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/pg/msg_listcollections.go
+++ b/internal/handlers/pg/msg_listcollections.go
@@ -97,7 +97,7 @@ func (h *Handler) MsgListCollections(ctx context.Context, msg *wire.OpMsg) (*wir
 	}
 
 	var reply wire.OpMsg
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{must.NotFail(types.NewDocument(
 			"cursor", must.NotFail(types.NewDocument(
 				"id", int64(0),
@@ -106,10 +106,7 @@ func (h *Handler) MsgListCollections(ctx context.Context, msg *wire.OpMsg) (*wir
 			)),
 			"ok", float64(1),
 		))},
-	})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/pg/msg_listdatabases.go
+++ b/internal/handlers/pg/msg_listdatabases.go
@@ -108,25 +108,21 @@ func (h *Handler) MsgListDatabases(ctx context.Context, msg *wire.OpMsg) (*wire.
 
 	switch {
 	case nameOnly:
-		err = reply.SetSections(wire.OpMsgSection{
+		must.NoError(reply.SetSections(wire.OpMsgSection{
 			Documents: []*types.Document{must.NotFail(types.NewDocument(
 				"databases", databases,
 				"ok", float64(1),
 			))},
-		})
+		}))
 	default:
-		err = reply.SetSections(wire.OpMsgSection{
+		must.NoError(reply.SetSections(wire.OpMsgSection{
 			Documents: []*types.Document{must.NotFail(types.NewDocument(
 				"databases", databases,
 				"totalSize", totalSize,
 				"totalSizeMb", totalSize/1024/1024,
 				"ok", float64(1),
 			))},
-		})
-	}
-
-	if err != nil {
-		return nil, lazyerrors.Error(err)
+		}))
 	}
 
 	return &reply, nil

--- a/internal/handlers/pg/msg_ping.go
+++ b/internal/handlers/pg/msg_ping.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/FerretDB/FerretDB/internal/types"
-	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
 	"github.com/FerretDB/FerretDB/internal/util/must"
 	"github.com/FerretDB/FerretDB/internal/wire"
 )
@@ -26,14 +25,11 @@ import (
 // MsgPing implements HandlerInterface.
 func (h *Handler) MsgPing(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error) {
 	var reply wire.OpMsg
-	err := reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{must.NotFail(types.NewDocument(
 			"ok", float64(1),
 		))},
-	})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/pg/msg_update.go
+++ b/internal/handlers/pg/msg_update.go
@@ -216,12 +216,9 @@ func (h *Handler) MsgUpdate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 	res.Set("ok", float64(1))
 
 	var reply wire.OpMsg
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{res},
-	})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/tigris/msg_collstats.go
+++ b/internal/handlers/tigris/msg_collstats.go
@@ -57,7 +57,7 @@ func (h *Handler) MsgCollStats(ctx context.Context, msg *wire.OpMsg) (*wire.OpMs
 	}
 
 	var reply wire.OpMsg
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{must.NotFail(types.NewDocument(
 			"ns", db+"."+collection,
 			"count", stats.NumObjects,
@@ -68,11 +68,7 @@ func (h *Handler) MsgCollStats(ctx context.Context, msg *wire.OpMsg) (*wire.OpMs
 			"scaleFactor", int32(1),
 			"ok", float64(1),
 		))},
-	})
-
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/tigris/msg_count.go
+++ b/internal/handlers/tigris/msg_count.go
@@ -94,15 +94,12 @@ func (h *Handler) MsgCount(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, e
 	}
 
 	var reply wire.OpMsg
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{must.NotFail(types.NewDocument(
 			"n", int32(len(resDocs)),
 			"ok", float64(1),
 		))},
-	})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/tigris/msg_datasize.go
+++ b/internal/handlers/tigris/msg_datasize.go
@@ -82,13 +82,9 @@ func (h *Handler) MsgDataSize(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg
 	)
 
 	var reply wire.OpMsg
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{must.NotFail(types.NewDocument(pairs...))},
-	})
-
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/tigris/msg_dbstats.go
+++ b/internal/handlers/tigris/msg_dbstats.go
@@ -86,7 +86,7 @@ func (h *Handler) MsgDBStats(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg,
 	}
 
 	var reply wire.OpMsg
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{must.NotFail(types.NewDocument(
 			"db", db,
 			"collections", int32(len(stats.Collections)),
@@ -102,11 +102,7 @@ func (h *Handler) MsgDBStats(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg,
 			"scaleFactor", scale,
 			"ok", float64(1),
 		))},
-	})
-
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/tigris/msg_delete.go
+++ b/internal/handlers/tigris/msg_delete.go
@@ -120,13 +120,9 @@ func (h *Handler) MsgDelete(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 	replyDoc.Set("n", deleted)
 
 	var reply wire.OpMsg
-
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{replyDoc},
-	})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/tigris/msg_distinct.go
+++ b/internal/handlers/tigris/msg_distinct.go
@@ -59,16 +59,12 @@ func (h *Handler) MsgDistinct(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg
 	}
 
 	var reply wire.OpMsg
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{must.NotFail(types.NewDocument(
 			"values", distinct,
 			"ok", float64(1),
 		))},
-	})
-
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/tigris/msg_drop.go
+++ b/internal/handlers/tigris/msg_drop.go
@@ -67,16 +67,13 @@ func (h *Handler) MsgDrop(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, er
 	}
 
 	var reply wire.OpMsg
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{must.NotFail(types.NewDocument(
 			"nIndexesWas", int32(1), // TODO
 			"ns", db+"."+collection,
 			"ok", float64(1),
 		))},
-	})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/tigris/msg_dropdatabase.go
+++ b/internal/handlers/tigris/msg_dropdatabase.go
@@ -63,12 +63,9 @@ func (h *Handler) MsgDropDatabase(ctx context.Context, msg *wire.OpMsg) (*wire.O
 	res.Set("ok", float64(1))
 
 	var reply wire.OpMsg
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{res},
-	})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/tigris/msg_explain.go
+++ b/internal/handlers/tigris/msg_explain.go
@@ -84,7 +84,7 @@ func (h *Handler) MsgExplain(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg,
 
 	var reply wire.OpMsg
 
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{must.NotFail(types.NewDocument(
 			"queryPlanner", queryPlanner,
 			"explainVersion", "1",
@@ -93,10 +93,7 @@ func (h *Handler) MsgExplain(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg,
 			"serverInfo", serverInfo,
 			"ok", float64(1),
 		))},
-	})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/tigris/msg_getlog.go
+++ b/internal/handlers/tigris/msg_getlog.go
@@ -152,10 +152,9 @@ func (h *Handler) MsgGetLog(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 	}
 
 	var reply wire.OpMsg
-	err = reply.SetSections(wire.OpMsgSection{Documents: []*types.Document{resDoc}})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	must.NoError(reply.SetSections(wire.OpMsgSection{
+		Documents: []*types.Document{resDoc},
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/tigris/msg_getparameter.go
+++ b/internal/handlers/tigris/msg_getparameter.go
@@ -46,7 +46,6 @@ func (h *Handler) MsgGetParameter(_ context.Context, msg *wire.OpMsg) (*wire.OpM
 		"ok", float64(1),
 	))
 
-	var reply wire.OpMsg
 	resDoc := resDB
 	if getParameter != "*" {
 		resDoc, err = selectParam(resDB)
@@ -55,10 +54,10 @@ func (h *Handler) MsgGetParameter(_ context.Context, msg *wire.OpMsg) (*wire.OpM
 		}
 	}
 
-	err = reply.SetSections(wire.OpMsgSection{Documents: []*types.Document{resDoc}})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	var reply wire.OpMsg
+	must.NoError(reply.SetSections(wire.OpMsgSection{
+		Documents: []*types.Document{resDoc},
+	}))
 
 	common.Ignored(document, h.L, "comment")
 

--- a/internal/handlers/tigris/msg_insert.go
+++ b/internal/handlers/tigris/msg_insert.go
@@ -86,13 +86,9 @@ func (h *Handler) MsgInsert(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 	replyDoc.Set("n", inserted)
 
 	var reply wire.OpMsg
-
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{replyDoc},
-	})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }

--- a/internal/handlers/tigris/msg_update.go
+++ b/internal/handlers/tigris/msg_update.go
@@ -185,12 +185,9 @@ func (h *Handler) MsgUpdate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 	res.Set("ok", float64(1))
 
 	var reply wire.OpMsg
-	err = reply.SetSections(wire.OpMsgSection{
+	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{res},
-	})
-	if err != nil {
-		return nil, lazyerrors.Error(err)
-	}
+	}))
 
 	return &reply, nil
 }


### PR DESCRIPTION
# Description

Just a small clean-up.

## Readiness checklist

* [ ] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [ ] I added/updated comments and checked rendering.
* [x] I made spot refactorings.
* [ ] I updated user documentation.
* [x] I ran `task all`, and it passed.
* [x] I ensured that PR title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
