### PR TITLE
Add `iterator.WithClose` helper

### DIFF
--- a/internal/handlers/pg/pgdb/query.go
+++ b/internal/handlers/pg/pgdb/query.go
@@ -129,6 +129,8 @@ func Explain(ctx context.Context, tx pgx.Tx, sp *SQLParam) (*types.Document, err
 // GetDocuments returns an queryIterator to fetch documents for given SQLParams.
 // If the collection doesn't exist, it returns an empty iterator and no error.
 // If an error occurs, it returns nil and that error, possibly wrapped.
+//
+// Transaction is not closed by this function. Use iterator.WithClose if needed.
 func GetDocuments(ctx context.Context, tx pgx.Tx, sp *SQLParam) (iterator.Interface[int, *types.Document], error) {
 	table, err := getMetadata(ctx, tx, sp.DB, sp.Collection)
 

--- a/internal/handlers/pg/pgdb/query_iterator.go
+++ b/internal/handlers/pg/pgdb/query_iterator.go
@@ -38,7 +38,7 @@ type queryIterator struct {
 
 	m     sync.Mutex
 	rows  pgx.Rows
-	stack []byte
+	stack []byte // not really under mutex, but placed there to make struct smaller (due to alignment)
 	n     int
 }
 
@@ -92,6 +92,10 @@ func (iter *queryIterator) Next() (int, *types.Document, error) {
 	}
 
 	if !iter.rows.Next() {
+		if err := iter.rows.Err(); err != nil {
+			return 0, nil, lazyerrors.Error(err)
+		}
+
 		// to avoid context cancellation changing the next `Next()` error
 		// from `iterator.ErrIteratorDone` to `context.Canceled`
 		iter.close()
@@ -123,6 +127,8 @@ func (iter *queryIterator) Close() {
 }
 
 // close closes iterator without holding mutex.
+//
+// This should be called only when the caller already holds the mutex.
 func (iter *queryIterator) close() {
 	queryIteratorProfiles.Remove(iter)
 

--- a/internal/util/iterator/close.go
+++ b/internal/util/iterator/close.go
@@ -1,0 +1,42 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iterator
+
+// withClose wraps an iterator with a custom close function.
+type withClose[K, V any] struct {
+	iter  Interface[K, V]
+	close func()
+}
+
+// WithClose wraps an iterator with a custom close function.
+//
+// That function should call Close() method of the wrapped iterator.
+func WithClose[K, V any](iter Interface[K, V], close func()) Interface[K, V] {
+	return &withClose[K, V]{
+		iter:  iter,
+		close: close,
+	}
+}
+
+// Next implements iterator.Interface by calling Next() method of the wrapped iterator.
+func (iter *withClose[K, V]) Next() (K, V, error) {
+	return iter.iter.Next()
+}
+
+// Close implements iterator.Interface by calling the provided close function.
+func (iter *withClose[K, V]) Close() {
+	// we might want to wrap it with sync.Once if needed
+	iter.close()
+}


### PR DESCRIPTION
# Description

It could be used to track both rows and transaction in a single iterator.

## Readiness checklist

* [ ] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [x] I added/updated comments and checked rendering.
* [x] I made spot refactorings.
* [ ] I updated user documentation.
* [x] I ran `task all`, and it passed.
* [x] I ensured that PR title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
