### PR TITLE
Add a test script to show `$elemMatch` behavior with inequality operators

### DIFF
--- a/build/legacy-mongo-shell/test.js
+++ b/build/legacy-mongo-shell/test.js
@@ -3,5 +3,15 @@
 (function() {
   'use strict';
 
+  const coll = db.jstests_elemmatch_value;
+  coll.drop();
+
+  assert.commandWorked(coll.insert([
+    {a: 5},
+    {a: [5]}, // matches all the specified query criteria
+    {a: [3, 7]},
+  ]))
+
+  assert.eq(coll.find({a: {$elemMatch: {$lt: 6, $gt: 4}}}, {_id: 0}).toArray(), [{a: [5]}]);
   print('test.js passed!');
 })();


### PR DESCRIPTION
# Description

This PR shows that we do not match an array field properly when using `$elemMatch`. We should match documents where at least one element satisfies _all_ the [query criteria](https://www.mongodb.com/docs/manual/reference/operator/query/elemMatch/#mongodb-query-op.-elemMatch), but we seem to match more than we should.

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [ ] I added/updated comments and checked rendering.
* [ ] I made spot refactorings.
* [ ] I updated user documentation.
* [ ] I ran `task all`, and it passed.
* [ ] I ensured that PR title is good enough for the changelog.
* [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [ ] I marked all done items in this checklist.
