### PR TITLE
Do not specify Docker Compose version

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ For more configuration options check [Configuration flags and variables](https:/
 1. Store the following in the `docker-compose.yml` file:
 
    ```yaml
-   version: "3"
-
    services:
      postgres:
        image: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
 ---
 # This file is used for the development of FerretDB, not for actually running it.
 
-version: "3.8"
-
 services:
   postgres:
     build:

--- a/website/blog/2022-10-06-how-to-start-ferretdb-locally-with-docker.md
+++ b/website/blog/2022-10-06-how-to-start-ferretdb-locally-with-docker.md
@@ -40,9 +40,6 @@ Ensure to specify the `POSTGRES_DB` env variable with the same database name for
 It will be used to store all MongoDB collections.
 
 ```js
-version: "3"
-
-services:
 services:
   postgres:
     image: postgres:14

--- a/website/docs/quickstart_guide/docker.md
+++ b/website/docs/quickstart_guide/docker.md
@@ -12,8 +12,6 @@ For more configuration options check [Configuration flags and variables](../flag
 1. Store the following in the `docker-compose.yml` file:
 
    ```yaml
-   version: "3"
-
    services:
      postgres:
        image: postgres


### PR DESCRIPTION
# Description

It is deprecated: https://docs.docker.com/compose/compose-file/compose-versioning/

## Readiness checklist

* [ ] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [ ] I added/updated comments and checked rendering.
* [ ] I made spot refactorings.
* [x] I updated user documentation.
* [x] I ran `task all`, and it passed.
* [x] I ensured that PR title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
