### PR TITLE
Add `env-repl` to Taskfile

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -138,7 +138,7 @@ tasks:
     desc: "A minimal environment for testing a single-node replica set"
     cmds:
       - >
-        docker compose up --always-recreate-deps --force-recreate --remove-orphans --renew-anon-volumes --timeout=0 --detach --build --pull=always {{.REPLSET}}
+        docker compose up --always-recreate-deps --force-recreate --remove-orphans --renew-anon-volumes --timeout=0 --detach --build {{.REPLSET}}
       - task: env-logs
   gen:
     desc: "Generate (and format) code"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -264,7 +264,7 @@ tasks:
         bin/ferretdb-testcover{{exeExt}} -test.coverprofile=cover.txt --
         --listen-addr=:27017
         --proxy-addr=127.0.0.1:47017
-        --mode=normal
+        --mode=diff-normal
         --handler=pg
         --postgresql-url=postgres://username@127.0.0.1:5432/ferretdb
         --test-records-dir=records

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -12,6 +12,7 @@ vars:
   UNIXSOCKETFLAG: -target-unix-socket={{ne OS "windows"}}
   BUILDTAGS: ferretdb_debug,ferretdb_tigris,ferretdb_hana
   SERVICES: postgres postgres_secured tigris tigris1 tigris2 tigris3 tigris4 mongodb mongodb_secured jaeger
+  REPLSET: postgres mongodb_replset init_mongodb_replset
 
 tasks:
   # invoked when `task` is run without arguments
@@ -132,7 +133,13 @@ tasks:
     desc: "Fill `test` database with data for experiments"
     cmds:
       - bin/task{{exeExt}} -d integration env-data
-
+  
+  env-repl:
+    desc: "A minimal environment for testing a single-node replica set"
+    cmds:
+      - >
+        docker compose up --always-recreate-deps --force-recreate --remove-orphans --renew-anon-volumes --timeout=0 --detach --build --pull=always {{.REPLSET}}
+      - task: env-logs
   gen:
     desc: "Generate (and format) code"
     cmds:
@@ -257,7 +264,7 @@ tasks:
         bin/ferretdb-testcover{{exeExt}} -test.coverprofile=cover.txt --
         --listen-addr=:27017
         --proxy-addr=127.0.0.1:47017
-        --mode=diff-normal
+        --mode=normal
         --handler=pg
         --postgresql-url=postgres://username@127.0.0.1:5432/ferretdb
         --test-records-dir=records

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -138,7 +138,7 @@ tasks:
     desc: "A minimal environment for testing a single-node replica set"
     cmds:
       - >
-        docker compose up --always-recreate-deps --force-recreate --remove-orphans --renew-anon-volumes --timeout=0 --detach --build {{.REPLSET}}
+        docker compose up --remove-orphans --renew-anon-volumes --timeout=0 --detach --build {{.REPLSET}}
       - task: env-logs
   gen:
     desc: "Generate (and format) code"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,7 +110,7 @@ services:
       context: ./build/deps
       dockerfile: ${MONGO_DOCKERFILE:-mongo6}.Dockerfile
     container_name: mongodb_replset
-    command: mongod --port 27017 --bind_ip_all --replSet rs0
+    command: --config /etc/mongod.conf
     ports:
       - 47017:27017
     extra_hosts:
@@ -118,6 +118,8 @@ services:
     environment:
       # Always UTC+05:45. Set to catch timezone problems.
       - TZ=Asia/Kathmandu
+    volumes:
+      - ./build/mongod_repl.conf:/etc/mongod.conf
   
   # initiates the replica set
   init_mongodb_replset:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,6 +103,32 @@ services:
     volumes:
       - ./build/certs:/etc/certs
       - ./build/mongod.conf:/etc/mongod.conf
+  
+  # used to testing the oplog
+  mongodb_replset:
+    build:
+      context: ./build/deps
+      dockerfile: ${MONGO_DOCKERFILE:-mongo6}.Dockerfile
+    container_name: mongodb_replset
+    command: mongod --port 27017 --bind_ip_all --replSet rs0
+    ports:
+      - 47017:27017
+    extra_hosts:
+    - "host.docker.internal:host-gateway"
+    environment:
+      # Always UTC+05:45. Set to catch timezone problems.
+      - TZ=Asia/Kathmandu
+  
+  # initiates the replica set
+  init_mongodb_replset:
+    build:
+      context: ./build/deps
+      dockerfile: legacy-mongo-shell.Dockerfile
+    container_name: init_mongodb_replset
+    depends_on:
+      - mongodb_replset
+    restart: "no"
+    entrypoint: ["bash", "-c", "sleep 10 && mongo --host mongodb_replset:27017 --eval 'rs.initiate();'"]  
 
   mongodb_secured:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,7 @@ services:
       - ./build/mongod_repl.conf:/etc/mongod.conf
   
   # initiates the replica set
+  # we need a seperate container to run rs.initiate()
   init_mongodb_replset:
     build:
       context: ./build/deps

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,7 +128,7 @@ services:
     depends_on:
       - mongodb_replset
     restart: "no"
-    entrypoint: ["bash", "-c", "mongosh --host mongodb_replset:27017 --eval 'rs.initiate();'"]  
+    entrypoint: ["bash", "-c", "sleep 10 && mongosh --host mongodb_replset:27017 --eval 'rs.initiate();'"]  
 
   mongodb_secured:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
       - ./build/mongod_repl.conf:/etc/mongod.conf
   
   # initiates the replica set
-  # we need a seperate container to run rs.initiate()
+  # we need a separate container to run rs.initiate()
   init_mongodb_replset:
     build:
       context: ./build/deps

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,7 +104,7 @@ services:
       - ./build/certs:/etc/certs
       - ./build/mongod.conf:/etc/mongod.conf
   
-  # used to testing the oplog
+  # used for testing a replica set
   mongodb_replset:
     build:
       context: ./build/deps

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,12 +123,12 @@ services:
   init_mongodb_replset:
     build:
       context: ./build/deps
-      dockerfile: legacy-mongo-shell.Dockerfile
+      dockerfile: ${MONGO_DOCKERFILE:-mongo6}.Dockerfile
     container_name: init_mongodb_replset
     depends_on:
       - mongodb_replset
     restart: "no"
-    entrypoint: ["bash", "-c", "sleep 10 && mongo --host mongodb_replset:27017 --eval 'rs.initiate();'"]  
+    entrypoint: ["bash", "-c", "mongosh --host mongodb_replset:27017 --eval 'rs.initiate();'"]  
 
   mongodb_secured:
     build:


### PR DESCRIPTION
# Description

Tracked by https://github.com/FerretDB/dance/pull/351.

This PR adds a task to create a single-node replica set. This is useful for testing the oplog and change streams. I opted to create separate containers but we could just convert all instances to a replica set if that's better. However, that would add more log output by introducing [REPL](https://www.mongodb.com/docs/manual/reference/log-messages/#mongodb-data-REPL) messages.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [ ] I added/updated comments and checked rendering.
* [ ] I made spot refactorings.
* [ ] I updated user documentation.
* [ ] I ran `task all`, and it passed.
* [x] I ensured that PR title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
