### PR TITLE
Fix skip for tigris in integration test

### DIFF
--- a/integration/setup/test_helpers.go
+++ b/integration/setup/test_helpers.go
@@ -46,7 +46,9 @@ func SkipForTigrisWithReason(tb testing.TB, reason string) {
 
 	require.NotEmpty(tb, reason, "reason must not be empty")
 
-	tb.Skipf("Skipping for Tigris: %s.", reason)
+	if IsTigris(tb) {
+		tb.Skipf("Skipping for Tigris: %s.", reason)
+	}
 }
 
 // TigrisOnlyWithReason skips the current test except for FerretDB with `tigris` handler.


### PR DESCRIPTION
# Description

Skip tigris skips only tigris tests, it's skipping more tests than we want.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [ ] I added/updated comments and checked rendering.
* [ ] I made spot refactorings.
* [ ] I updated user documentation.
* [ ] I ran `task all`, and it passed.
* [ ] I ensured that PR title is good enough for the changelog.
* [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [ ] I marked all done items in this checklist.
