### PR TITLE
Make `$pullAll` remove all instances from the existing array

### DIFF
--- a/build/legacy-mongo-shell/test.js
+++ b/build/legacy-mongo-shell/test.js
@@ -6,6 +6,14 @@
   const t = db.pullall;
   t.drop();
 
+  t.insert({_id: 1, a: [0, 2, 5, 5, 1, 0]});
+  t.updateOne({_id: 1}, {$pullAll: {a: [0, 5]}});
+  const res = t.findOne().a;
+  res.sort();
+  assert.eq([1, 2], res);
+
+  t.drop();
+
   t.insert({a: [1, 2, 3]});
   t.update({}, {$pullAll: {a: [3]}});
   assert.eq([1, 2], t.findOne().a);

--- a/build/legacy-mongo-shell/test.js
+++ b/build/legacy-mongo-shell/test.js
@@ -3,5 +3,40 @@
 (function() {
   'use strict';
 
+  const t = db.pullall;
+  t.drop();
+
+  t.insert({a: [1, 2, 3]});
+  t.update({}, {$pullAll: {a: [3]}});
+  assert.eq([1, 2], t.findOne().a);
+  t.update({}, {$pullAll: {a: [3]}});
+  assert.eq([1, 2], t.findOne().a);
+
+  t.drop();
+  t.insert({a: [1, 2, 3]});
+  t.update({}, {$pullAll: {a: [2, 3]}});
+  assert.eq([1], t.findOne().a);
+  t.update({}, {$pullAll: {a: []}});
+  assert.eq([1], t.findOne().a);
+  t.update({}, {$pullAll: {a: [5]}});
+  assert.eq([1], t.findOne().a);
+  t.update({}, {$pullAll: {a: [1, 5]}});
+  assert.eq([], t.findOne().a);
+
+  // test we can pull an embedded array
+  t.drop();
+  const ten = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+  t.insert({a: {b: ten}});
+  t.update({}, {$pullAll: {'a.b': ten}});
+  assert.eq([], t.findOne().a.b);
+
+
+  t.drop();
+  t.insert({m: 1});
+  t.update({m: 1}, {$pullAll: {'a.b': [1]}});
+  assert(('a' in t.findOne()) == false);
+  t.update({m: 1}, {$pullAll: {'x.y': [1]}});
+  assert(('z' in t.findOne()) == false);
+
   print('test.js passed!');
 })();

--- a/internal/handlers/common/update_array_operators.go
+++ b/internal/handlers/common/update_array_operators.go
@@ -317,7 +317,6 @@ func processAddToSetArrayUpdateExpression(doc, update *types.Document) (bool, er
 }
 
 // processpulAllUpdateExpression changes document according to $pullAll array update operator.
-// It should remove all instances of value from the array.
 func processPullAllArrayUpdateExpression(doc, update *types.Document) (bool, error) {
 	var changed bool
 

--- a/internal/handlers/common/update_array_operators.go
+++ b/internal/handlers/common/update_array_operators.go
@@ -374,7 +374,6 @@ func processPullAllArrayUpdateExpression(doc, update *types.Document) (bool, err
 			)
 		}
 
-		// remove all instances
 		for j := 0; j < pullAllArray.Len(); j++ {
 			valueToPull, indexErr := pullAllArray.Get(j)
 			if err != nil {

--- a/internal/handlers/common/update_array_operators.go
+++ b/internal/handlers/common/update_array_operators.go
@@ -374,17 +374,18 @@ func processPullAllArrayUpdateExpression(doc, update *types.Document) (bool, err
 			)
 		}
 
+		// remove all instances
 		for j := 0; j < pullAllArray.Len(); j++ {
-			valueToPull, err := pullAllArray.Get(j)
+			valueToPull, indexErr := pullAllArray.Get(j)
 			if err != nil {
-				return false, lazyerrors.Error(err)
+				return false, lazyerrors.Error(indexErr)
 			}
 
 			i := array.Len() - 1
 			for i >= 0 {
-				value, err := array.Get(i)
+				value, indexErr := array.Get(i)
 				if err != nil {
-					return false, lazyerrors.Error(err)
+					return false, lazyerrors.Error(indexErr)
 				}
 
 				if types.Compare(value, valueToPull) == types.Equal {


### PR DESCRIPTION
# Description

When I was testing I noticed that https://github.com/FerretDB/FerretDB/pull/2032 did not remove all instances from the array. According to [here](https://www.mongodb.com/docs/v6.0/reference/operator/update/pullAll/#behavior) it should remove all instances specified in the `$pullAll` field. This PR attempts to resolve that issue.

branch.txt: pullall-fix
version.txt: v0.9.2-rc.1-5-g3b261df-dirty
commit.txt: 3b261dff96c576cdc809d736ffc8242156dcfcea

Example:

```
> const t = db.pullall;
> t.drop();
true
> t.insert({_id: 1, a: [0, 2, 5, 5, 1, 0]});
WriteResult({ "nInserted" : 1 })
// remove all instances of 0 and 5 in a.
> t.updateOne({_id: 1}, {$pullAll: {a: [0, 5]}});
{ "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 1 }
> const res = t.findOne().a;
> res.sort();
> assert.eq([1, 2], res);
uncaught exception: Error: [[ 1, 2 ]] != [[ 0, 1, 2, 5 ]] are not equal :
doassert@src/mongo/shell/assert.js:20:14
assert.eq@src/mongo/shell/assert.js:180:17
@(shell):1:8
> 
```

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [ ] I added/updated comments and checked rendering.
* [ ] I made spot refactorings.
* [ ] I updated user documentation.
* [ ] I ran `task all`, and it passed.
* [ ] I ensured that PR title is good enough for the changelog.
* [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [ ] I marked all done items in this checklist.
