### PR TITLE
Pushdown `date` values

### DIFF
--- a/integration/query_comparison_compat_test.go
+++ b/integration/query_comparison_compat_test.go
@@ -86,7 +86,6 @@ func testQueryComparisonCompatImplicit() map[string]queryCompatTestCase {
 			filter:         bson.D{{"v", math.SmallestNonzeroFloat64}},
 			resultPushdown: true,
 		},
-
 		"DoubleBigInt64": {
 			filter:         bson.D{{"v", float64(2 << 61)}},
 			resultPushdown: true,
@@ -144,6 +143,22 @@ func testQueryComparisonCompatImplicit() map[string]queryCompatTestCase {
 		},
 		"BoolTrue": {
 			filter:         bson.D{{"v", true}},
+			resultPushdown: true,
+		},
+		"Datetime": {
+			filter:         bson.D{{"v", primitive.NewDateTimeFromTime(time.Date(2021, 11, 1, 10, 18, 42, 123000000, time.UTC))}},
+			resultPushdown: true,
+		},
+		"DatetimeEpoch": {
+			filter:         bson.D{{"v", primitive.NewDateTimeFromTime(time.Unix(0, 0))}},
+			resultPushdown: true,
+		},
+		"DatetimeYearMin": {
+			filter:         bson.D{{"v", primitive.NewDateTimeFromTime(time.Date(0, 1, 1, 0, 0, 0, 0, time.UTC))}},
+			resultPushdown: true,
+		},
+		"DatetimeYearMax": {
+			filter:         bson.D{{"v", primitive.NewDateTimeFromTime(time.Date(9999, 12, 31, 23, 59, 59, 999000000, time.UTC))}},
 			resultPushdown: true,
 		},
 		"IDNull": {
@@ -322,16 +337,20 @@ func testQueryComparisonCompatEq() map[string]queryCompatTestCase {
 			resultPushdown: true,
 		},
 		"Datetime": {
-			filter: bson.D{{"v", bson.D{{"$eq", primitive.NewDateTimeFromTime(time.Date(2021, 11, 1, 10, 18, 42, 123000000, time.UTC))}}}},
+			filter:         bson.D{{"v", bson.D{{"$eq", primitive.NewDateTimeFromTime(time.Date(2021, 11, 1, 10, 18, 42, 123000000, time.UTC))}}}},
+			resultPushdown: true,
 		},
 		"DatetimeEpoch": {
-			filter: bson.D{{"v", bson.D{{"$eq", primitive.NewDateTimeFromTime(time.Unix(0, 0))}}}},
-		},
-		"DatetimeYearMax": {
-			filter: bson.D{{"v", bson.D{{"$eq", primitive.NewDateTimeFromTime(time.Date(0, 1, 1, 0, 0, 0, 0, time.UTC))}}}},
+			filter:         bson.D{{"v", bson.D{{"$eq", primitive.NewDateTimeFromTime(time.Unix(0, 0))}}}},
+			resultPushdown: true,
 		},
 		"DatetimeYearMin": {
-			filter: bson.D{{"v", bson.D{{"$eq", primitive.NewDateTimeFromTime(time.Date(9999, 12, 31, 23, 59, 59, 999000000, time.UTC))}}}},
+			filter:         bson.D{{"v", bson.D{{"$eq", primitive.NewDateTimeFromTime(time.Date(0, 1, 1, 0, 0, 0, 0, time.UTC))}}}},
+			resultPushdown: true,
+		},
+		"DatetimeYearMax": {
+			filter:         bson.D{{"v", bson.D{{"$eq", primitive.NewDateTimeFromTime(time.Date(9999, 12, 31, 23, 59, 59, 999000000, time.UTC))}}}},
+			resultPushdown: true,
 		},
 		"Null": {
 			filter: bson.D{{"v", bson.D{{"$eq", nil}}}},
@@ -1022,16 +1041,20 @@ func testQueryComparisonCompatNe() map[string]queryCompatTestCase {
 			resultPushdown: true,
 		},
 		"Datetime": {
-			filter: bson.D{{"v", bson.D{{"$ne", primitive.NewDateTimeFromTime(time.Date(2021, 11, 1, 10, 18, 42, 123000000, time.UTC))}}}},
+			filter:         bson.D{{"v", bson.D{{"$ne", primitive.NewDateTimeFromTime(time.Date(2021, 11, 1, 10, 18, 42, 123000000, time.UTC))}}}},
+			resultPushdown: true,
 		},
 		"DatetimeEpoch": {
-			filter: bson.D{{"v", bson.D{{"$ne", primitive.NewDateTimeFromTime(time.Unix(0, 0))}}}},
-		},
-		"DatetimeYearMax": {
-			filter: bson.D{{"v", bson.D{{"$ne", primitive.NewDateTimeFromTime(time.Date(0, 1, 1, 0, 0, 0, 0, time.UTC))}}}},
+			filter:         bson.D{{"v", bson.D{{"$ne", primitive.NewDateTimeFromTime(time.Unix(0, 0))}}}},
+			resultPushdown: true,
 		},
 		"DatetimeYearMin": {
-			filter: bson.D{{"v", bson.D{{"$ne", primitive.NewDateTimeFromTime(time.Date(9999, 12, 31, 23, 59, 59, 999000000, time.UTC))}}}},
+			filter:         bson.D{{"v", bson.D{{"$ne", primitive.NewDateTimeFromTime(time.Date(0, 1, 1, 0, 0, 0, 0, time.UTC))}}}},
+			resultPushdown: true,
+		},
+		"DatetimeYearMax": {
+			filter:         bson.D{{"v", bson.D{{"$ne", primitive.NewDateTimeFromTime(time.Date(9999, 12, 31, 23, 59, 59, 999000000, time.UTC))}}}},
+			resultPushdown: true,
 		},
 		"Timestamp": {
 			filter: bson.D{{"v", bson.D{{"$ne", primitive.Timestamp{T: 42, I: 13}}}}},

--- a/internal/handlers/pg/pgdb/query.go
+++ b/internal/handlers/pg/pgdb/query.go
@@ -296,9 +296,9 @@ func prepareWhereClause(sqlFilters *types.Document) (string, []any, error) {
 				case "$eq":
 					switch v := v.(type) {
 					case *types.Document, *types.Array, types.Binary,
-						time.Time, types.NullType, types.Regex, types.Timestamp:
+						types.NullType, types.Regex, types.Timestamp:
 						// type not supported for pushdown
-					case float64, string, types.ObjectID, bool, int32, int64:
+					case float64, string, types.ObjectID, bool, time.Time, int32, int64:
 						// Select if value under the key is equal to provided value.
 						sql := `_jsonb->%[1]s @> %[2]s`
 
@@ -311,9 +311,9 @@ func prepareWhereClause(sqlFilters *types.Document) (string, []any, error) {
 				case "$ne":
 					switch v := v.(type) {
 					case *types.Document, *types.Array, types.Binary,
-						time.Time, types.NullType, types.Regex, types.Timestamp:
+						types.NullType, types.Regex, types.Timestamp:
 						// type not supported for pushdown
-					case float64, string, types.ObjectID, bool, int32, int64:
+					case float64, string, types.ObjectID, bool, time.Time, int32, int64:
 						sql := `NOT ( ` +
 							// does document contain the key,
 							// it is necessary, as NOT won't work correctly if the key does not exist.
@@ -335,11 +335,11 @@ func prepareWhereClause(sqlFilters *types.Document) (string, []any, error) {
 				}
 			}
 
-		case *types.Array, types.Binary, time.Time, types.NullType, types.Regex, types.Timestamp:
+		case *types.Array, types.Binary, types.NullType, types.Regex, types.Timestamp:
 			// type not supported for pushdown
 			continue
 
-		case float64, string, types.ObjectID, bool, int32, int64:
+		case float64, string, types.ObjectID, bool, time.Time, int32, int64:
 			// Select if value under the key is equal to provided value.
 			sql := `_jsonb->%[1]s @> %[2]s`
 

--- a/internal/handlers/pg/pgdb/query_test.go
+++ b/internal/handlers/pg/pgdb/query_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v4"
 	"github.com/stretchr/testify/assert"
@@ -350,6 +351,12 @@ func TestPrepareWhereClause(t *testing.T) {
 			filter:   must.NotFail(types.NewDocument("v", true)),
 			expected: whereContain,
 		},
+		"ImplicitDatetime": {
+			filter: must.NotFail(types.NewDocument(
+				"v", time.Date(2021, 11, 1, 10, 18, 42, 123000000, time.UTC),
+			)),
+			expected: whereContain,
+		},
 		"ImplicitObjectID": {
 			filter:   must.NotFail(types.NewDocument("v", objectID)),
 			expected: whereContain,
@@ -407,6 +414,14 @@ func TestPrepareWhereClause(t *testing.T) {
 			)),
 			expected: whereContain,
 		},
+		"EqDatetime": {
+			filter: must.NotFail(types.NewDocument(
+				"v", must.NotFail(types.NewDocument(
+					"$eq", time.Date(2021, 11, 1, 10, 18, 42, 123000000, time.UTC),
+				)),
+			)),
+			expected: whereContain,
+		},
 		"EqObjectID": {
 			filter: must.NotFail(types.NewDocument(
 				"v", must.NotFail(types.NewDocument("$eq", objectID)),
@@ -456,6 +471,14 @@ func TestPrepareWhereClause(t *testing.T) {
 				"v", must.NotFail(types.NewDocument("$ne", true)),
 			)),
 			expected: whereNotEq + `'"bool"' )`,
+		},
+		"NeDatetime": {
+			filter: must.NotFail(types.NewDocument(
+				"v", must.NotFail(types.NewDocument(
+					"$ne", time.Date(2021, 11, 1, 10, 18, 42, 123000000, time.UTC),
+				)),
+			)),
+			expected: whereNotEq + `'"date"' )`,
 		},
 		"NeObjectID": {
 			filter: must.NotFail(types.NewDocument(

--- a/internal/handlers/tigris/tigrisdb/query.go
+++ b/internal/handlers/tigris/tigrisdb/query.go
@@ -151,9 +151,9 @@ func BuildFilter(filter *types.Document) (string, error) {
 				case "$eq":
 					switch docVal := v.(type) {
 					case *types.Document, *types.Array, types.Binary,
-						time.Time, types.NullType, types.Regex, types.Timestamp:
+						types.NullType, types.Regex, types.Timestamp:
 						// type not supported for pushdown
-					case float64, string, types.ObjectID, bool, int32, int64:
+					case float64, string, types.ObjectID, bool, time.Time, int32, int64:
 						rawValue, err := tjson.Marshal(docVal)
 						if err != nil {
 							return "", lazyerrors.Error(err)
@@ -170,11 +170,11 @@ func BuildFilter(filter *types.Document) (string, error) {
 				}
 			}
 
-		case *types.Array, types.Binary, time.Time, types.NullType, types.Regex, types.Timestamp:
+		case *types.Array, types.Binary, types.NullType, types.Regex, types.Timestamp:
 			// type not supported for pushdown
 			continue
 
-		case float64, string, types.ObjectID, bool, int32, int64:
+		case float64, string, types.ObjectID, bool, time.Time, int32, int64:
 			rawValue, err := tjson.Marshal(v)
 			if err != nil {
 				return "", lazyerrors.Error(err)

--- a/internal/handlers/tigris/tigrisdb/query_test.go
+++ b/internal/handlers/tigris/tigrisdb/query_test.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -279,6 +280,12 @@ func TestBuildFilter(t *testing.T) {
 			filter:   must.NotFail(types.NewDocument("v", true)),
 			expected: `{"v":true}`,
 		},
+		"ImplicitDatetime": {
+			filter: must.NotFail(types.NewDocument(
+				"v", time.Date(2021, 11, 1, 10, 18, 42, 123000000, time.UTC),
+			)),
+			expected: `{"v":"2021-11-01T10:18:42.123Z"}`,
+		},
 		"ImplicitObjectID": {
 			filter:   must.NotFail(types.NewDocument("v", objectID)),
 			expected: `{"v":"YlbFugutwP/u////"}`,
@@ -326,6 +333,14 @@ func TestBuildFilter(t *testing.T) {
 				"v", must.NotFail(types.NewDocument("$eq", true)),
 			)),
 			expected: `{"v":true}`,
+		},
+		"EqDatetime": {
+			filter: must.NotFail(types.NewDocument(
+				"v", must.NotFail(types.NewDocument(
+					"$eq", time.Date(2021, 11, 1, 10, 18, 42, 123000000, time.UTC),
+				)),
+			)),
+			expected: `{"v":"2021-11-01T10:18:42.123Z"}`,
 		},
 		"EqObjectID": {
 			filter: must.NotFail(types.NewDocument(


### PR DESCRIPTION
# Description

Closes #2114.

`$eq` should work correctly, the tests for Max and Min values were already there and I couldn't came up with any other corner cases that could potentially skip some data. As we don't validate types on backend, query will prefetch everything that's equal to underlying value, but the final type filtering is done by FerretDB.

`$ne` should work correctly as it does the type checking on the backend.

I've also changed the name of PR to `date` as that's how bson call it. If we prefer other naming like `datetime`, `time` or anything, feel free to edit it.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [x] I added/updated unit tests.
* [x] I added/updated integration/compatibility tests.
* [ ] I added/updated comments and checked rendering.
* [ ] I made spot refactorings.
* [ ] I updated user documentation.
* [ ] I ran `task all`, and it passed.
* [x] I ensured that PR title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
