### PR TITLE
Disable value marshaling on pushdown for string.

### DIFF
--- a/internal/handlers/pg/pgdb/query.go
+++ b/internal/handlers/pg/pgdb/query.go
@@ -271,12 +271,18 @@ func prepareWhereClause(sqlFilters *types.Document) (string, []any, error) {
 					case *types.Document, *types.Array, types.Binary,
 						types.NullType, types.Regex, types.Timestamp:
 						// type not supported for pushdown
-					case float64, string, types.ObjectID, bool, time.Time, int32, int64:
+					case float64, types.ObjectID, bool, time.Time, int32, int64:
 						// Select if value under the key is equal to provided value.
 						sql := `_jsonb->%[1]s @> %[2]s`
 
 						filters = append(filters, fmt.Sprintf(sql, p.Next(), p.Next()))
 						args = append(args, rootKey, string(must.NotFail(pjson.MarshalSingleValue(v))))
+					case string:
+						// Select if value under the key is equal to provided value.
+						sql := `_jsonb->%[1]s @> %[2]s`
+
+						filters = append(filters, fmt.Sprintf(sql, p.Next(), p.Next()))
+						args = append(args, rootKey, v)
 					default:
 						panic(fmt.Sprintf("Unexpected type of value: %v", v))
 					}


### PR DESCRIPTION
# Description

Closes #2057.

This PR demonstrates how SQL query fails if we don't marshal string argument to json value. I disabled `MarshalSingleValue` only for string and only for `$eq` just for a simpler debugging.

The motivation behind this change is that in most cases we shouldn't marshal values to json. For example, currently we marshal int64(42) to `"42"`, but it works either without marshaling, and send just `42` as an SQL argument.

It seems though, that after disabling marshal for strings, query fails:
```
logger.go:130: 2023-03-13T14:29:35.200+0100 ERROR   pgdb    v4@v4.18.1/conn.go:354  Query   {"err": "ERROR: invalid input syntax for type json (SQLSTATE 22P02)", "sql": "EXPLAIN (VERBOSE true, FORMAT JSON) SELECT _jsonb  FROM \"testquerycompatrunner_pg\".\"TestQueryCompatRunner_ObjectIDKeys_b4c0615a\" WHERE _jsonb->$1 @> $2", "time": "786.058µs", "args": ["v","foo"], "pid": 326}
```

I assume that from pgx perspective it's required for strings to be double quoted like: `"\"foo\""`.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [ ] I added/updated comments and checked rendering.
* [ ] I made spot refactorings.
* [ ] I updated user documentation.
* [ ] I ran `task all`, and it passed.
* [ ] I ensured that PR title is good enough for the changelog.
* [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [ ] I marked all done items in this checklist.
