### PR TITLE
Fix `hana` and `tigris` handlers initialization

### DIFF
--- a/cmd/ferretdb/main_hana.go
+++ b/cmd/ferretdb/main_hana.go
@@ -16,11 +16,7 @@
 
 package main
 
-import (
-	"github.com/alecthomas/kong"
-)
-
 // init adds "hana" handler flags when "ferretdb_hana" build tag is provided.
 func init() {
-	cli.Plugins = kong.Plugins{&hanaFlags}
+	cli.Plugins = append(cli.Plugins, &hanaFlags)
 }

--- a/cmd/ferretdb/main_tigris.go
+++ b/cmd/ferretdb/main_tigris.go
@@ -16,11 +16,7 @@
 
 package main
 
-import (
-	"github.com/alecthomas/kong"
-)
-
 // init adds "tigris" handler flags when "ferretdb_tigris" build tag is provided.
 func init() {
-	cli.Plugins = kong.Plugins{&tigrisFlags}
+	cli.Plugins = append(cli.Plugins, &tigrisFlags)
 }


### PR DESCRIPTION
# Description

One of them disabled another.

## Readiness checklist

* [ ] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [ ] I added/updated comments and checked rendering.
* [ ] I made spot refactorings.
* [ ] I updated user documentation.
* [ ] I ran `task all`, and it passed.
* [x] I ensured that PR title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
