### PR TITLE
Add test script to show `$elemMatch` behaviour with embedded documents

### DIFF
--- a/build/legacy-mongo-shell/test.js
+++ b/build/legacy-mongo-shell/test.js
@@ -3,5 +3,13 @@
 (function() {
   'use strict';
 
+  const t = db.foo;
+  t.drop();
+
+  t.save({a: [{}, {b: 1}]});
+  assert.eq(1, t.find({'a.b': 1}).itcount()); // to show the expected behaviour.
+
+  assert.eq(1, t.find({a: {$elemMatch: {b: 1}}}).itcount());
+
   print('test.js passed!');
 })();


### PR DESCRIPTION
# Description

This PR adds a test script to show that we do not match an array of embedded documents when using the `$elemMatch` operator.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [ ] I added/updated comments and checked rendering.
* [ ] I made spot refactorings.
* [ ] I updated user documentation.
* [ ] I ran `task all`, and it passed.
* [ ] I ensured that PR title is good enough for the changelog.
* [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [ ] I marked all done items in this checklist.
