### PR TITLE
Fix traffic recording

### DIFF
--- a/internal/clientconn/conn.go
+++ b/internal/clientconn/conn.go
@@ -177,7 +177,8 @@ func (c *conn) run(ctx context.Context) (err error) {
 
 		var f *os.File
 
-		if f, err = os.CreateTemp("", "ferretdb-test-record-*.bin"); err != nil {
+		// use local directory so os.Rename below always works
+		if f, err = os.CreateTemp(c.testRecordsDir, "_*.partial"); err != nil {
 			return
 		}
 


### PR DESCRIPTION
# Description

`os.Rename` fails when `/tmp` and `./tmp` are on different devices.

## Readiness checklist

* [ ] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [x] I added/updated comments and checked rendering.
* [ ] I made spot refactorings.
* [ ] I updated user documentation.
* [ ] I ran `task all`, and it passed.
* [x] I ensured that PR title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
