### PR TITLE
Remove indexes from `DocumentsIterator`

### DIFF
--- a/internal/handlers/common/filter_iterator.go
+++ b/internal/handlers/common/filter_iterator.go
@@ -22,8 +22,6 @@ import (
 // FilterIterator returns an iterator that filters out documents that don't match the filter.
 //
 // Next method returns the next document that matches the filter.
-// Returned indexes are the same as in the underlying iterator.
-// If the document was filtered out, that index will be skipped.
 //
 // Close method closes the underlying iterator.
 // For that reason, there is no need to track both iterators.
@@ -41,20 +39,22 @@ type filterIterator struct {
 }
 
 // Next implements iterator.Interface. See FilterIterator for details.
-func (iter *filterIterator) Next() (int, *types.Document, error) {
+func (iter *filterIterator) Next() (struct{}, *types.Document, error) {
+	var unused struct{}
+
 	for {
-		i, doc, err := iter.iter.Next()
+		_, doc, err := iter.iter.Next()
 		if err != nil {
-			return 0, nil, lazyerrors.Error(err)
+			return unused, nil, lazyerrors.Error(err)
 		}
 
 		matches, err := FilterDocument(doc, iter.filter)
 		if err != nil {
-			return 0, nil, lazyerrors.Error(err)
+			return unused, nil, lazyerrors.Error(err)
 		}
 
 		if matches {
-			return i, doc, nil
+			return unused, doc, nil
 		}
 	}
 }

--- a/internal/handlers/pg/msg_aggregate.go
+++ b/internal/handlers/pg/msg_aggregate.go
@@ -115,7 +115,7 @@ func (h *Handler) MsgAggregate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMs
 			return getErr
 		}
 
-		docs, err = iterator.Values(iterator.Interface[int, *types.Document](iter))
+		docs, err = iterator.Values(iterator.Interface[struct{}, *types.Document](iter))
 		return err
 	})
 

--- a/internal/handlers/pg/msg_find.go
+++ b/internal/handlers/pg/msg_find.go
@@ -83,7 +83,7 @@ func (h *Handler) MsgFind(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, er
 
 		iter = common.FilterIterator(iter, params.Filter)
 
-		resDocs, err = iterator.Values(iterator.Interface[int, *types.Document](iter))
+		resDocs, err = iterator.Values(iterator.Interface[struct{}, *types.Document](iter))
 		return err
 	})
 
@@ -172,5 +172,5 @@ func fetchAndFilterDocs(ctx context.Context, fp *fetchParams) ([]*types.Document
 
 	f := common.FilterIterator(iter, filter)
 
-	return iterator.Values(iterator.Interface[int, *types.Document](f))
+	return iterator.Values(iterator.Interface[struct{}, *types.Document](f))
 }

--- a/internal/handlers/pg/pgdb/query_iterator.go
+++ b/internal/handlers/pg/pgdb/query_iterator.go
@@ -35,12 +35,11 @@ var queryIteratorProfiles = pprof.NewProfile("github.com/FerretDB/FerretDB/inter
 // queryIterator implements iterator.Interface to fetch documents from the database.
 type queryIterator struct {
 	ctx       context.Context
-	unmarshal func(b []byte) (*types.Document, error) // defaults to pjson.Unmarshal.
+	unmarshal func(b []byte) (*types.Document, error) // defaults to pjson.Unmarshal
 
 	m     sync.Mutex
 	rows  pgx.Rows
 	stack []byte // not really under mutex, but placed there to make struct smaller (due to alignment)
-	n     int
 }
 
 // newIterator returns a new queryIterator for the given pgx.Rows.
@@ -85,44 +84,44 @@ func newIterator(ctx context.Context, rows pgx.Rows, p *iteratorParams) types.Do
 //
 // Otherwise, as the first value it returns the number of the current iteration (starting from 0),
 // as the second value it returns the document.
-func (iter *queryIterator) Next() (int, *types.Document, error) {
+func (iter *queryIterator) Next() (struct{}, *types.Document, error) {
 	iter.m.Lock()
 	defer iter.m.Unlock()
 
+	var unused struct{}
+
 	// ignore context error, if any, if iterator is already closed
 	if iter.rows == nil {
-		return 0, nil, iterator.ErrIteratorDone
+		return unused, nil, iterator.ErrIteratorDone
 	}
 
 	if err := iter.ctx.Err(); err != nil {
-		return 0, nil, lazyerrors.Error(err)
+		return unused, nil, lazyerrors.Error(err)
 	}
 
 	if !iter.rows.Next() {
 		if err := iter.rows.Err(); err != nil {
-			return 0, nil, lazyerrors.Error(err)
+			return unused, nil, lazyerrors.Error(err)
 		}
 
 		// to avoid context cancellation changing the next `Next()` error
 		// from `iterator.ErrIteratorDone` to `context.Canceled`
 		iter.close()
 
-		return 0, nil, iterator.ErrIteratorDone
+		return unused, nil, iterator.ErrIteratorDone
 	}
 
 	var b []byte
 	if err := iter.rows.Scan(&b); err != nil {
-		return 0, nil, lazyerrors.Error(err)
+		return unused, nil, lazyerrors.Error(err)
 	}
 
 	doc, err := iter.unmarshal(b)
 	if err != nil {
-		return 0, nil, lazyerrors.Error(err)
+		return unused, nil, lazyerrors.Error(err)
 	}
 
-	iter.n++
-
-	return iter.n - 1, doc, nil
+	return unused, doc, nil
 }
 
 // Close implements iterator.Interface.

--- a/internal/handlers/pg/pgdb/query_test.go
+++ b/internal/handlers/pg/pgdb/query_test.go
@@ -68,33 +68,28 @@ func TestGetDocuments(t *testing.T) {
 
 			defer iter.Close()
 
-			n, doc, err := iter.Next()
+			_, doc, err := iter.Next()
 			require.NoError(t, err)
-			assert.Equal(t, 0, n)
 			assert.Equal(t, doc1, doc)
 
-			n, doc, err = iter.Next()
+			_, doc, err = iter.Next()
 			require.NoError(t, err)
-			assert.Equal(t, 1, n)
 			assert.Equal(t, doc2, doc)
 
-			n, doc, err = iter.Next()
+			_, doc, err = iter.Next()
 			require.Equal(t, iterator.ErrIteratorDone, err, "%v", err)
-			assert.Zero(t, n)
 			assert.Nil(t, doc)
 
 			// still done
-			n, doc, err = iter.Next()
+			_, doc, err = iter.Next()
 			require.Equal(t, iterator.ErrIteratorDone, err, "%v", err)
-			assert.Zero(t, n)
 			assert.Nil(t, doc)
 
 			cancelGet()
 
 			// still done
-			n, doc, err = iter.Next()
+			_, doc, err = iter.Next()
 			require.Equal(t, iterator.ErrIteratorDone, err, "%v", err)
-			assert.Zero(t, n)
 			assert.Nil(t, doc)
 
 			return nil

--- a/internal/handlers/tigris/msg_aggregate.go
+++ b/internal/handlers/tigris/msg_aggregate.go
@@ -115,7 +115,7 @@ func (h *Handler) MsgAggregate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMs
 
 	defer iter.Close()
 
-	docs, err = iterator.Values(iterator.Interface[int, *types.Document](iter))
+	docs, err = iterator.Values(iterator.Interface[struct{}, *types.Document](iter))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/handlers/tigris/msg_find.go
+++ b/internal/handlers/tigris/msg_find.go
@@ -72,7 +72,7 @@ func (h *Handler) MsgFind(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, er
 
 	iter = common.FilterIterator(iter, params.Filter)
 
-	resDocs, err := iterator.Values(iterator.Interface[int, *types.Document](iter))
+	resDocs, err := iterator.Values(iterator.Interface[struct{}, *types.Document](iter))
 	if err != nil {
 		return nil, lazyerrors.Error(err)
 	}
@@ -158,5 +158,5 @@ func fetchAndFilterDocs(ctx context.Context, fp *fetchParams) ([]*types.Document
 
 	f := common.FilterIterator(iter, filter)
 
-	return iterator.Values(iterator.Interface[int, *types.Document](f))
+	return iterator.Values(iterator.Interface[struct{}, *types.Document](f))
 }

--- a/internal/handlers/tigris/tigrisdb/query_iterator.go
+++ b/internal/handlers/tigris/tigrisdb/query_iterator.go
@@ -40,7 +40,6 @@ type queryIterator struct {
 	m     sync.Mutex
 	iter  driver.Iterator
 	stack []byte // not really under mutex, but placed there to make struct smaller (due to alignment)
-	n     int
 }
 
 // newIterator returns a new queryIterator for the given driver.Iterator.
@@ -80,17 +79,19 @@ func newQueryIterator(ctx context.Context, titer driver.Iterator, schema *tjson.
 //
 // Otherwise, as the first value it returns the number of the current iteration (starting from 0),
 // as the second value it returns the document.
-func (iter *queryIterator) Next() (int, *types.Document, error) {
+func (iter *queryIterator) Next() (struct{}, *types.Document, error) {
 	iter.m.Lock()
 	defer iter.m.Unlock()
 
+	var unused struct{}
+
 	// ignore context error, if any, if iterator is already closed
 	if iter.iter == nil {
-		return 0, nil, iterator.ErrIteratorDone
+		return unused, nil, iterator.ErrIteratorDone
 	}
 
 	if err := iter.ctx.Err(); err != nil {
-		return 0, nil, err
+		return unused, nil, err
 	}
 
 	var document driver.Document
@@ -108,24 +109,22 @@ func (iter *queryIterator) Next() (int, *types.Document, error) {
 			// MongoDB would skip that document because the type is different.
 			// Tigris returns a schema error in such cases that we ignore.
 		default:
-			return 0, nil, lazyerrors.Error(err)
+			return unused, nil, lazyerrors.Error(err)
 		}
 
 		// to avoid context cancellation changing the next `Next()` error
 		// from `iterator.ErrIteratorDone` to `context.Canceled`
 		iter.close()
 
-		return 0, nil, iterator.ErrIteratorDone
+		return unused, nil, iterator.ErrIteratorDone
 	}
 
 	doc, err := tjson.Unmarshal(document, iter.schema)
 	if err != nil {
-		return 0, nil, lazyerrors.Error(err)
+		return unused, nil, lazyerrors.Error(err)
 	}
 
-	iter.n++
-
-	return iter.n - 1, doc.(*types.Document), nil
+	return unused, doc.(*types.Document), nil
 }
 
 // Close implements iterator.Interface.

--- a/internal/handlers/tigris/tigrisdb/query_test.go
+++ b/internal/handlers/tigris/tigrisdb/query_test.go
@@ -64,21 +64,17 @@ func TestQueryDocuments(t *testing.T) {
 
 		var queried []*types.Document
 
-		i := 0
 		for {
-			var n int
 			var doc *types.Document
 
-			n, doc, err = iter.Next()
+			_, doc, err = iter.Next()
 			if errors.Is(err, iterator.ErrIteratorDone) {
 				break
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, i, n)
 
 			queried = append(queried, doc)
-			i++
 		}
 
 		require.Equal(t, len(inserted), len(queried))

--- a/internal/types/documents_iterator.go
+++ b/internal/types/documents_iterator.go
@@ -17,4 +17,7 @@ package types
 import "github.com/FerretDB/FerretDB/internal/util/iterator"
 
 // DocumentsIterator represents an iterator over documents.
-type DocumentsIterator iterator.Interface[int, *Document]
+//
+// Key/index is not used there because it is unclear what it should be in the filter/sort/limit/skip chain,
+// and it is not used anyway.
+type DocumentsIterator iterator.Interface[struct{}, *Document]


### PR DESCRIPTION
## Readiness checklist

* [x] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [x] I added/updated comments and checked rendering.
* [x] I made spot refactorings.
* [ ] I updated user documentation.
* [x] I ran `task all`, and it passed.
* [x] I ensured that PR title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
