### PR TITLE
Close iterator properly

### DIFF
--- a/integration/query_projection_test.go
+++ b/integration/query_projection_test.go
@@ -35,6 +35,7 @@ func TestQueryProjection(t *testing.T) {
 		projection any
 		filter     any
 		expected   bson.D
+		err        bool // TODO check error type
 	}{
 		"FindProjectionIDExclusion": {
 			filter: bson.D{{"_id", "document-composite"}},
@@ -42,12 +43,21 @@ func TestQueryProjection(t *testing.T) {
 			projection: bson.D{{"_id", false}, {"array", int32(1)}},
 			expected:   bson.D{},
 		},
+		"Invalid": {
+			filter:     bson.D{},
+			projection: bson.D{{"a", bson.A{}}},
+			err:        true,
+		},
 	} {
 		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
 			cursor, err := collection.Find(ctx, tc.filter, options.Find().SetProjection(tc.projection))
+			if tc.err {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
 
 			var actual []bson.D

--- a/internal/handlers/common/sort_iterator.go
+++ b/internal/handlers/common/sort_iterator.go
@@ -24,6 +24,7 @@ import (
 //
 // Since sorting iterator is impossible, this function fully consumes and closes the underlying iterator,
 // sorts documents in memory and returns a new iterator over the sorted slice.
+// That iterator should be closed by the caller.
 func SortIterator(iter types.DocumentsIterator, sort *types.Document) (types.DocumentsIterator, error) {
 	docs, err := iterator.ConsumeValues(iterator.Interface[struct{}, *types.Document](iter))
 	if err != nil {
@@ -34,5 +35,7 @@ func SortIterator(iter types.DocumentsIterator, sort *types.Document) (types.Doc
 		return nil, lazyerrors.Error(err)
 	}
 
-	return iterator.Values(iterator.ForSlice(docs)), nil
+	sliceIter := iterator.ForSlice(docs)
+
+	return iterator.Values(sliceIter), nil
 }

--- a/internal/handlers/pg/msg_find.go
+++ b/internal/handlers/pg/msg_find.go
@@ -104,6 +104,9 @@ func (h *Handler) MsgFind(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, er
 			return lazyerrors.Error(err)
 		}
 
+		// SortIterator should be closed
+		defer iter.Close()
+
 		iter = common.LimitIterator(iter, params.Limit)
 
 		iter = common.SkipIterator(iter, params.Skip)

--- a/internal/handlers/tigris/msg_find.go
+++ b/internal/handlers/tigris/msg_find.go
@@ -94,6 +94,9 @@ func (h *Handler) MsgFind(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, er
 			return lazyerrors.Error(err)
 		}
 
+		// SortIterator should be closed
+		defer iter.Close()
+
 		iter = common.LimitIterator(iter, params.Limit)
 
 		iter = common.SkipIterator(iter, params.Skip)


### PR DESCRIPTION
# Description

Closes #2330.

This PR doesn't have https://github.com/FerretDB/FerretDB/labels/code%2Fbug label because #2330 wasn't released yet.

## Readiness checklist

* [ ] I added/updated unit tests.
* [x] I added/updated integration/compatibility tests.
* [x] I added/updated comments and checked rendering.
* [ ] I made spot refactorings.
* [ ] I updated user documentation.
* [x] I ran `task all`, and it passed.
* [x] I ensured that PR title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
