### PR TITLE
Ignore `unique` index option for now

### DIFF
--- a/internal/handlers/pg/msg_createindexes.go
+++ b/internal/handlers/pg/msg_createindexes.go
@@ -209,7 +209,11 @@ func processIndexOptions(indexDoc *types.Document) (*pgdb.Index, error) {
 		case "key", "name":
 			// already processed, do nothing
 
-		case "unique", "sparse", "partialFilterExpression", "expireAfterSeconds", "hidden", "storageEngine",
+		case "unique":
+			// TODO https://github.com/FerretDB/FerretDB/issues/2045
+			// just ignore it for now, don't return error
+
+		case "sparse", "partialFilterExpression", "expireAfterSeconds", "hidden", "storageEngine",
 			"weights", "default_language", "language_override", "textIndexVersion", "2dsphereIndexVersion",
 			"bits", "min", "max", "bucketSize", "collation", "wildcardProjection":
 			return nil, commonerrors.NewCommandErrorMsgWithArgument(


### PR DESCRIPTION
# Description

It was requested.

## Readiness checklist

* [ ] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [ ] I added/updated comments and checked rendering.
* [ ] I made spot refactorings.
* [ ] I updated user documentation.
* [ ] I ran `task all`, and it passed.
* [x] I ensured that PR title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
