### PR TITLE
Use `draft` instead of `unlisted`

### DIFF
--- a/website/blog/_guide/YYYY-MM-DD.blog-template.md
+++ b/website/blog/_guide/YYYY-MM-DD.blog-template.md
@@ -11,7 +11,7 @@ keywords:
   - keyword2
 image: /img/blog/post-cover-image.jpg
 tags: [tag1, tag2]
-unlisted: true
+draft: true
 ---
 
 Leave a space before starting article.

--- a/website/blog/_guide/content-process.md
+++ b/website/blog/_guide/content-process.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-unlisted: true
+draft: true
 ---
 
 # Content Creation Guide for FerretDB
@@ -39,7 +39,7 @@ Please see our [writing guide](writing-guide.md) for help formatting your blog p
 
 Front matter is the metadata that appears at the top of the markdown file and provides information about the post, such as the title, author, and date.
 
-In the front matter, ensure to set the `unlisted: true` in the front matter until it's ready to publish.
+In the front matter, ensure to set the `draft: true` in the front matter until it's ready to publish.
 Make sure to include all necessary information in the front matter, such as the title, author, and date.
 
 ## Reviewing and Editing Content
@@ -57,7 +57,7 @@ Once the content is ready for review, please open a PR and assign it to @Ferretd
 ## Final Approval and Publishing
 
 The final approval for publishing content is given once it has passed through all reviews and approved by the team.
-To publish the content, change the date in the front matter to the proposed published date, and then remove `unlisted: true` from the front matter.
+To publish the content, change the date in the front matter to the proposed published date, and then remove `draft: true` from the front matter.
 
 ## Post Publishing
 

--- a/website/docs/contributing/writing-guide.md
+++ b/website/docs/contributing/writing-guide.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 99
-unlisted: true
+draft: true
 ---
 
 # Writing guide


### PR DESCRIPTION
# Description

It seems like `unlisted` feature wasn't release yet.
It is mentioned there: https://docusaurus.io/docs/next/api/plugins/@docusaurus/plugin-content-docs#markdown-front-matter
but not there: https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs#markdown-front-matter

Closes #2370.

## Readiness checklist

* [ ] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [ ] I added/updated comments and checked rendering.
* [ ] I made spot refactorings.
* [x] I updated user documentation.
* [ ] I ran `task all`, and it passed.
* [x] I ensured that PR title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
