### PR TITLE
Add test script to show `totalSize` discrepancy

### DIFF
--- a/build/legacy-mongo-shell/test.js
+++ b/build/legacy-mongo-shell/test.js
@@ -3,5 +3,19 @@
 (function() {
   'use strict';
 
+  // Make 4 test databases.
+  db.getSiblingDB('foo').coll.insert({});
+  db.getSiblingDB('bar').coll.insert({});
+  db.getSiblingDB('buz').coll.insert({});
+  db.getSiblingDB('baz').coll.insert({});
+
+  const listDatabasesOut = db.adminCommand({listDatabases: 1});
+  const dbList = listDatabasesOut.databases;
+  let sizeSum = 0;
+  for (let i = 0; i < dbList.length; i++) {
+    sizeSum += dbList[i].sizeOnDisk;
+  }
+  assert.eq(sizeSum, listDatabasesOut.totalSize);
+
   print('test.js passed!');
 })();


### PR DESCRIPTION
# Description

Refs #2374.

This PR adds a test to show that `totalSize` reports a different size compared to the sum of all individual sizes on disk.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [ ] I added/updated comments and checked rendering.
* [ ] I made spot refactorings.
* [ ] I updated user documentation.
* [ ] I ran `task all`, and it passed.
* [ ] I ensured that PR title is good enough for the changelog.
* [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [ ] I marked all done items in this checklist.
