### PR TITLE
Fix types order linter

### DIFF
--- a/tools/checkswitch/checkswitch.go
+++ b/tools/checkswitch/checkswitch.go
@@ -45,7 +45,7 @@ var orderTypes = map[string]int{
 	"bool":     7,
 	"boolType": 7,
 
-	"time.Time":    8,
+	"Time":         8,
 	"dateTimeType": 8,
 
 	"NullType": 9,

--- a/tools/checkswitch/testdata/testdata.go
+++ b/tools/checkswitch/testdata/testdata.go
@@ -20,12 +20,12 @@ import (
 	"time"
 )
 
-func test(v any) {
+func testCorrect(v any) {
 	switch v.(type) {
 	case *types.Document:
 	case *types.Array:
 	case float64, int32, int64: // multiple types
-	case int8: // unknown
+	case int8: // unexpected type
 	case string:
 	case types.Binary:
 	case types.ObjectID:
@@ -34,38 +34,25 @@ func test(v any) {
 	case types.NullType:
 	case types.Regex:
 	case types.Timestamp:
-	default:
 	}
+}
 
+func testIncorrectSimple(v any) {
 	switch v.(type) { // want "Document should go before Array in the switch"
 	case *types.Array:
 	case *types.Document:
-	case float64:
-	case string:
-	case types.Binary:
-	case types.ObjectID:
-	case bool:
-	case time.Time:
-	case types.NullType:
-	case types.Regex:
-	case int32:
-	case types.Timestamp:
-	case int64:
-	default:
 	}
+}
 
-	switch v.(type) { // want "int32 should go before int64 in the switch"
-	case *types.Document:
-	case *types.Array:
-	case float64, int64, int32:
-	case string:
-	case types.Binary:
-	case types.ObjectID:
-	case bool:
+func testIncorrectMixed(v any) {
+	switch v.(type) { // want "Document should go before Time in the switch"
 	case time.Time:
-	case types.NullType:
-	case types.Regex:
-	case types.Timestamp:
-	default:
+	case *types.Document:
+	}
+}
+
+func testIncorrectMultiple(v any) {
+	switch v.(type) { // want "int32 should go before int64 in the switch"
+	case float64, int64, int32:
 	}
 }


### PR DESCRIPTION
# Description

Select (package name) is ignored by that linter, so `time.Time` wasn't handled properly.

Closes #1630.

## Readiness checklist

* [x] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [ ] I added/updated comments and checked rendering.
* [ ] I made spot refactorings.
* [ ] I updated user documentation.
* [x] I ran `task all`, and it passed.
* [x] I ensured that PR title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
