### PR TITLE
Add test demonstrating parallel subtests problem

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,8 +175,12 @@ For example:
   with [Go execution tracer](https://pkg.go.dev/runtime/trace) enabled,
   you may use `env GOFLAGS='-trace=trace.out' task test-integration-tigris`.
 
-(It is not recommended to set `GOFLAGS` and other Go environment variables with `export GOFLAGS=...`
-or `go env -w GOFLAGS=...` because they are invisible and easy to forget about, leading to confusion.)
+> **Note**
+> It is not recommended to set `GOFLAGS` and other Go environment variables with `export GOFLAGS=...`
+> or `go env -w GOFLAGS=...` because they are invisible and easy to forget about, leading to confusion.
+
+> **Warning**
+> lala
 
 In general, we prefer integration tests over unit tests,
 tests using real databases over short tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,9 +180,10 @@ For example:
 > It is not recommended to set `GOFLAGS` and other Go environment variables with `export GOFLAGS=...`
 > or `go env -w GOFLAGS=...` because they are invisible and easy to forget about, leading to confusion.
 
-> **Warning**
+> **Note**
 >
-> lala
+> Due to the way, we use parallel subtests, `-failfast` flag could provide confusing results.
+> Consider using `-run=TestName/TestCaseName -parallel=1` instead.
 
 In general, we prefer integration tests over unit tests,
 tests using real databases over short tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,10 +176,12 @@ For example:
   you may use `env GOFLAGS='-trace=trace.out' task test-integration-tigris`.
 
 > **Note**
+>
 > It is not recommended to set `GOFLAGS` and other Go environment variables with `export GOFLAGS=...`
 > or `go env -w GOFLAGS=...` because they are invisible and easy to forget about, leading to confusion.
 
 > **Warning**
+>
 > lala
 
 In general, we prefer integration tests over unit tests,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,7 +182,7 @@ For example:
 
 > **Note**
 >
-> Due to the way, we use parallel subtests, `-failfast` flag could provide confusing results.
+> Due to the way we use parallel subtests, `-failfast` flag could provide confusing results.
 > Consider using `-run=TestName/TestCaseName -parallel=1` instead.
 
 In general, we prefer integration tests over unit tests,

--- a/integration/query_projection_test.go
+++ b/integration/query_projection_test.go
@@ -45,7 +45,7 @@ func TestQueryProjection(t *testing.T) {
 		},
 		"Invalid": {
 			filter:     bson.D{},
-			projection: bson.D{{"a", bson.A{}}},
+			projection: bson.D{{"a", "$"}},
 			err:        true,
 		},
 	} {

--- a/integration/query_projection_test.go
+++ b/integration/query_projection_test.go
@@ -35,6 +35,7 @@ func TestQueryProjection(t *testing.T) {
 		projection any
 		filter     any
 		expected   bson.D
+		err        bool // TODO check error type
 	}{
 		"FindProjectionIDExclusion": {
 			filter: bson.D{{"_id", "document-composite"}},
@@ -42,12 +43,21 @@ func TestQueryProjection(t *testing.T) {
 			projection: bson.D{{"_id", false}, {"array", int32(1)}},
 			expected:   bson.D{},
 		},
+		"Invalid": {
+			filter:     bson.D{},
+			projection: bson.D{{"a", bson.A{}}},
+			err:        true,
+		},
 	} {
 		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
 			cursor, err := collection.Find(ctx, tc.filter, options.Find().SetProjection(tc.projection))
+			if tc.err {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
 
 			var actual []bson.D


### PR DESCRIPTION
# Description

I found it while working on #2330 / #2333.

Run it with `env GOFLAGS='-run=TestQueryProjection' task test-integration-pg`. Sometimes it passes, and sometime it fails with:

<details><summary>Confusing output</summary>

```
-> env GOFLAGS='-run=TestQueryProjection' task test-integration-pg
task: [test-integration-pg] go test -count=1 -timeout=30m -race=true -tags=ferretdb_debug,ferretdb_tigris,ferretdb_hana -shuffle=on -coverpkg=../... -coverprofile=integration-pg.txt . -target-backend=ferretdb-pg -target-tls -postgresql-url=postgres://username@127.0.0.1:5432/ferretdb -compat-url='mongodb://username:password@127.0.0.1:47018/?tls=true&tlsCertificateKeyFile=../build/certs/client.pem&tlsCaFile=../build/certs/rootCA-cert.pem'

2023-04-11T11:04:55.528+0400	INFO	setup/startup.go:68	Target system: ferretdb-pg (built-in).
2023-04-11T11:04:55.529+0400	INFO	debug	debug/debug.go:95	Starting debug server on http://127.0.0.1:60849/
2023-04-11T11:04:55.714+0400	INFO	setup/startup.go:79	Compat system: MongoDB (mongodb://username:password@127.0.0.1:47018/?tls=true&tlsCertificateKeyFile=../build/certs/client.pem&tlsCaFile=../build/certs/rootCA-cert.pem).
-test.shuffle 1681196695714473000
FAIL
	github.com/FerretDB/FerretDB/build/version	coverage: 40.0% of statements in ../...
	github.com/FerretDB/FerretDB/ferretdb	coverage: 13.9% of statements in ../...
	github.com/FerretDB/FerretDB/integration	coverage: 27.0% of statements in ../...
	github.com/FerretDB/FerretDB/integration/setup	coverage: 74.1% of statements in ../...
	github.com/FerretDB/FerretDB/integration/shareddata	coverage: 59.6% of statements in ../...
	github.com/FerretDB/FerretDB/internal/bson	coverage: 60.0% of statements in ../...
	github.com/FerretDB/FerretDB/internal/clientconn	coverage: 60.3% of statements in ../...
	github.com/FerretDB/FerretDB/internal/clientconn/conninfo	coverage: 85.7% of statements in ../...
	github.com/FerretDB/FerretDB/internal/clientconn/connmetrics	coverage: 4.7% of statements in ../...
	github.com/FerretDB/FerretDB/internal/clientconn/cursor	coverage: 6.1% of statements in ../...
	github.com/FerretDB/FerretDB/internal/handlers	coverage: [no statements]
	github.com/FerretDB/FerretDB/internal/handlers/common	coverage: 9.1% of statements in ../...
	github.com/FerretDB/FerretDB/internal/handlers/common/aggregations	coverage: 0.0% of statements in ../...
	github.com/FerretDB/FerretDB/internal/handlers/commonerrors	coverage: 32.4% of statements in ../...
	github.com/FerretDB/FerretDB/internal/handlers/dummy	coverage: 0.0% of statements in ../...
	github.com/FerretDB/FerretDB/internal/handlers/hana	coverage: 0.0% of statements in ../...
	github.com/FerretDB/FerretDB/internal/handlers/hana/hanadb	coverage: 0.0% of statements in ../...
	github.com/FerretDB/FerretDB/internal/handlers/pg	coverage: 23.0% of statements in ../...
	github.com/FerretDB/FerretDB/internal/handlers/pg/pgdb	coverage: 55.7% of statements in ../...
	github.com/FerretDB/FerretDB/internal/handlers/pg/pjson	coverage: 56.5% of statements in ../...
	github.com/FerretDB/FerretDB/internal/handlers/proxy	coverage: 0.0% of statements in ../...
	github.com/FerretDB/FerretDB/internal/handlers/registry	coverage: 50.0% of statements in ../...
	github.com/FerretDB/FerretDB/internal/handlers/tigris	coverage: 0.0% of statements in ../...
	github.com/FerretDB/FerretDB/internal/handlers/tigris/tigrisdb	coverage: 0.0% of statements in ../...
	github.com/FerretDB/FerretDB/internal/handlers/tigris/tjson	coverage: 0.0% of statements in ../...
	github.com/FerretDB/FerretDB/internal/types	coverage: 21.3% of statements in ../...
	github.com/FerretDB/FerretDB/internal/types/fjson	coverage: 60.0% of statements in ../...
	github.com/FerretDB/FerretDB/internal/util/ctxutil	coverage: 69.2% of statements in ../...
	github.com/FerretDB/FerretDB/internal/util/debug	coverage: 80.8% of statements in ../...
	github.com/FerretDB/FerretDB/internal/util/debugbuild	coverage: 66.7% of statements in ../...
	github.com/FerretDB/FerretDB/internal/util/hex	coverage: 0.0% of statements in ../...
	github.com/FerretDB/FerretDB/internal/util/iterator	coverage: 62.8% of statements in ../...
	github.com/FerretDB/FerretDB/internal/util/lazyerrors	coverage: 81.8% of statements in ../...
	github.com/FerretDB/FerretDB/internal/util/logging	coverage: 43.2% of statements in ../...
	github.com/FerretDB/FerretDB/internal/util/must	coverage: 57.1% of statements in ../...
	github.com/FerretDB/FerretDB/internal/util/resource	coverage: 72.7% of statements in ../...
	github.com/FerretDB/FerretDB/internal/util/state	coverage: 35.9% of statements in ../...
	github.com/FerretDB/FerretDB/internal/util/testutil	coverage: 35.7% of statements in ../...
	github.com/FerretDB/FerretDB/internal/wire	coverage: 49.9% of statements in ../...
FAIL	github.com/FerretDB/FerretDB/integration	3.359s
FAIL
task: Failed to run task "test-integration-pg": exit status 1
```
</details>

Adding `-v` shows errors like:

```
    setup.go:246:
        	Error Trace:	/Users/aleksi/Code/FerretDB/FerretDB/integration/setup/setup.go:246
        	            				/opt/homebrew/Cellar/go/1.20.3/libexec/src/testing/testing.go:1150
        	            				/opt/homebrew/Cellar/go/1.20.3/libexec/src/testing/testing.go:1328
        	            				/opt/homebrew/Cellar/go/1.20.3/libexec/src/testing/testing.go:1545
        	Error:      	Received unexpected error:
        	            	connection(127.0.0.1:60964[-10]) socket was unexpectedly closed: EOF
        	Test:       	TestQueryProjection
```

So we probably use cleanup incorrectly.

## Readiness checklist

* [ ] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [ ] I added/updated comments and checked rendering.
* [ ] I made spot refactorings.
* [ ] I updated user documentation.
* [ ] I ran `task all`, and it passed.
* [ ] I ensured that PR title is good enough for the changelog.
* [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [ ] I marked all done items in this checklist.
