### PR TITLE
Use exponential backoff with jitter

### DIFF
--- a/cmd/envtool/envtool.go
+++ b/cmd/envtool/envtool.go
@@ -59,7 +59,7 @@ func waitForPort(ctx context.Context, logger *zap.SugaredLogger, port uint16) er
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
 	logger.Infof("Waiting for %s to be up...", addr)
 
-	var attempts = int64(1)
+	attempts := int64(1)
 	for ctx.Err() == nil {
 		conn, err := net.Dial("tcp", addr)
 		if err == nil {
@@ -99,7 +99,7 @@ func setupAnyPostgres(ctx context.Context, logger *zap.SugaredLogger, uri string
 
 	var pgPool *pgdb.Pool
 
-	var attempts = int64(1)
+	attempts := int64(1)
 	for ctx.Err() == nil {
 		if pgPool, err = pgdb.NewPool(ctx, uri, logger.Desugar(), p); err == nil {
 			break
@@ -167,7 +167,7 @@ func setupAnyTigris(ctx context.Context, logger *zap.SugaredLogger, port uint16)
 
 	var db *tigrisdb.TigrisDB
 
-	var attempts = int64(1)
+	attempts := int64(1)
 	for ctx.Err() == nil {
 		if db, err = tigrisdb.New(ctx, cfg, logger.Desugar()); err == nil {
 			break

--- a/cmd/envtool/envtool.go
+++ b/cmd/envtool/envtool.go
@@ -59,6 +59,7 @@ func waitForPort(ctx context.Context, logger *zap.SugaredLogger, port uint16) er
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
 	logger.Infof("Waiting for %s to be up...", addr)
 
+	var attempts = int64(1)
 	for ctx.Err() == nil {
 		conn, err := net.Dial("tcp", addr)
 		if err == nil {
@@ -67,7 +68,9 @@ func waitForPort(ctx context.Context, logger *zap.SugaredLogger, port uint16) er
 		}
 
 		logger.Infof("%s: %s", addr, err)
-		ctxutil.Sleep(ctx, time.Second)
+
+		ctxutil.SleepWithJitter(ctx, time.Second, attempts)
+		attempts++
 	}
 
 	return fmt.Errorf("failed to connect to %s", addr)
@@ -96,13 +99,15 @@ func setupAnyPostgres(ctx context.Context, logger *zap.SugaredLogger, uri string
 
 	var pgPool *pgdb.Pool
 
+	var attempts = int64(1)
 	for ctx.Err() == nil {
 		if pgPool, err = pgdb.NewPool(ctx, uri, logger.Desugar(), p); err == nil {
 			break
 		}
 
 		logger.Infof("%s: %s", uri, err)
-		ctxutil.Sleep(ctx, time.Second)
+		ctxutil.SleepWithJitter(ctx, time.Second, attempts)
+		attempts++
 	}
 
 	defer pgPool.Close()
@@ -162,13 +167,15 @@ func setupAnyTigris(ctx context.Context, logger *zap.SugaredLogger, port uint16)
 
 	var db *tigrisdb.TigrisDB
 
+	var attempts = int64(1)
 	for ctx.Err() == nil {
 		if db, err = tigrisdb.New(ctx, cfg, logger.Desugar()); err == nil {
 			break
 		}
 
 		logger.Infof("%s: %s", cfg.URL, err)
-		ctxutil.Sleep(ctx, time.Second)
+		ctxutil.SleepWithJitter(ctx, time.Second, attempts)
+		attempts++
 	}
 
 	defer db.Driver.Close()

--- a/integration/commands_administration_test.go
+++ b/integration/commands_administration_test.go
@@ -907,6 +907,7 @@ func TestCommandsAdministrationServerStatusFreeMonitoring(t *testing.T) {
 
 			// MongoDB might be slow to update the status
 			var status any
+			var attempts int64 = 1
 			for i := 0; i < 3; i++ {
 				var actual bson.D
 				err := s.Collection.Database().RunCommand(s.Ctx, bson.D{{"serverStatus", 1}}).Decode(&actual)
@@ -923,7 +924,8 @@ func TestCommandsAdministrationServerStatusFreeMonitoring(t *testing.T) {
 				if status == tc.expectedStatus {
 					break
 				}
-				ctxutil.Sleep(s.Ctx, time.Second)
+				ctxutil.SleepWithJitter(s.Ctx, time.Second, attempts)
+				attempts++
 			}
 
 			assert.Equal(t, tc.expectedStatus, status)

--- a/internal/clientconn/listener.go
+++ b/internal/clientconn/listener.go
@@ -243,6 +243,7 @@ func setupTLSListener(opts *setupTLSListenerOpts) (net.Listener, error) {
 
 // acceptLoop runs listener's connection accepting loop.
 func acceptLoop(ctx context.Context, listener net.Listener, wg *sync.WaitGroup, l *Listener, logger *zap.Logger) {
+	var attempts = int64(1)
 	for {
 		netConn, err := listener.Accept()
 		if err != nil {
@@ -255,7 +256,8 @@ func acceptLoop(ctx context.Context, listener net.Listener, wg *sync.WaitGroup, 
 
 			logger.Warn("Failed to accept connection", zap.Error(err))
 			if !errors.Is(err, net.ErrClosed) {
-				ctxutil.Sleep(ctx, time.Second)
+				ctxutil.SleepWithJitter(ctx, time.Second, attempts)
+				attempts++
 			}
 			continue
 		}

--- a/internal/clientconn/listener.go
+++ b/internal/clientconn/listener.go
@@ -243,7 +243,7 @@ func setupTLSListener(opts *setupTLSListenerOpts) (net.Listener, error) {
 
 // acceptLoop runs listener's connection accepting loop.
 func acceptLoop(ctx context.Context, listener net.Listener, wg *sync.WaitGroup, l *Listener, logger *zap.Logger) {
-	var attempts = int64(1)
+	attempts := int64(1)
 	for {
 		netConn, err := listener.Accept()
 		if err != nil {

--- a/internal/handlers/pg/pgdb/transactions.go
+++ b/internal/handlers/pg/pgdb/transactions.go
@@ -137,7 +137,7 @@ func (pgPool *Pool) InTransactionRetry(ctx context.Context, f func(pgx.Tx) error
 				map[string]any{"err": err, "attempt": attempts, "delay": delay},
 			)
 
-			ctxutil.Sleep(ctx, delay)
+			ctxutil.SleepWithJitter(ctx, retryDelayMax, int64(attempts))
 
 		default:
 			return lazyerrors.Errorf("non-retriable error: %w", err)

--- a/internal/handlers/tigris/tigrisdb/databases.go
+++ b/internal/handlers/tigris/tigrisdb/databases.go
@@ -74,7 +74,7 @@ func (tdb *TigrisDB) createDatabaseIfNotExists(ctx context.Context, db string) (
 					zap.String("db", db), zap.Error(err), zap.Duration("delay", delay),
 				)
 
-				ctxutil.Sleep(ctx, delay)
+				ctxutil.SleepWithJitter(ctx, retryDelayMax, int64(i+1))
 				continue
 			}
 

--- a/internal/util/ctxutil/ctxutil_test.go
+++ b/internal/util/ctxutil/ctxutil_test.go
@@ -14,8 +14,32 @@
 
 package ctxutil
 
-import "testing"
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestDummy(t *testing.T) {
 	// we need at least one test per package to correctly calculate coverage
+}
+
+func TestDurationWithJitter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("larger or equal then 1ms", func(t *testing.T) {
+		sleep := DurationWithJitter(time.Second, 1)
+		assert.GreaterOrEqual(t, sleep, time.Millisecond)
+	})
+
+	t.Run("less or equal then duration input", func(t *testing.T) {
+		sleep := DurationWithJitter(time.Second, 100000)
+		assert.LessOrEqual(t, sleep, time.Second)
+	})
+
+	t.Run("attempt cannot be less then 1", func(t *testing.T) {
+		sleep := DurationWithJitter(time.Second, 0)
+		assert.LessOrEqual(t, sleep, time.Second)
+	})
 }

--- a/website/blog/2023-04-11-ferretdb-1-0-ga-opensource-mongodb-alternative.md
+++ b/website/blog/2023-04-11-ferretdb-1-0-ga-opensource-mongodb-alternative.md
@@ -10,7 +10,7 @@ tags: [document database, mongodb alternative, mongodb compatible]
 
 ![Announcing FerretDB 1.0 GA - MongoDB compatibility](/img/blog/ferretdb-v1.0.jpg)
 
-## Consider starring us on GitHub: [https://github.com/FerretDB/FerretDB](https://github.com/FerretDB/FerretDB)
+### Consider starring us on GitHub: [https://github.com/FerretDB/FerretDB](https://github.com/FerretDB/FerretDB)
 
 After several months of development, [FerretDB](https://www.ferretdb.io/) is now production-ready.
 We are excited to announce the general availability of FerretDB, a truly Open Source MongoDB alternative, built on PostgreSQL, and released under the Apache 2.0 license.


### PR DESCRIPTION
# Description

Closes #1720.

I have added ctxutil.SleepWithJitter based on https://aws.amazon.com/ru/blogs/architecture/exponential-backoff-and-jitter/ (FullJitter).

I did not complete all tasks in the issue for the following reason:
- time.Sleep is not used
- context.WithTimeout is only used for actual timeout from what I'm reading. It does not make sense to add jitter to context timeouts if FerretDB does not retry something based on the context timing out.
- ctxutil.Sleep has been replaced with a version that adds jitter with one exception: reporter.Run has a reportInternal duration that has no need for jitter.
- All other ctxutil.Sleeps where located in for loops where the intention is clear that FerretDB is retrying some task. Adding jitter makes sense in these cases.

For the three unit tests I have added I had difficulty with making sure my tests are correct because SleepWithJitter uses rand.Int63n which makes it difficult to validate testing boundaries.

## Readiness checklist

* [x] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [ ] I added/updated comments and checked rendering.
* [x] I made spot refactorings.
* [ ] I updated user documentation.
* [ ] I ran `task all`, and it passed. <-- returns `package.txt: open package.txt: no such file or directory`
* [x] I ensured that PR title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [ ] I marked all done items in this checklist.
