### PR TITLE
Fix typo in docs

### DIFF
--- a/website/docs/quickstart-guide/docker.md
+++ b/website/docs/quickstart-guide/docker.md
@@ -45,7 +45,7 @@ The following steps describe a quick local setup:
        ports:
          - 27017:27017
        environment:
-         - FERRETDB_POSTGRESQL_URL=postgres://postgres:5432/ferretdb
+         - FERRETDB_POSTGRESQL_URL=postgres://username:password@postgres:5432/ferretdb
 
    networks:
      default:


### PR DESCRIPTION
# Description

Fix documentation typo. I could not get FerretDB to connect to the Postgres server, the fix was what I changed in the docs.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [ ] I added/updated comments and checked rendering.
* [ ] I made spot refactorings.
* [x] I updated user documentation.
* [ ] I ran `task all`, and it passed.
* [ ] I ensured that PR title is good enough for the changelog.
* [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Assignee, Labels, Project and project's Sprint fields.
* [ ] I marked all done items in this checklist.
