### PR TITLE
Add identifying Arch Linux version in `hostInfo` command

### DIFF
--- a/internal/handlers/common/msg_hostinfo.go
+++ b/internal/handlers/common/msg_hostinfo.go
@@ -40,7 +40,10 @@ func MsgHostInfo(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error) {
 	if runtime.GOOS == "linux" {
 		file, err := os.Open("/etc/os-release")
 		if err != nil {
-			return nil, lazyerrors.Error(err)
+			file, err = os.Open("/etc/arch-release")
+			if err != nil {
+				return nil, lazyerrors.Error(err)
+			}
 		}
 		defer file.Close()
 


### PR DESCRIPTION
# Description

Closes #2500.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->
Add identifying Arch Linux version in `hostInfo` command.
Most of Linux distributions contain `/etc/os-release` - the file used by FerretDB for `hostInfo` command.
However, Arch has `/etc/arch-release` instead of it. To keep functionality for most of Linux distributions the special Arch condition has been added.


## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [ ] I added/updated comments and checked rendering.
* [x] I made spot refactorings.
* [ ] I updated user documentation.
* [x] I ran `task all`, and it passed.
* [x] I ensured that PR title is good enough for the changelog.
* [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
* [ ] I marked all done items in this checklist.
