### PR TITLE
Handle absent `os-release` file

### DIFF
--- a/internal/handlers/common/msg_hostinfo.go
+++ b/internal/handlers/common/msg_hostinfo.go
@@ -37,19 +37,16 @@ func MsgHostInfo(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error) {
 
 	var osName, osVersion string
 
+	// try to parse Linux distro name and version, but do not fail if they are not present
 	if runtime.GOOS == "linux" {
 		file, err := os.Open("/etc/os-release")
 		if err != nil {
 			file, err = os.Open("/usr/lib/os-release")
-			if err != nil {
-				return nil, lazyerrors.Error(err)
-			}
 		}
-		defer file.Close()
 
-		osName, osVersion, err = parseOSRelease(file)
-		if err != nil {
-			return nil, lazyerrors.Error(err)
+		if err == nil {
+			defer file.Close()
+			osName, osVersion, _ = parseOSRelease(file)
 		}
 	}
 

--- a/internal/handlers/common/msg_hostinfo.go
+++ b/internal/handlers/common/msg_hostinfo.go
@@ -40,7 +40,7 @@ func MsgHostInfo(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error) {
 	if runtime.GOOS == "linux" {
 		file, err := os.Open("/etc/os-release")
 		if err != nil {
-			file, err = os.Open("/etc/arch-release")
+			file, err = os.Open("/usr/lib/os-release")
 			if err != nil {
 				return nil, lazyerrors.Error(err)
 			}

--- a/internal/handlers/common/parse_osrelease.go
+++ b/internal/handlers/common/parse_osrelease.go
@@ -22,18 +22,21 @@ import (
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
 )
 
-// parseOSRelease parses the /etc/os-release file.
-func parseOSRelease(reader io.Reader) (string, string, error) {
-	scanner := bufio.NewScanner(reader)
+// parseOSRelease parses the /etc/os-release or /usr/lib/os-release file content,
+// returning the OS name and version.
+func parseOSRelease(r io.Reader) (string, string, error) {
+	scanner := bufio.NewScanner(r)
 
 	configParams := map[string]string{}
 	for scanner.Scan() {
 		str := strings.Split(scanner.Text(), "=")
-		if len(str) == 1 {
+		if len(str) != 2 {
 			continue
 		}
+
 		configParams[str[0]] = str[1]
 	}
+
 	if err := scanner.Err(); err != nil {
 		return "", "", lazyerrors.Error(err)
 	}


### PR DESCRIPTION
# Description

Closes #2500.
Based on @AlekSi 's comment:
Update identifying Linux version in `hostInfo` comand - based on `/usr/lib/os-release` instead of `/usr/lib/arch-release`.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [x] I added/updated comments and checked rendering.
* [x] I made spot refactorings.
* [ ] I updated user documentation.
* [x] I ran `task all`, and it passed.
* [x] I ensured that PR title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
* [ ] I marked all done items in this checklist.
