### PR TITLE
Improve handling of `os-release` files

### DIFF
--- a/internal/handlers/common/msg_hostinfo.go
+++ b/internal/handlers/common/msg_hostinfo.go
@@ -43,9 +43,9 @@ func MsgHostInfo(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error) {
 		if err != nil {
 			file, err = os.Open("/usr/lib/os-release")
 		}
-		defer file.Close()
 
 		if err == nil {
+			defer file.Close()
 			osName, osVersion, _ = parseOSRelease(file)
 		}
 	}

--- a/internal/handlers/common/msg_hostinfo.go
+++ b/internal/handlers/common/msg_hostinfo.go
@@ -43,9 +43,9 @@ func MsgHostInfo(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error) {
 		if err != nil {
 			file, err = os.Open("/usr/lib/os-release")
 		}
+		defer file.Close()
 
 		if err == nil {
-			defer file.Close()
 			osName, osVersion, _ = parseOSRelease(file)
 		}
 	}

--- a/internal/handlers/common/parse_osrelease.go
+++ b/internal/handlers/common/parse_osrelease.go
@@ -39,11 +39,12 @@ func parseOSRelease(r io.Reader) (string, string, error) {
 		value := strings.Join(str[1:], "")
 		unquotedValue, err := strconv.Unquote(value)
 
-		if errors.Is(err, nil) {
+		switch {
+		case errors.Is(err, nil):
 			configParams[str[0]] = unquotedValue
-		} else if errors.Is(err, strconv.ErrSyntax) {
+		case errors.Is(err, strconv.ErrSyntax):
 			configParams[str[0]] = value
-		} else {
+		default:
 			return "", "", lazyerrors.Error(err)
 		}
 	}

--- a/internal/handlers/common/parse_osrelease.go
+++ b/internal/handlers/common/parse_osrelease.go
@@ -16,6 +16,7 @@ package common
 
 import (
 	"bufio"
+	"errors"
 	"io"
 	"strconv"
 	"strings"
@@ -38,13 +39,11 @@ func parseOSRelease(r io.Reader) (string, string, error) {
 		value := strings.Join(str[1:], "")
 		unquotedValue, err := strconv.Unquote(value)
 
-		switch err {
-		case nil:
+		if errors.Is(err, nil) {
 			configParams[str[0]] = unquotedValue
-		// when value does not contain quotes
-		case strconv.ErrSyntax:
+		} else if errors.Is(err, strconv.ErrSyntax) {
 			configParams[str[0]] = value
-		default:
+		} else {
 			return "", "", lazyerrors.Error(err)
 		}
 	}

--- a/internal/handlers/common/parse_osrelease.go
+++ b/internal/handlers/common/parse_osrelease.go
@@ -17,6 +17,7 @@ package common
 import (
 	"bufio"
 	"io"
+	"strconv"
 	"strings"
 
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
@@ -34,7 +35,18 @@ func parseOSRelease(r io.Reader) (string, string, error) {
 			continue
 		}
 
-		configParams[str[0]] = str[1]
+		value := strings.Join(str[1:], "")
+		unquotedValue, err := strconv.Unquote(value)
+
+		switch err {
+		case nil:
+			configParams[str[0]] = unquotedValue
+		// when value does not contain quotes
+		case strconv.ErrSyntax:
+			configParams[str[0]] = value
+		default:
+			return "", "", lazyerrors.Error(err)
+		}
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/internal/handlers/common/parse_osrelease_test.go
+++ b/internal/handlers/common/parse_osrelease_test.go
@@ -70,6 +70,17 @@ REDHAT_BUGZILLA_PRODUCT_VERSION=7.6
 REDHAT_SUPPORT_PRODUCT=Red Hat Enterprise Linux
 REDHAT_SUPPORT_PRODUCT_VERSION=7.6
 `,
+		"Arch Linux": `NAME="Arch Linux"
+PRETTY_NAME="Arch Linux"
+ID=arch
+BUILD_ID=rolling
+ANSI_COLOR="38;2;23;147;209"
+HOME_URL="https://archlinux.org/"
+DOCUMENTATION_URL="https://wiki.archlinux.org/"
+SUPPORT_URL="https://bbs.archlinux.org/"
+BUG_REPORT_URL="https://bugs.archlinux.org/"
+PRIVACY_POLICY_URL="https://terms.archlinux.org/docs/privacy-policy/"
+LOGO=archlinux-logo`,
 	}
 
 	testCases := map[string]map[string]string{
@@ -84,6 +95,10 @@ REDHAT_SUPPORT_PRODUCT_VERSION=7.6
 		"redHat": {
 			"NAME":    "Red Hat Enterprise Linux Server",
 			"VERSION": "7.6 (Maipo)",
+		},
+		"Arch Linux": {
+			"NAME":    "Arch Linux",
+			"VERSION": "",
 		},
 	}
 


### PR DESCRIPTION
# Description

Closes #2500 .

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->
Add  in parseOSRelease support for:
- unquoting values
- dealing with more than one `=` in values - there should be only one delimiter per line

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [x] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [x] I added/updated comments and checked rendering.
* [x] I made spot refactorings.
* [ ] I updated user documentation.
* [x] I ran `task all`, and it passed.
* [x] I ensured that PR title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
