### PR TITLE
Add proper CLI to `envtool` - `envtool setup`  subcommand

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -94,7 +94,7 @@ tasks:
   env-setup:
     deps: [gen-version]
     cmds:
-      - go run {{.RACEFLAG}} ./cmd/envtool
+      - go run {{.RACEFLAG}} ./cmd/envtool setup
 
   env-logs:
     cmds:

--- a/cmd/envtool/envtool.go
+++ b/cmd/envtool/envtool.go
@@ -324,11 +324,12 @@ func printDiagnosticData(setupError error, logger *zap.SugaredLogger) {
 // cli struct represents all command-line commands, fields and flags.
 // It's used for parsing the user input.
 var cli struct {
-	Debug bool `help:"Enable debug mode."`
+	Debug bool     `help:"Enable debug mode."`
+	Setup struct{} `cmd:""`
 }
 
 func main() {
-	kong.Parse(&cli)
+	kongCtx := kong.Parse(&cli)
 
 	// always enable debug logging on CI
 	if t, _ := strconv.ParseBool(os.Getenv("CI")); t {
@@ -346,8 +347,11 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	if err := setup(ctx, logger); err != nil {
-		printDiagnosticData(err, logger)
-		os.Exit(1)
+	switch kongCtx.Command() {
+	case "setup":
+		if err := setup(ctx, logger); err != nil {
+			printDiagnosticData(err, logger)
+			os.Exit(1)
+		}
 	}
 }


### PR DESCRIPTION
# Description

Closes #2550 .

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->
Added `envtool setup` [kong](https://github.com/alecthomas/kong) subcommand.

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [ ] I added/updated comments and checked rendering.
* [x] I made spot refactorings.
* [ ] I updated user documentation.
* [x] I ran `task all`, and it passed.
* [x] I ensured that PR title is good enough for the changelog.
* [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
* [ ] I marked all done items in this checklist.
