### PR TITLE
Simplify `envtool shell` subcommands

### DIFF
--- a/cmd/envtool/envtool.go
+++ b/cmd/envtool/envtool.go
@@ -382,6 +382,7 @@ func main() {
 	defer cancel()
 
 	var err error
+
 	switch cmd := kongCtx.Command(); cmd {
 	case "setup":
 		err = setup(ctx, logger)

--- a/cmd/envtool/envtool_test.go
+++ b/cmd/envtool/envtool_test.go
@@ -15,8 +15,6 @@
 package main
 
 import (
-	"errors"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,38 +35,26 @@ func TestPrintDiagnosticData(t *testing.T) {
 func TestRmdirAbsentDir(t *testing.T) {
 	t.Parallel()
 
-	err := rmdir([]string{"rz"})
+	err := rmdir("absent")
 	assert.NoError(t, err)
 }
 
 func TestMkdirAndRmdir(t *testing.T) {
 	t.Parallel()
 
-	paths := []string{"ab/c"}
+	paths := []string{"ab/c", "ab"}
 
-	err := mkdir(paths)
+	err := mkdir(paths...)
 	assert.NoError(t, err)
 
-	// check if paths exist.
-	var errs error
-
 	for _, path := range paths {
-		if _, err = os.Stat(path); err != nil {
-			errs = errors.Join(errs, err)
-		}
+		assert.DirExists(t, path)
 	}
 
-	assert.NoError(t, errs)
-
-	err = rmdir(paths)
+	err = rmdir(paths...)
 	assert.NoError(t, err)
 
-	// check if paths do not exist.
 	for _, path := range paths {
-		if _, err = os.Stat(path); !os.IsNotExist(err) {
-			errs = errors.Join(errs, err)
-		}
+		assert.NoDirExists(t, path)
 	}
-
-	assert.NoError(t, errs)
 }


### PR DESCRIPTION
## Readiness checklist

* [x] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [x] I added/updated comments and checked rendering.
* [x] I made spot refactorings.
* [ ] I updated user documentation.
* [x] I ran `task all`, and it passed.
* [x] I ensured that PR title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
