### PR TITLE
Return `int64` values for `dbStats` and `collStats`

### DIFF
--- a/integration/commands_administration_test.go
+++ b/integration/commands_administration_test.go
@@ -586,12 +586,12 @@ func TestCommandsAdministrationCollStatsEmpty(t *testing.T) {
 	// Expected result is to have empty statistics (neither the database nor the collection exists)
 	doc := ConvertDocument(t, actual)
 	assert.Equal(t, collection.Database().Name()+"."+collection.Name(), must.NotFail(doc.Get("ns")))
-	assert.Equal(t, int32(0), must.NotFail(doc.Get("size")))
-	assert.Equal(t, int32(0), must.NotFail(doc.Get("count")))
-	assert.Equal(t, int32(0), must.NotFail(doc.Get("storageSize")))
-	assert.Equal(t, int32(0), must.NotFail(doc.Get("nindexes")))
-	assert.Equal(t, int32(0), must.NotFail(doc.Get("totalIndexSize")))
-	assert.Equal(t, int32(0), must.NotFail(doc.Get("totalSize")))
+	assert.EqualValues(t, 0, must.NotFail(doc.Get("size")))
+	assert.EqualValues(t, 0, must.NotFail(doc.Get("count")))
+	assert.EqualValues(t, 0, must.NotFail(doc.Get("storageSize")))
+	assert.EqualValues(t, 0, must.NotFail(doc.Get("nindexes")))
+	assert.EqualValues(t, 0, must.NotFail(doc.Get("totalIndexSize")))
+	assert.EqualValues(t, 0, must.NotFail(doc.Get("totalSize")))
 	assert.Equal(t, int32(1), must.NotFail(doc.Get("scaleFactor")))
 	assert.Equal(t, float64(1), must.NotFail(doc.Get("ok")))
 }
@@ -607,9 +607,11 @@ func TestCommandsAdministrationCollStats(t *testing.T) {
 
 	doc := ConvertDocument(t, actual)
 
+	// Values are returned as "numbers" that could be int32 or int64.
+	// FerretDB always returns int64 for simplicity.
 	// TODO Set better expected results https://github.com/FerretDB/FerretDB/issues/1771
 	assert.Equal(t, collection.Database().Name()+"."+collection.Name(), must.NotFail(doc.Get("ns")))
-	assert.Equal(t, int32(6), must.NotFail(doc.Get("count"))) // // Number of documents in DocumentsStrings
+	assert.EqualValues(t, 6, must.NotFail(doc.Get("count"))) // // Number of documents in DocumentsStrings
 	assert.Equal(t, int32(1), must.NotFail(doc.Get("scaleFactor")))
 	assert.Equal(t, float64(1), must.NotFail(doc.Get("ok")))
 
@@ -625,12 +627,14 @@ func TestCommandsAdministrationCollStats(t *testing.T) {
 		return
 	}
 
-	assert.InDelta(t, int32(40_000), must.NotFail(doc.Get("size")), 39_900)
-	assert.InDelta(t, int32(2_400), must.NotFail(doc.Get("avgObjSize")), 2_370)
-	assert.InDelta(t, int32(40_000), must.NotFail(doc.Get("storageSize")), 39_900)
-	assert.Equal(t, int32(1), must.NotFail(doc.Get("nindexes")))
-	assert.InDelta(t, int32(12_000), must.NotFail(doc.Get("totalIndexSize")), 11_000)
-	assert.InDelta(t, int32(32_000), must.NotFail(doc.Get("totalSize")), 30_000)
+	// Values are returned as "numbers" that could be int32 or int64.
+	// FerretDB always returns int64 for simplicity.
+	assert.InDelta(t, 40_000, must.NotFail(doc.Get("size")), 39_900)
+	assert.InDelta(t, 2_400, must.NotFail(doc.Get("avgObjSize")), 2_370)
+	assert.InDelta(t, 40_000, must.NotFail(doc.Get("storageSize")), 39_900)
+	assert.EqualValues(t, 1, must.NotFail(doc.Get("nindexes")))
+	assert.InDelta(t, 12_000, must.NotFail(doc.Get("totalIndexSize")), 11_000)
+	assert.InDelta(t, 32_000, must.NotFail(doc.Get("totalSize")), 30_000)
 }
 
 func TestCommandsAdministrationCollStatsWithScale(t *testing.T) {
@@ -645,7 +649,7 @@ func TestCommandsAdministrationCollStatsWithScale(t *testing.T) {
 	// TODO Set better expected results https://github.com/FerretDB/FerretDB/issues/1771
 	doc := ConvertDocument(t, actual)
 	assert.Equal(t, collection.Database().Name()+"."+collection.Name(), must.NotFail(doc.Get("ns")))
-	assert.Equal(t, int32(6), must.NotFail(doc.Get("count"))) // Number of documents in DocumentsStrings
+	assert.EqualValues(t, 6, must.NotFail(doc.Get("count"))) // Number of documents in DocumentsStrings
 	assert.Equal(t, int32(1000), must.NotFail(doc.Get("scaleFactor")))
 	assert.Equal(t, float64(1), must.NotFail(doc.Get("ok")))
 
@@ -661,12 +665,12 @@ func TestCommandsAdministrationCollStatsWithScale(t *testing.T) {
 		return
 	}
 
-	assert.InDelta(t, int32(16), must.NotFail(doc.Get("size")), 16)
-	assert.InDelta(t, int32(2_400), must.NotFail(doc.Get("avgObjSize")), 2_370)
-	assert.InDelta(t, int32(24), must.NotFail(doc.Get("storageSize")), 24)
-	assert.Equal(t, int32(1), must.NotFail(doc.Get("nindexes")))
-	assert.InDelta(t, int32(8), must.NotFail(doc.Get("totalIndexSize")), 8)
-	assert.InDelta(t, int32(24), must.NotFail(doc.Get("totalSize")), 24)
+	assert.InDelta(t, 16, must.NotFail(doc.Get("size")), 16)
+	assert.InDelta(t, 2_400, must.NotFail(doc.Get("avgObjSize")), 2_370)
+	assert.InDelta(t, 24, must.NotFail(doc.Get("storageSize")), 24)
+	assert.EqualValues(t, 1, must.NotFail(doc.Get("nindexes")))
+	assert.InDelta(t, 8, must.NotFail(doc.Get("totalIndexSize")), 8)
+	assert.InDelta(t, 24, must.NotFail(doc.Get("totalSize")), 24)
 }
 
 func TestCommandsAdministrationDataSize(t *testing.T) {
@@ -683,9 +687,9 @@ func TestCommandsAdministrationDataSize(t *testing.T) {
 
 		doc := ConvertDocument(t, actual)
 		assert.Equal(t, float64(1), must.NotFail(doc.Get("ok")))
-		assert.InDelta(t, float64(24_576), must.NotFail(doc.Get("size")), 24_576)
-		assert.InDelta(t, float64(4), must.NotFail(doc.Get("numObjects")), 4) // TODO https://github.com/FerretDB/FerretDB/issues/727
-		assert.InDelta(t, float64(200), must.NotFail(doc.Get("millis")), 200)
+		assert.InDelta(t, 24_576, must.NotFail(doc.Get("size")), 24_576)
+		assert.InDelta(t, 4, must.NotFail(doc.Get("numObjects")), 4) // TODO https://github.com/FerretDB/FerretDB/issues/727
+		assert.InDelta(t, 200, must.NotFail(doc.Get("millis")), 200)
 	})
 
 	t.Run("NonExistent", func(t *testing.T) {
@@ -699,9 +703,9 @@ func TestCommandsAdministrationDataSize(t *testing.T) {
 
 		doc := ConvertDocument(t, actual)
 		assert.Equal(t, float64(1), must.NotFail(doc.Get("ok")))
-		assert.Equal(t, int32(0), must.NotFail(doc.Get("size")))
-		assert.Equal(t, int32(0), must.NotFail(doc.Get("numObjects")))
-		assert.InDelta(t, float64(159), must.NotFail(doc.Get("millis")), 159)
+		assert.EqualValues(t, 0, must.NotFail(doc.Get("size")))
+		assert.EqualValues(t, 0, must.NotFail(doc.Get("numObjects")))
+		assert.InDelta(t, 159, must.NotFail(doc.Get("millis")), 159)
 	})
 }
 
@@ -714,11 +718,13 @@ func TestCommandsAdministrationDBStats(t *testing.T) {
 	err := collection.Database().RunCommand(ctx, command).Decode(&actual)
 	require.NoError(t, err)
 
+	// Values are returned as "numbers" that could be int32 or int64.
+	// FerretDB always returns int64 for simplicity.
 	// TODO Set better expected results https://github.com/FerretDB/FerretDB/issues/1771
 	doc := ConvertDocument(t, actual)
 	assert.Equal(t, collection.Database().Name(), doc.Remove("db"))
-	assert.Equal(t, int32(1), doc.Remove("collections"))
-	assert.Equal(t, int32(6), doc.Remove("objects")) // Number of documents in DocumentsStrings
+	assert.EqualValues(t, 1, doc.Remove("collections"))
+	assert.EqualValues(t, 6, doc.Remove("objects")) // Number of documents in DocumentsStrings
 	assert.Equal(t, float64(1), doc.Remove("scaleFactor"))
 	assert.Equal(t, float64(1), doc.Remove("ok"))
 
@@ -732,10 +738,10 @@ func TestCommandsAdministrationDBStats(t *testing.T) {
 		return
 	}
 
-	assert.InDelta(t, int32(37_500), doc.Remove("avgObjSize"), 37_460)
-	assert.InDelta(t, int32(37_500), doc.Remove("dataSize"), 37_450)
-	assert.InDelta(t, int32(37_500), doc.Remove("storageSize"), 37_450)
-	assert.InDelta(t, int32(49_152), doc.Remove("totalSize"), 49_100)
+	assert.InDelta(t, 37_500, doc.Remove("avgObjSize"), 37_460)
+	assert.InDelta(t, 37_500, doc.Remove("dataSize"), 37_450)
+	assert.InDelta(t, 37_500, doc.Remove("storageSize"), 37_450)
+	assert.InDelta(t, 49_152, doc.Remove("totalSize"), 49_100)
 
 	// TODO assert.Empty(t, doc.Keys())
 	// https://github.com/FerretDB/FerretDB/issues/727
@@ -756,9 +762,9 @@ func TestCommandsAdministrationDBStatsEmpty(t *testing.T) {
 	assert.Equal(t, collection.Database().Name(), doc.Remove("db"))
 	assert.EqualValues(t, float64(1), doc.Remove("scaleFactor")) // TODO use assert.Equal https://github.com/FerretDB/FerretDB/issues/727
 
-	assert.InDelta(t, int32(1), doc.Remove("collections"), 1)
-	assert.InDelta(t, float64(35500), doc.Remove("dataSize"), 35500)
-	assert.InDelta(t, float64(16384), doc.Remove("totalSize"), 16384)
+	assert.InDelta(t, 1, doc.Remove("collections"), 1)
+	assert.InDelta(t, 35500, doc.Remove("dataSize"), 35500)
+	assert.InDelta(t, 16384, doc.Remove("totalSize"), 16384)
 
 	// TODO assert.Empty(t, doc.Keys())
 	// https://github.com/FerretDB/FerretDB/issues/727
@@ -779,9 +785,9 @@ func TestCommandsAdministrationDBStatsWithScale(t *testing.T) {
 	assert.Equal(t, collection.Database().Name(), doc.Remove("db"))
 	assert.Equal(t, float64(1000), doc.Remove("scaleFactor"))
 
-	assert.InDelta(t, int32(1), doc.Remove("collections"), 1)
-	assert.InDelta(t, float64(35500), doc.Remove("dataSize"), 35500)
-	assert.InDelta(t, float64(16384), doc.Remove("totalSize"), 16384)
+	assert.InDelta(t, 1, doc.Remove("collections"), 1)
+	assert.InDelta(t, 35500, doc.Remove("dataSize"), 35500)
+	assert.InDelta(t, 16384, doc.Remove("totalSize"), 16384)
 
 	// TODO assert.Empty(t, doc.Keys())
 	// https://github.com/FerretDB/FerretDB/issues/727
@@ -802,9 +808,9 @@ func TestCommandsAdministrationDBStatsEmptyWithScale(t *testing.T) {
 	assert.Equal(t, collection.Database().Name(), doc.Remove("db"))
 	assert.EqualValues(t, float64(1000), doc.Remove("scaleFactor")) // TODO use assert.Equal https://github.com/FerretDB/FerretDB/issues/727
 
-	assert.InDelta(t, int32(1), doc.Remove("collections"), 1)
-	assert.InDelta(t, float64(35500), doc.Remove("dataSize"), 35500)
-	assert.InDelta(t, float64(16384), doc.Remove("totalSize"), 16384)
+	assert.InDelta(t, 1, doc.Remove("collections"), 1)
+	assert.InDelta(t, 35500, doc.Remove("dataSize"), 35500)
+	assert.InDelta(t, 16384, doc.Remove("totalSize"), 16384)
 
 	// TODO assert.Empty(t, doc.Keys())
 	// https://github.com/FerretDB/FerretDB/issues/727
@@ -844,8 +850,8 @@ func TestCommandsAdministrationServerStatus(t *testing.T) {
 	assert.True(t, ok)
 
 	// catalogStats is calculated across all the databases, so there could be quite a lot of collections here.
-	assert.InDelta(t, float64(632), must.NotFail(catalogStats.Get("collections")), 632)
-	assert.InDelta(t, float64(3), must.NotFail(catalogStats.Get("internalCollections")), 3)
+	assert.InDelta(t, 632, must.NotFail(catalogStats.Get("collections")), 632)
+	assert.InDelta(t, 3, must.NotFail(catalogStats.Get("internalCollections")), 3)
 
 	assert.Equal(t, int32(0), must.NotFail(catalogStats.Get("capped")))
 	assert.Equal(t, int32(0), must.NotFail(catalogStats.Get("timeseries")))

--- a/internal/handlers/common/aggregations/stages/collstats.go
+++ b/internal/handlers/common/aggregations/stages/collstats.go
@@ -102,7 +102,7 @@ func (c *collStats) Process(ctx context.Context, iter types.DocumentsIterator, c
 			for _, key := range scalable {
 				path := types.NewStaticPath("storageStats", key)
 				val := must.NotFail(res.GetByPath(path))
-				must.NoError(res.SetByPath(path, val.(int32)/scale))
+				must.NoError(res.SetByPath(path, val.(int64)/scale))
 			}
 		}
 

--- a/internal/handlers/common/aggregations/stages/collstats.go
+++ b/internal/handlers/common/aggregations/stages/collstats.go
@@ -102,7 +102,7 @@ func (c *collStats) Process(ctx context.Context, iter types.DocumentsIterator, c
 			for _, key := range scalable {
 				path := types.NewStaticPath("storageStats", key)
 				val := must.NotFail(res.GetByPath(path))
-				must.NoError(res.SetByPath(path, val.(int64)/scale))
+				must.NoError(res.SetByPath(path, val.(int64)/int64(scale)))
 			}
 		}
 

--- a/internal/handlers/common/serverstatus.go
+++ b/internal/handlers/common/serverstatus.go
@@ -75,6 +75,10 @@ func ServerStatus(state *state.State, cm *connmetrics.ConnMetrics) (*types.Docum
 		"metrics", must.NotFail(types.NewDocument(
 			"commands", metricsDoc,
 		)),
+
+		// our extensions
+		"ferretdbVersion", version.Get().Version,
+
 		"ok", float64(1),
 	))
 

--- a/internal/handlers/pg/msg_aggregate.go
+++ b/internal/handlers/pg/msg_aggregate.go
@@ -289,7 +289,7 @@ func processStagesStats(ctx context.Context, p *stagesStatsParams) ([]*types.Doc
 				"count", collStats.CountObjects,
 				"avgObjSize", avgObjSize,
 				"storageSize", collStats.SizeCollection,
-				"freeStorageSize", int32(0), // TODO https://github.com/FerretDB/FerretDB/issues/2342
+				"freeStorageSize", int64(0), // TODO https://github.com/FerretDB/FerretDB/issues/2342
 				"capped", false, // TODO https://github.com/FerretDB/FerretDB/issues/2342
 				"wiredTiger", must.NotFail(types.NewDocument()), // TODO https://github.com/FerretDB/FerretDB/issues/2342
 				"nindexes", collStats.CountIndexes,

--- a/internal/handlers/pg/msg_aggregate.go
+++ b/internal/handlers/pg/msg_aggregate.go
@@ -278,25 +278,25 @@ func processStagesStats(ctx context.Context, p *stagesStatsParams) ([]*types.Doc
 	}
 
 	if hasStorage {
-		var avgObjSize int32
+		var avgObjSize int64
 		if collStats.CountObjects > 0 {
-			avgObjSize = int32(collStats.SizeCollection) / collStats.CountObjects
+			avgObjSize = collStats.SizeCollection / collStats.CountObjects
 		}
 
 		doc.Set(
 			"storageStats", must.NotFail(types.NewDocument(
-				"size", int32(collStats.SizeTotal),
+				"size", collStats.SizeTotal,
 				"count", collStats.CountObjects,
 				"avgObjSize", avgObjSize,
-				"storageSize", int32(collStats.SizeCollection),
+				"storageSize", collStats.SizeCollection,
 				"freeStorageSize", int32(0), // TODO https://github.com/FerretDB/FerretDB/issues/2342
 				"capped", false, // TODO https://github.com/FerretDB/FerretDB/issues/2342
 				"wiredTiger", must.NotFail(types.NewDocument()), // TODO https://github.com/FerretDB/FerretDB/issues/2342
 				"nindexes", collStats.CountIndexes,
 				"indexDetails", must.NotFail(types.NewDocument()), // TODO https://github.com/FerretDB/FerretDB/issues/2342
 				"indexBuilds", must.NotFail(types.NewDocument()), // TODO https://github.com/FerretDB/FerretDB/issues/2342
-				"totalIndexSize", int32(collStats.SizeIndexes),
-				"totalSize", int32(collStats.SizeTotal),
+				"totalIndexSize", collStats.SizeIndexes,
+				"totalSize", collStats.SizeTotal,
 				"indexSizes", must.NotFail(types.NewDocument()), // TODO https://github.com/FerretDB/FerretDB/issues/2342
 			)),
 		)

--- a/internal/handlers/pg/msg_collstats.go
+++ b/internal/handlers/pg/msg_collstats.go
@@ -82,7 +82,7 @@ func (h *Handler) MsgCollStats(ctx context.Context, msg *wire.OpMsg) (*wire.OpMs
 
 	pairs := []any{
 		"ns", db + "." + collection,
-		"size", stats.SizeCollection / scale,
+		"size", stats.SizeCollection / int64(scale),
 		"count", stats.CountObjects,
 	}
 
@@ -92,10 +92,10 @@ func (h *Handler) MsgCollStats(ctx context.Context, msg *wire.OpMsg) (*wire.OpMs
 	}
 
 	pairs = append(pairs,
-		"storageSize", stats.SizeTotal/scale,
+		"storageSize", stats.SizeTotal/int64(scale),
 		"nindexes", stats.CountIndexes,
-		"totalIndexSize", stats.SizeIndexes/scale,
-		"totalSize", stats.SizeTotal/scale,
+		"totalIndexSize", stats.SizeIndexes/int64(scale),
+		"totalSize", stats.SizeTotal/int64(scale),
 		"scaleFactor", scale,
 		"ok", float64(1),
 	)

--- a/internal/handlers/pg/msg_dbstats.go
+++ b/internal/handlers/pg/msg_dbstats.go
@@ -77,11 +77,11 @@ func (h *Handler) MsgDBStats(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg,
 	}
 
 	pairs = append(pairs,
-		"dataSize", stats.SizeCollections/scale,
-		"storageSize", stats.SizeCollections/scale,
+		"dataSize", stats.SizeCollections/int64(scale),
+		"storageSize", stats.SizeCollections/int64(scale),
 		"indexes", stats.CountIndexes,
-		"indexSize", stats.SizeIndexes/scale,
-		"totalSize", stats.SizeTotal/scale,
+		"indexSize", stats.SizeIndexes/int64(scale),
+		"totalSize", stats.SizeTotal/int64(scale),
 		"scaleFactor", float64(scale),
 		"ok", float64(1),
 	)

--- a/internal/handlers/pg/msg_explain.go
+++ b/internal/handlers/pg/msg_explain.go
@@ -88,6 +88,8 @@ func (h *Handler) MsgExplain(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg,
 		"host", hostname,
 		"version", version.Get().MongoDBVersion,
 		"gitVersion", version.Get().Commit,
+
+		// our extensions
 		"ferretdbVersion", version.Get().Version,
 	))
 

--- a/internal/handlers/pg/pgdb/stats.go
+++ b/internal/handlers/pg/pgdb/stats.go
@@ -31,25 +31,31 @@ type ServerStats struct {
 
 // DBStats describes statistics for a FerretDB database (PostgreSQL schema).
 //
+// MongoDB uses "numbers" for those values that could be int32 or int64.
+// FerretDB always returns int64 for simplicity.
+//
 // TODO Include more data https://github.com/FerretDB/FerretDB/issues/2447.
 type DBStats struct {
-	CountCollections int32
-	CountObjects     int32
-	CountIndexes     int32
-	SizeTotal        int32
-	SizeIndexes      int32
-	SizeCollections  int32
+	CountCollections int64
+	CountObjects     int64
+	CountIndexes     int64
+	SizeTotal        int64
+	SizeIndexes      int64
+	SizeCollections  int64
 }
 
 // CollStats describes statistics for a FerretDB collection (PostgreSQL table).
 //
+// MongoDB uses "numbers" for those values that could be int32 or int64.
+// FerretDB always returns int64 for simplicity.
+//
 // TODO Include more data https://github.com/FerretDB/FerretDB/issues/2447.
 type CollStats struct {
-	CountObjects   int32
-	CountIndexes   int32
-	SizeTotal      int32
-	SizeIndexes    int32
-	SizeCollection int32
+	CountObjects   int64
+	CountIndexes   int64
+	SizeTotal      int64
+	SizeIndexes    int64
+	SizeCollection int64
 }
 
 // CalculateServerStats returns statistics for all the FerretDB databases on the server.
@@ -88,14 +94,14 @@ func CalculateDBStats(ctx context.Context, tx pgx.Tx, db string) (*DBStats, erro
 	// It also includes the size of FerretDB metadata relations.
 	//  See also https://www.postgresql.org/docs/15/functions-admin.html#FUNCTIONS-ADMIN-DBOBJECT
 	sql = `
-		SELECT 
-		    SUM(pg_total_relation_size(quote_ident(schemaname) || '.' || quote_ident(tablename))) 
-		FROM pg_tables 
+		SELECT
+		    SUM(pg_total_relation_size(quote_ident(schemaname) || '.' || quote_ident(tablename)))
+		FROM pg_tables
 		WHERE schemaname = $1`
 	args := []any{db}
 	row := tx.QueryRow(ctx, sql, args...)
 
-	var schemaSize *int32
+	var schemaSize *int64
 	if err := row.Scan(&schemaSize); err != nil {
 		return nil, lazyerrors.Error(err)
 	}
@@ -109,7 +115,7 @@ func CalculateDBStats(ctx context.Context, tx pgx.Tx, db string) (*DBStats, erro
 
 	// In this query we select all the tables in the given schema, but we exclude FerretDB metadata table (by reserved prefix).
 	sql = `
-		SELECT 
+		SELECT
 			COUNT(t.tablename)                       AS CountTables,
 			COUNT(i.indexname)                       AS CountIndexes,
 			COALESCE(SUM(c.reltuples), 0)            AS CountRows,
@@ -161,7 +167,7 @@ func CalculateCollStats(ctx context.Context, tx pgx.Tx, db, collection string) (
 			COALESCE(pg_total_relation_size(oid), 0) AS SizeTotal,
 			COALESCE(pg_table_size(oid), 0)          AS SizeTable,
 			COALESCE(pg_indexes_size(oid), 0)        AS SizeIndexes
-		FROM pg_class 
+		FROM pg_class
 		WHERE oid = '%s'::regclass`,
 		pgx.Identifier{db, metadata.table}.Sanitize(),
 	)

--- a/internal/handlers/tigris/msg_aggregate.go
+++ b/internal/handlers/tigris/msg_aggregate.go
@@ -269,18 +269,18 @@ func processStagesStats(ctx context.Context, p *stagesStatsParams) ([]*types.Doc
 
 		doc.Set(
 			"storageStats", must.NotFail(types.NewDocument(
-				"size", int32(dbStats.Size),
+				"size", dbStats.Size,
 				"count", dbStats.NumObjects,
 				"avgObjSize", avgObjSize,
-				"storageSize", int32(dbStats.Size),
-				"freeStorageSize", int32(0), // TODO https://github.com/FerretDB/FerretDB/issues/2342
+				"storageSize", dbStats.Size,
+				"freeStorageSize", int64(0), // TODO https://github.com/FerretDB/FerretDB/issues/2342
 				"capped", false, // TODO https://github.com/FerretDB/FerretDB/issues/2342
 				"wiredTiger", must.NotFail(types.NewDocument()), // TODO https://github.com/FerretDB/FerretDB/issues/2342
-				"nindexes", int32(0), // Not supported for Tigris
+				"nindexes", int64(0), // Not supported for Tigris
 				"indexDetails", must.NotFail(types.NewDocument()), // Not supported for Tigris
 				"indexBuilds", must.NotFail(types.NewDocument()), // Not supported for Tigris
-				"totalIndexSize", int32(0), // Not supported for Tigris
-				"totalSize", int32(dbStats.Size),
+				"totalIndexSize", int64(0), // Not supported for Tigris
+				"totalSize", dbStats.Size,
 				"indexSizes", must.NotFail(types.NewDocument()), // Not supported for Tigris
 			)),
 		)

--- a/internal/handlers/tigris/msg_collstats.go
+++ b/internal/handlers/tigris/msg_collstats.go
@@ -67,7 +67,7 @@ func (h *Handler) MsgCollStats(ctx context.Context, msg *wire.OpMsg) (*wire.OpMs
 
 	pairs := []any{
 		"ns", db + "." + collection,
-		"size", int32(stats.Size) / scale,
+		"size", stats.Size / int64(scale),
 		"count", stats.NumObjects,
 	}
 

--- a/internal/handlers/tigris/msg_datasize.go
+++ b/internal/handlers/tigris/msg_datasize.go
@@ -75,7 +75,7 @@ func (h *Handler) MsgDataSize(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg
 		pairs = append(pairs, "estimate", false)
 	}
 	pairs = append(pairs,
-		"size", int32(stats.Size),
+		"size", stats.Size,
 		"numObjects", stats.NumObjects,
 		"millis", int32(elapses.Milliseconds()),
 		"ok", float64(1),

--- a/internal/handlers/tigris/msg_explain.go
+++ b/internal/handlers/tigris/msg_explain.go
@@ -77,6 +77,8 @@ func (h *Handler) MsgExplain(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg,
 		"host", hostname,
 		"version", version.Get().MongoDBVersion,
 		"gitVersion", version.Get().Commit,
+
+		// our extensions
 		"ferretdbVersion", version.Get().Version,
 	))
 


### PR DESCRIPTION
# Description

To make them work for large databases and collections.

## Readiness checklist

* [ ] I added/updated unit tests.
* [x] I added/updated integration/compatibility tests.
* [x] I added/updated comments and checked rendering.
* [ ] I made spot refactorings.
* [ ] I updated user documentation.
* [x] I ran `task all`, and it passed.
* [x] I ensured that PR title is good enough for the changelog.
* [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
* [x] I marked all done items in this checklist.
