### PR TITLE
Fix `ObjectID` formatting in update error messages

### DIFF
--- a/internal/handlers/common/update_array_operators.go
+++ b/internal/handlers/common/update_array_operators.go
@@ -206,8 +206,9 @@ func processPushArrayUpdateExpression(doc *types.Document, update *types.Documen
 			return false, commonerrors.NewWriteErrorMsg(
 				commonerrors.ErrBadValue,
 				fmt.Sprintf(
+					// TODO
 					"The field '%s' must be an array but is of type '%s' in document {_id: %s}",
-					key, commonparams.AliasFromType(val), must.NotFail(doc.Get("_id")),
+					key, commonparams.AliasFromType(val), types.FormatAnyValue(must.NotFail(doc.Get("_id"))),
 				),
 			)
 		}
@@ -296,7 +297,7 @@ func processAddToSetArrayUpdateExpression(doc, update *types.Document) (bool, er
 				commonerrors.ErrBadValue,
 				fmt.Sprintf(
 					"The field '%s' must be an array but is of type '%s' in document {_id: %s}",
-					key, commonparams.AliasFromType(val), must.NotFail(doc.Get("_id")),
+					key, commonparams.AliasFromType(val), types.FormatAnyValue(must.NotFail(doc.Get("_id"))),
 				),
 			)
 		}
@@ -369,8 +370,8 @@ func processPullAllArrayUpdateExpression(doc, update *types.Document) (bool, err
 			return false, commonerrors.NewWriteErrorMsg(
 				commonerrors.ErrBadValue,
 				fmt.Sprintf(
-					"The field '%s' must be an array but is of type '%s' in document {_id: %s}",
-					key, commonparams.AliasFromType(val), must.NotFail(doc.Get("_id")),
+					"The field '%s' must be an array but is of type '%s' in document {_id: %v}",
+					key, commonparams.AliasFromType(val), types.FormatAnyValue(must.NotFail(doc.Get("_id"))),
 				),
 			)
 		}


### PR DESCRIPTION
# Description

In some places in update we return raw `_id` data from the document, which results in UTF-8 parsing when `_id` is the `ObjectID`:

```
�}ngoServerError: The field 'e' must be an array but is of type 'int' in document {_id: do>ZڥaI[
test> db.values.updateMany({},{$inc:{"d":1},$push:{'e':1}})
```

After this PR:

```
test> db.values.updateMany({},{$inc:{"d":1},$push:{'e':1}})
MongoServerError: The field 'e' must be an array but is of type 'int' in document {_id: ObjectId('646f3e5adaa51e61495b0db9')}
```

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

* [ ] I added/updated unit tests.
* [ ] I added/updated integration/compatibility tests.
* [ ] I added/updated comments and checked rendering.
* [ ] I made spot refactorings.
* [ ] I updated user documentation.
* [ ] I ran `task all`, and it passed.
* [ ] I ensured that PR title is good enough for the changelog.
* [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
* [ ] I marked all done items in this checklist.
