### PR TITLE
Add a test for `$collStats` error

### DIFF
--- a/build/legacy-mongo-shell/test.js
+++ b/build/legacy-mongo-shell/test.js
@@ -3,5 +3,12 @@
 (function() {
   'use strict';
 
+  const t = db.collstats;
+  t.drop();
+
+  let pipeline = [{$match: {}}, {$collStats: {}}];
+  const res = db.runCommand({aggregate: 'collstats', pipeline: pipeline, cursor: {}});
+  assert.commandFailedWithCode(res, 40602);
+
   print('test.js passed!');
 })();


### PR DESCRIPTION
For #2763

# Description

This PR shows that we return the wrong error when `$collStats` is not the first stage in the pipeline.

I assume this applies to all stages that must be first in the pipeline.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

- [ ] I added/updated unit tests.
- [ ] I added/updated integration/compatibility tests.
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [ ] I ensured that PR title is good enough for the changelog.
- [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
- [ ] I marked all done items in this checklist.
