### PR TITLE
Clean-up `lazyerrors`, use them in more places

### DIFF
--- a/.golangci-new.yml
+++ b/.golangci-new.yml
@@ -6,6 +6,11 @@ run:
   timeout: 3m
 
 linters-settings:
+  asasalint:
+    exclude:
+      - ^lazyerrors\.Errorf$
+    use-builtin-exclusions: true
+    ignore-test: false
   errorlint:
     # see caveats at https://github.com/polyfloyd/go-errorlint#fmterrorf-wrapping-verb
     errorf: false

--- a/integration/.golangci-new.yml
+++ b/integration/.golangci-new.yml
@@ -6,6 +6,11 @@ run:
   timeout: 3m
 
 linters-settings:
+  asasalint:
+    exclude:
+      - ^lazyerrors\.Errorf$
+    use-builtin-exclusions: true
+    ignore-test: false
   errorlint:
     # see caveats at https://github.com/polyfloyd/go-errorlint#fmterrorf-wrapping-verb
     errorf: false
@@ -17,7 +22,7 @@ linters-settings:
   revive:
     ignore-generated-header: true
     severity: warning
-    # TODO enable-all-rules: true
+    # TODO enable-all-rules: true https://github.com/FerretDB/FerretDB/issues/2748
     rules:
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md
       - name: exported
@@ -62,8 +67,9 @@ linters:
     - unused
     - whitespace
 
-    # TODO configure and enable one by one
+    # TODO https://github.com/FerretDB/FerretDB/issues/2748
     - bidichk
+    - bodyclose
     - containedctx
     - contextcheck
     - cyclop
@@ -110,6 +116,8 @@ linters:
     - prealloc
     - predeclared
     - promlinter
+    - rowserrcheck
+    - sqlclosecheck
     - stylecheck
     - tagliatelle
     - tenv
@@ -120,13 +128,8 @@ linters:
     - unparam
     - varcheck
     - varnamelen
-    - wrapcheck
-
-    # TODO https://github.com/golangci/golangci-lint/issues/2649
-    - bodyclose
-    - rowserrcheck
-    - sqlclosecheck
     - wastedassign
+    - wrapcheck
 
     # deprecated
     - golint

--- a/internal/handlers/pg/pgdb/pool.go
+++ b/internal/handlers/pg/pgdb/pool.go
@@ -16,7 +16,6 @@ package pgdb
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 	"strings"
 
@@ -27,6 +26,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/FerretDB/FerretDB/internal/util/debugbuild"
+	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
 	"github.com/FerretDB/FerretDB/internal/util/state"
 )
 
@@ -51,7 +51,7 @@ type Pool struct {
 func NewPool(ctx context.Context, uri string, logger *zap.Logger, p *state.Provider) (*Pool, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
-		return nil, fmt.Errorf("pgdb.NewPool: %w", err)
+		return nil, lazyerrors.Error(err)
 	}
 
 	values := u.Query()
@@ -82,13 +82,13 @@ func NewPool(ctx context.Context, uri string, logger *zap.Logger, p *state.Provi
 
 	config, err := pgxpool.ParseConfig(u.String())
 	if err != nil {
-		return nil, fmt.Errorf("pgdb.NewPool: %w", err)
+		return nil, lazyerrors.Error(err)
 	}
 
 	config.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
 		var v string
 		if err := conn.QueryRow(ctx, `SHOW server_version`).Scan(&v); err != nil {
-			return err
+			return lazyerrors.Error(err)
 		}
 
 		if err := p.Update(func(s *state.State) { s.HandlerVersion = v }); err != nil {
@@ -118,7 +118,7 @@ func NewPool(ctx context.Context, uri string, logger *zap.Logger, p *state.Provi
 
 	pool, err := pgxpool.NewWithConfig(ctx, config)
 	if err != nil {
-		return nil, fmt.Errorf("pgdb.NewPool: %w", err)
+		return nil, lazyerrors.Error(err)
 	}
 
 	res := &Pool{
@@ -128,7 +128,7 @@ func NewPool(ctx context.Context, uri string, logger *zap.Logger, p *state.Provi
 
 	if err = res.checkConnection(ctx); err != nil {
 		res.Close()
-		return nil, err
+		return nil, lazyerrors.Error(err)
 	}
 
 	return res, nil
@@ -168,7 +168,7 @@ func isSupportedLocale(v string) bool {
 func (pgPool *Pool) checkConnection(ctx context.Context) error {
 	rows, err := pgPool.p.Query(ctx, "SHOW ALL")
 	if err != nil {
-		return fmt.Errorf("pgdb.checkConnection: %w", err)
+		return lazyerrors.Error(err)
 	}
 	defer rows.Close()
 
@@ -176,11 +176,11 @@ func (pgPool *Pool) checkConnection(ctx context.Context) error {
 		// handle variable number of columns as a workaround for https://github.com/cockroachdb/cockroach/issues/101715
 		values, err := rows.Values()
 		if err != nil {
-			return fmt.Errorf("pgdb.checkConnection: %w", err)
+			return lazyerrors.Error(err)
 		}
 
 		if len(values) < 2 {
-			return fmt.Errorf("pgdb.checkConnection: invalid row: %#v", values)
+			return lazyerrors.Errorf("invalid row: %#v", values)
 		}
 		name := values[0].(string)
 		setting := values[1].(string)
@@ -188,15 +188,15 @@ func (pgPool *Pool) checkConnection(ctx context.Context) error {
 		switch name {
 		case "server_encoding", "client_encoding":
 			if !isSupportedEncoding(setting) {
-				return fmt.Errorf("pgdb.checkConnection: %q is %q; supported value is %q", name, setting, supportedEncoding)
+				return lazyerrors.Errorf("%q is %q; supported value is %q", name, setting, supportedEncoding)
 			}
 		case "lc_collate", "lc_ctype":
 			if !isSupportedLocale(setting) {
-				return fmt.Errorf("pgdb.checkConnection: %q is %q; supported values are %v", name, setting, supportedLocales)
+				return lazyerrors.Errorf("%q is %q; supported values are %v", name, setting, supportedLocales)
 			}
 		case "standard_conforming_strings": // To sanitize safely: https://github.com/jackc/pgx/issues/868#issuecomment-725544647
 			if setting != "on" {
-				return fmt.Errorf("pgdb.checkConnection: %q is %q, want %q", name, setting, "on")
+				return lazyerrors.Errorf("%q is %q, want %q", name, setting, "on")
 			}
 		default:
 			continue
@@ -211,7 +211,7 @@ func (pgPool *Pool) checkConnection(ctx context.Context) error {
 	}
 
 	if err := rows.Err(); err != nil {
-		return fmt.Errorf("pgdb.checkConnection: %w", err)
+		return lazyerrors.Error(err)
 	}
 
 	return nil

--- a/internal/util/lazyerrors/lazyerrors.go
+++ b/internal/util/lazyerrors/lazyerrors.go
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package lazyerrors provides temporary error wrapping for lazy developers.
+// Package lazyerrors provides error wrapping with file location.
+//
+// Only one file location is captures for each error, not a full stack.
+// If the chain is needed, don't forget to add links manually.
 package lazyerrors
 
 import (
@@ -23,12 +26,14 @@ import (
 	"strings"
 )
 
-type withStack struct {
+// withPC wraps errors with a single frame.
+type withPC struct {
 	error
 	pc uintptr
 }
 
-func (e withStack) Error() string {
+// Error return the wrapped error message prefixed with file location.
+func (e withPC) Error() string {
 	if e.pc == 0 {
 		return e.error.Error()
 	}
@@ -48,33 +53,34 @@ func (e withStack) Error() string {
 	return fmt.Sprintf("[%s] %s", l, e.error)
 }
 
-func (e withStack) Unwrap() error {
+// Unwrap returns the wrapped error.
+func (e withPC) Unwrap() error {
 	return e.error
 }
 
-// New returns new error based on string, enriched with callers.
+// New returns new error with a given error string and file location.
 func New(s string) error {
-	return withStack{
+	return withPC{
 		error: errors.New(s),
 		pc:    pc(),
 	}
 }
 
-// Error returns new error based on err and ensures err is not nil.
+// Error returns new error with a given non-nil error and file location.
 func Error(err error) error {
 	if err == nil {
 		panic("err is nil")
 	}
 
-	return withStack{
+	return withPC{
 		error: err,
 		pc:    pc(),
 	}
 }
 
-// Errorf returns formatted error enriched with callers.
+// Errorf returns new error with a given format string and file location.
 func Errorf(format string, a ...any) error {
-	return withStack{
+	return withPC{
 		error: fmt.Errorf(format, a...),
 		pc:    pc(),
 	}

--- a/internal/util/lazyerrors/lazyerrors_test.go
+++ b/internal/util/lazyerrors/lazyerrors_test.go
@@ -126,3 +126,25 @@ func TestPC(t *testing.T) {
 	err := <-ch
 	assert.Equal(t, "[lazyerrors_test.go:123 lazyerrors.TestPC.func1] err", err.Error())
 }
+
+var drain any
+
+func BenchmarkNew(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		drain = New("err")
+	}
+
+	b.StopTimer()
+
+	assert.NotNil(b, drain)
+}
+
+func BenchmarkStatic(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		drain = errors.New("[lazyerrors_test.go:144 lazyerrors.BenchmarkStatic] err")
+	}
+
+	b.StopTimer()
+
+	assert.NotNil(b, drain)
+}


### PR DESCRIPTION
## Readiness checklist

- [ ] I added/updated unit tests.
- [ ] I added/updated integration/compatibility tests.
- [x] I added/updated comments and checked rendering.
- [x] I made spot refactorings.
- [ ] I updated user documentation.
- [x] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
