### PR TITLE
Remove the need to call `DeepCopy` in some places

### DIFF
--- a/internal/handlers/pg/msg_insert.go
+++ b/internal/handlers/pg/msg_insert.go
@@ -139,9 +139,6 @@ func insertDocument(ctx context.Context, tx pgx.Tx, qp *pgdb.QueryParams, doc an
 	toInsert := d
 
 	if !toInsert.Has("_id") {
-		// Make a copy so that original document could be sent to the proxy as it is.
-		toInsert = d.DeepCopy()
-
 		toInsert.Set("_id", types.NewObjectID())
 	}
 

--- a/internal/handlers/tigris/msg_insert.go
+++ b/internal/handlers/tigris/msg_insert.go
@@ -118,9 +118,6 @@ func insertDocument(ctx context.Context, dbPool *tigrisdb.TigrisDB, qp *tigrisdb
 	toInsert := doc
 
 	if !toInsert.Has("_id") {
-		// Make a copy so that original document could be sent to the proxy as it is.
-		toInsert = doc.DeepCopy()
-
 		toInsert.Set("_id", types.NewObjectID())
 	}
 


### PR DESCRIPTION
# Description

Closes #2754.

## Readiness checklist

- [ ] I added/updated unit tests.
- [ ] I added/updated integration/compatibility tests.
- [x] I added/updated comments and checked rendering.
- [x] I made spot refactorings.
- [ ] I updated user documentation.
- [x] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
