### PR TITLE
Add test for zero divisor `$mod`

### DIFF
--- a/build/legacy-mongo-shell/test.js
+++ b/build/legacy-mongo-shell/test.js
@@ -16,7 +16,7 @@
 
   let code = 2; // BadValue for $mod in a $match pipeline stage.
 
-  const assertThrowsMsg = 'expected the following error code: ' + tojson(code);
+  let assertThrowsMsg = 'expected the following error code: ' + tojson(code);
   assert.commandFailedWithCode(res, code, assertThrowsMsg);
 
   pipe = {$project: {a: {$mod: [0 /* invalid */, 0]}}};
@@ -28,6 +28,7 @@
   // eslint-disable-next-line max-len
   code = 16610; // Failed to optimize pipeline :: caused by :: can't $mod by zero"
 
+  assertThrowsMsg = 'expected the following error code: ' + tojson(code);
   assert.commandFailedWithCode(res, code, assertThrowsMsg);
 
   print('test.js passed!');

--- a/build/legacy-mongo-shell/test.js
+++ b/build/legacy-mongo-shell/test.js
@@ -11,12 +11,23 @@
   pipe = [pipe];
 
   // FailedToParse occurs when cursor is not present.
-  const cmd = {pipeline: pipe, cursor: {batchSize: 0}};
-  const res = t.runCommand('aggregate', cmd);
+  let cmd = {pipeline: pipe, cursor: {batchSize: 0}};
+  let res = t.runCommand('aggregate', cmd);
 
-  const code = 2; // BadValue for $mod in a $match pipeline stage.
+  let code = 2; // BadValue for $mod in a $match pipeline stage.
 
   const assertThrowsMsg = 'expected the following error code: ' + tojson(code);
+  assert.commandFailedWithCode(res, code, assertThrowsMsg);
+
+  pipe = {$project: {a: {$mod: [0 /* invalid */, 0]}}};
+  pipe = [pipe];
+
+  cmd = {pipeline: pipe, cursor: {batchSize: 0}};
+  res = t.runCommand('aggregate', cmd);
+
+  // eslint-disable-next-line max-len
+  code = 16610; // Failed to optimize pipeline :: caused by :: can't $mod by zero"
+
   assert.commandFailedWithCode(res, code, assertThrowsMsg);
 
   print('test.js passed!');

--- a/build/legacy-mongo-shell/test.js
+++ b/build/legacy-mongo-shell/test.js
@@ -3,5 +3,21 @@
 (function() {
   'use strict';
 
+  const t = db.match_div_zero;
+  t.drop();
+
+  // divisor cannot be 0, second argument is the divisor.
+  let pipe = {$match: {a: {$mod: [0 /* invalid */, 0]}}};
+  pipe = [pipe];
+
+  // FailedToParse occurs when cursor is not present.
+  const cmd = {pipeline: pipe, cursor: {batchSize: 0}};
+  const res = t.runCommand('aggregate', cmd);
+
+  const code = 2; // BadValue for $mod in a $match pipeline stage.
+
+  const assertThrowsMsg = 'expected the following error code: ' + tojson(code);
+  assert.commandFailedWithCode(res, code, assertThrowsMsg);
+
   print('test.js passed!');
 })();


### PR DESCRIPTION
For #2780.

# Description

This PR shows that we allow the divisor to be zero in a both match and project stages.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

- [ ] I added/updated unit tests.
- [ ] I added/updated integration/compatibility tests.
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [ ] I ensured that PR title is good enough for the changelog.
- [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
- [ ] I marked all done items in this checklist.
