### PR TITLE
Implement simple `$addFields/$set` aggregation pipeline stages

### DIFF
--- a/integration/aggregate_documents_compat_test.go
+++ b/integration/aggregate_documents_compat_test.go
@@ -1852,14 +1852,14 @@ func TestAggregateCompatSet(t *testing.T) {
 		},
 		"UnsupportedExpressionObject": {
 			pipeline: bson.A{
-				bson.D{{"$addFields", bson.D{{"newField1", bson.D{{"$sum", 1}}}}}},
+				bson.D{{"$set", bson.D{{"newField1", bson.D{{"$sum", 1}}}}}},
 			},
 			resultType: emptyResult,
 			skip:       "https://github.com/FerretDB/FerretDB/issues/1413",
 		},
 		"UnsupportedExpressionArray": {
 			pipeline: bson.A{
-				bson.D{{"$addFields", bson.D{{"newField1", bson.A{bson.D{{"$sum", 1}}}}}}},
+				bson.D{{"$set", bson.D{{"newField1", bson.A{bson.D{{"$sum", 1}}}}}}},
 			},
 			resultType: emptyResult,
 			skip:       "https://github.com/FerretDB/FerretDB/issues/1413",

--- a/integration/aggregate_documents_compat_test.go
+++ b/integration/aggregate_documents_compat_test.go
@@ -1608,3 +1608,149 @@ func TestAggregateCompatProject(t *testing.T) {
 
 	testAggregateStagesCompat(t, testCases)
 }
+
+func TestAggregateCompatAddFields(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]aggregateStagesCompatTestCase{
+		"InvalidTypeString": {
+			pipeline: bson.A{
+				bson.D{{"$addFields", "invalid"}},
+			},
+			resultType: emptyResult,
+		},
+		"InvalidTypeBool": {
+			pipeline: bson.A{
+				bson.D{{"$addFields", false}},
+			},
+			resultType: emptyResult,
+		},
+		"InvalidTypeArray": {
+			pipeline: bson.A{
+				bson.D{{"$addFields", bson.A{}}},
+			},
+			resultType: emptyResult,
+		},
+		"InvalidTypeInt32": {
+			pipeline: bson.A{
+				bson.D{{"$addFields", int32(1)}},
+			},
+			resultType: emptyResult,
+		},
+		"InvalidTypeInt64": {
+			pipeline: bson.A{
+				bson.D{{"$addFields", int64(1)}},
+			},
+			resultType: emptyResult,
+		},
+		"InvalidTypeFloat32": {
+			pipeline: bson.A{
+				bson.D{{"$addFields", float32(1)}},
+			},
+			resultType: emptyResult,
+		},
+		"InvalidTypeFloat64": {
+			pipeline: bson.A{
+				bson.D{{"$addFields", float64(1)}},
+			},
+			resultType: emptyResult,
+		},
+		"InvalidTypeNull": {
+			pipeline: bson.A{
+				bson.D{{"$addFields", nil}},
+			},
+			resultType: emptyResult,
+		},
+		"Include1Field": {
+			pipeline: bson.A{
+				bson.D{{"$addFields", bson.D{{"newField", int32(1)}}}},
+			},
+		},
+		"Include2Fields": {
+			pipeline: bson.A{
+				bson.D{{"$addFields", bson.D{{"newField1", int32(1)}, {"newField2", int32(2)}}}},
+			},
+		},
+		"Include2Stages": {
+			pipeline: bson.A{
+				bson.D{{"$addFields", bson.D{{"newField1", int32(1)}}}},
+				bson.D{{"$addFields", bson.D{{"newField2", int32(2)}}}},
+			},
+		},
+	}
+
+	testAggregateStagesCompat(t, testCases)
+}
+
+func TestAggregateCompatSet(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]aggregateStagesCompatTestCase{
+		"InvalidTypeString": {
+			pipeline: bson.A{
+				bson.D{{"$set", "invalid"}},
+			},
+			resultType: emptyResult,
+		},
+		"InvalidTypeBool": {
+			pipeline: bson.A{
+				bson.D{{"$set", false}},
+			},
+			resultType: emptyResult,
+		},
+		"InvalidTypeArray": {
+			pipeline: bson.A{
+				bson.D{{"$set", bson.A{}}},
+			},
+			resultType: emptyResult,
+		},
+		"InvalidTypeInt32": {
+			pipeline: bson.A{
+				bson.D{{"$set", int32(1)}},
+			},
+			resultType: emptyResult,
+		},
+		"InvalidTypeInt64": {
+			pipeline: bson.A{
+				bson.D{{"$set", int64(1)}},
+			},
+			resultType: emptyResult,
+		},
+		"InvalidTypeFloat32": {
+			pipeline: bson.A{
+				bson.D{{"$set", float32(1)}},
+			},
+			resultType: emptyResult,
+		},
+		"InvalidTypeFloat64": {
+			pipeline: bson.A{
+				bson.D{{"$set", float64(1)}},
+			},
+			resultType: emptyResult,
+		},
+		"InvalidTypeNull": {
+			pipeline: bson.A{
+				bson.D{{"$set", nil}},
+			},
+			resultType: emptyResult,
+		},
+		"Include1Field": {
+			pipeline: bson.A{
+				bson.D{{"$set", bson.D{{"newField", int32(1)}}}},
+			},
+		},
+		"Include2Fields": {
+			pipeline: bson.A{
+				bson.D{{"$set", bson.D{{"newField1", int32(1)}, {"newField2", int32(2)}}}},
+			},
+		},
+		"Include2Stages": {
+			pipeline: bson.A{
+				bson.D{{"$set", bson.D{{"newField1", int32(1)}}}},
+				bson.D{{"$set", bson.D{{"newField2", int32(2)}}}},
+			},
+		},
+	}
+
+	testAggregateStagesCompat(t, testCases)
+}

--- a/integration/aggregate_documents_compat_test.go
+++ b/integration/aggregate_documents_compat_test.go
@@ -1677,6 +1677,20 @@ func TestAggregateCompatAddFields(t *testing.T) {
 				bson.D{{"$addFields", bson.D{{"newField2", int32(2)}}}},
 			},
 		},
+		"UnsupportedExpressionObject": {
+			pipeline: bson.A{
+				bson.D{{"$addFields", bson.D{{"newField1", bson.D{{"$sum", 1}}}}}},
+			},
+			resultType: emptyResult,
+			skip:       "https://github.com/FerretDB/FerretDB/issues/1413",
+		},
+		"UnsupportedExpressionArray": {
+			pipeline: bson.A{
+				bson.D{{"$addFields", bson.D{{"newField1", bson.A{bson.D{{"$sum", 1}}}}}}},
+			},
+			resultType: emptyResult,
+			skip:       "https://github.com/FerretDB/FerretDB/issues/1413",
+		},
 	}
 
 	testAggregateStagesCompat(t, testCases)
@@ -1749,6 +1763,20 @@ func TestAggregateCompatSet(t *testing.T) {
 				bson.D{{"$set", bson.D{{"newField1", int32(1)}}}},
 				bson.D{{"$set", bson.D{{"newField2", int32(2)}}}},
 			},
+		},
+		"UnsupportedExpressionObject": {
+			pipeline: bson.A{
+				bson.D{{"$addFields", bson.D{{"newField1", bson.D{{"$sum", 1}}}}}},
+			},
+			resultType: emptyResult,
+			skip:       "https://github.com/FerretDB/FerretDB/issues/1413",
+		},
+		"UnsupportedExpressionArray": {
+			pipeline: bson.A{
+				bson.D{{"$addFields", bson.D{{"newField1", bson.A{bson.D{{"$sum", 1}}}}}}},
+			},
+			resultType: emptyResult,
+			skip:       "https://github.com/FerretDB/FerretDB/issues/1413",
 		},
 	}
 

--- a/internal/handlers/common/add_fields_iterator.go
+++ b/internal/handlers/common/add_fields_iterator.go
@@ -53,7 +53,18 @@ func (iter *addFieldsIterator) Next() (struct{}, *types.Document, error) {
 	}
 
 	for _, key := range iter.newField.Keys() {
-		doc.Set(key, must.NotFail(iter.newField.Get(key)))
+		val := must.NotFail(iter.newField.Get(key))
+		switch value := val.(type) {
+		case *types.Document:
+			if err := ValidateDocumentExpression(value, "$addFields/$set"); err != nil {
+				return unused, nil, lazyerrors.Error(err)
+			}
+		case *types.Array:
+			if err := ValidateArrayExpression(value, "$addFields/$set"); err != nil {
+				return unused, nil, lazyerrors.Error(err)
+			}
+		}
+		doc.Set(key, val)
 	}
 
 	return unused, doc, nil

--- a/internal/handlers/common/add_fields_iterator.go
+++ b/internal/handlers/common/add_fields_iterator.go
@@ -1,0 +1,70 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"github.com/FerretDB/FerretDB/internal/types"
+	"github.com/FerretDB/FerretDB/internal/util/iterator"
+	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
+	"github.com/FerretDB/FerretDB/internal/util/must"
+)
+
+// AddFieldsIterator returns an iterator that adds a new field to the underlying iterator.
+// It will be added to the given closer.
+//
+// Next method returns the next document after adding the new field to the document.
+//
+// Close method closes the underlying iterator.
+func AddFieldsIterator(iter types.DocumentsIterator, closer *iterator.MultiCloser, newField *types.Document) types.DocumentsIterator { //nolint:lll // for readability
+	res := &addFieldsIterator{
+		iter:     iter,
+		newField: newField,
+	}
+	closer.Add(res)
+
+	return res
+}
+
+// addFieldsIterator is returned by AddFieldsIterator.
+type addFieldsIterator struct {
+	iter     types.DocumentsIterator
+	newField *types.Document
+}
+
+// Next implements iterator.Interface. See addFieldsIterator for details.
+func (iter *addFieldsIterator) Next() (struct{}, *types.Document, error) {
+	var unused struct{}
+
+	_, doc, err := iter.iter.Next()
+	if err != nil {
+		return unused, nil, lazyerrors.Error(err)
+	}
+
+	for _, key := range iter.newField.Keys() {
+		doc.Set(key, must.NotFail(iter.newField.Get(key)))
+	}
+
+	return unused, doc, nil
+}
+
+// Close implements iterator.Interface. See AddFieldsIterator for details.
+func (iter *addFieldsIterator) Close() {
+	iter.iter.Close()
+}
+
+// check interfaces
+var (
+	_ types.DocumentsIterator = (*addFieldsIterator)(nil)
+)

--- a/internal/handlers/common/add_fields_iterator.go
+++ b/internal/handlers/common/add_fields_iterator.go
@@ -54,16 +54,6 @@ func (iter *addFieldsIterator) Next() (struct{}, *types.Document, error) {
 
 	for _, key := range iter.newField.Keys() {
 		val := must.NotFail(iter.newField.Get(key))
-		switch value := val.(type) {
-		case *types.Document:
-			if err := ValidateDocumentExpression(value, "$addFields/$set"); err != nil {
-				return unused, nil, lazyerrors.Error(err)
-			}
-		case *types.Array:
-			if err := ValidateArrayExpression(value, "$addFields/$set"); err != nil {
-				return unused, nil, lazyerrors.Error(err)
-			}
-		}
 		doc.Set(key, val)
 	}
 

--- a/internal/handlers/common/aggregations/stages/add_fields.go
+++ b/internal/handlers/common/aggregations/stages/add_fields.go
@@ -35,7 +35,8 @@ type addFields struct {
 
 // newAddFields validates projection document and creates a new $addFields stage.
 func newAddFields(stage *types.Document) (aggregations.Stage, error) {
-	fields, err := stage.Get("$addFields")
+	const stageName = "$addFields"
+	fields, err := stage.Get(stageName)
 	if err != nil {
 		return nil, lazyerrors.Error(err)
 	}
@@ -44,9 +45,13 @@ func newAddFields(stage *types.Document) (aggregations.Stage, error) {
 	if !ok {
 		return nil, commonerrors.NewCommandErrorMsgWithArgument(
 			commonerrors.ErrSetBadExpression,
-			fmt.Sprintf("$addFields specification stage must be an object, got %T", fields),
-			"$addFields (stage)",
+			fmt.Sprintf("%s specification stage must be an object, got %T", stageName, fields),
+			fmt.Sprintf("%s (stage)", stageName),
 		)
+	}
+
+	if err := common.ValidateArrayAndDocExpression(fieldsDoc, stageName); err != nil {
+		return nil, err
 	}
 
 	return &addFields{

--- a/internal/handlers/common/aggregations/stages/add_fields.go
+++ b/internal/handlers/common/aggregations/stages/add_fields.go
@@ -35,8 +35,7 @@ type addFields struct {
 
 // newAddFields validates projection document and creates a new $addFields stage.
 func newAddFields(stage *types.Document) (aggregations.Stage, error) {
-	const stageName = "$addFields"
-	fields, err := stage.Get(stageName)
+	fields, err := stage.Get("$addFields")
 	if err != nil {
 		return nil, lazyerrors.Error(err)
 	}
@@ -45,12 +44,12 @@ func newAddFields(stage *types.Document) (aggregations.Stage, error) {
 	if !ok {
 		return nil, commonerrors.NewCommandErrorMsgWithArgument(
 			commonerrors.ErrSetBadExpression,
-			fmt.Sprintf("%s specification stage must be an object, got %T", stageName, fields),
-			fmt.Sprintf("%s (stage)", stageName),
+			fmt.Sprintf("$addFields specification stage must be an object, got %T", fields),
+			"$addFields (stage)",
 		)
 	}
 
-	if err := common.ValidateArrayAndDocExpression(fieldsDoc, stageName); err != nil {
+	if err := common.ValidateArrayAndDocExpression(fieldsDoc, "$addFields"); err != nil {
 		return nil, err
 	}
 

--- a/internal/handlers/common/aggregations/stages/add_fields.go
+++ b/internal/handlers/common/aggregations/stages/add_fields.go
@@ -1,0 +1,70 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stages
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/FerretDB/FerretDB/internal/handlers/common"
+	"github.com/FerretDB/FerretDB/internal/handlers/common/aggregations"
+	"github.com/FerretDB/FerretDB/internal/handlers/commonerrors"
+	"github.com/FerretDB/FerretDB/internal/types"
+	"github.com/FerretDB/FerretDB/internal/util/iterator"
+	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
+)
+
+// addFields represents $addFields stage.
+//
+//	{ $addFields: { <newField>: <expression>, ... } }
+type addFields struct {
+	newField *types.Document
+}
+
+// newAddFields validates projection document and creates a new $addFields stage.
+func newAddFields(stage *types.Document) (aggregations.Stage, error) {
+	fields, err := stage.Get("$addFields")
+	if err != nil {
+		return nil, lazyerrors.Error(err)
+	}
+
+	fieldsDoc, ok := fields.(*types.Document)
+	if !ok {
+		return nil, commonerrors.NewCommandErrorMsgWithArgument(
+			commonerrors.ErrSetBadExpression,
+			fmt.Sprintf("$addFields specification stage must be an object, got %T", fields),
+			"$addFields (stage)",
+		)
+	}
+
+	return &addFields{
+		newField: fieldsDoc,
+	}, nil
+}
+
+// Process implements Stage interface.
+func (s *addFields) Process(_ context.Context, iter types.DocumentsIterator, closer *iterator.MultiCloser) (types.DocumentsIterator, error) { //nolint:lll // for readability
+	return common.AddFieldsIterator(iter, closer, s.newField), nil
+}
+
+// Type implements Stage interface.
+func (s *addFields) Type() aggregations.StageType {
+	return aggregations.StageTypeDocuments
+}
+
+// check interfaces
+var (
+	_ aggregations.Stage = (*addFields)(nil)
+)

--- a/internal/handlers/common/aggregations/stages/group.go
+++ b/internal/handlers/common/aggregations/stages/group.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/FerretDB/FerretDB/internal/handlers/common"
 	"github.com/FerretDB/FerretDB/internal/handlers/common/aggregations"
@@ -83,7 +82,7 @@ func newGroup(stage *types.Document) (aggregations.Stage, error) {
 
 		if field == "_id" {
 			if doc, ok := v.(*types.Document); ok {
-				if err = validateDocumentExpression(doc); err != nil {
+				if err = common.ValidateDocumentExpression(doc, "$group"); err != nil {
 					return nil, err
 				}
 			}
@@ -255,38 +254,6 @@ func (m *groupMap) addOrAppend(groupKey any, docs ...*types.Document) {
 		groupID:   groupKey,
 		documents: docs,
 	})
-}
-
-// validateDocumentExpression returns error when there is unsupported expression present.
-func validateDocumentExpression(doc *types.Document) error {
-	iter := doc.Iterator()
-	defer iter.Close()
-
-	for {
-		k, v, err := iter.Next()
-		if errors.Is(err, iterator.ErrIteratorDone) {
-			return nil
-		}
-
-		if err != nil {
-			return err
-		}
-
-		if strings.HasPrefix(k, "$") {
-			// TODO: https://github.com/FerretDB/FerretDB/issues/2165
-			return commonerrors.NewCommandErrorMsgWithArgument(
-				commonerrors.ErrNotImplemented,
-				fmt.Sprintf("%s operator is not implemented for $group key expression yet", k),
-				"$group (stage)",
-			)
-		}
-
-		if docVal, ok := v.(*types.Document); ok {
-			if err = validateDocumentExpression(docVal); err != nil {
-				return err
-			}
-		}
-	}
 }
 
 // Type implements Stage interface.

--- a/internal/handlers/common/aggregations/stages/set.go
+++ b/internal/handlers/common/aggregations/stages/set.go
@@ -1,0 +1,72 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stages
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/FerretDB/FerretDB/internal/handlers/common"
+	"github.com/FerretDB/FerretDB/internal/handlers/common/aggregations"
+	"github.com/FerretDB/FerretDB/internal/handlers/commonerrors"
+	"github.com/FerretDB/FerretDB/internal/types"
+	"github.com/FerretDB/FerretDB/internal/util/iterator"
+	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
+)
+
+// set represents $set stage.
+//
+// The $set stage is an alias for $addFields.
+//
+//	{ $set: { <newField>: <expression>, ... } }
+type set struct {
+	newField *types.Document
+}
+
+// newSet validates projection document and creates a new $set stage.
+func newSet(stage *types.Document) (aggregations.Stage, error) {
+	fields, err := stage.Get("$set")
+	if err != nil {
+		return nil, lazyerrors.Error(err)
+	}
+
+	fieldsDoc, ok := fields.(*types.Document)
+	if !ok {
+		return nil, commonerrors.NewCommandErrorMsgWithArgument(
+			commonerrors.ErrSetBadExpression,
+			fmt.Sprintf("$set specification stage must be an object, got %T", fields),
+			"$set (stage)",
+		)
+	}
+
+	return &set{
+		newField: fieldsDoc,
+	}, nil
+}
+
+// Process implements Stage interface.
+func (s *set) Process(_ context.Context, iter types.DocumentsIterator, closer *iterator.MultiCloser) (types.DocumentsIterator, error) { //nolint:lll // for readability
+	return common.AddFieldsIterator(iter, closer, s.newField), nil
+}
+
+// Type implements Stage interface.
+func (s *set) Type() aggregations.StageType {
+	return aggregations.StageTypeDocuments
+}
+
+// check interfaces
+var (
+	_ aggregations.Stage = (*set)(nil)
+)

--- a/internal/handlers/common/aggregations/stages/set.go
+++ b/internal/handlers/common/aggregations/stages/set.go
@@ -37,7 +37,8 @@ type set struct {
 
 // newSet validates projection document and creates a new $set stage.
 func newSet(stage *types.Document) (aggregations.Stage, error) {
-	fields, err := stage.Get("$set")
+	const stageName = "$set"
+	fields, err := stage.Get(stageName)
 	if err != nil {
 		return nil, lazyerrors.Error(err)
 	}
@@ -46,9 +47,13 @@ func newSet(stage *types.Document) (aggregations.Stage, error) {
 	if !ok {
 		return nil, commonerrors.NewCommandErrorMsgWithArgument(
 			commonerrors.ErrSetBadExpression,
-			fmt.Sprintf("$set specification stage must be an object, got %T", fields),
-			"$set (stage)",
+			fmt.Sprintf("%s specification stage must be an object, got %T", stageName, fields),
+			fmt.Sprintf("%s (stage)", stageName),
 		)
+	}
+
+	if err := common.ValidateArrayAndDocExpression(fieldsDoc, stageName); err != nil {
+		return nil, err
 	}
 
 	return &set{

--- a/internal/handlers/common/aggregations/stages/set.go
+++ b/internal/handlers/common/aggregations/stages/set.go
@@ -37,8 +37,7 @@ type set struct {
 
 // newSet validates projection document and creates a new $set stage.
 func newSet(stage *types.Document) (aggregations.Stage, error) {
-	const stageName = "$set"
-	fields, err := stage.Get(stageName)
+	fields, err := stage.Get("$set")
 	if err != nil {
 		return nil, lazyerrors.Error(err)
 	}
@@ -47,12 +46,12 @@ func newSet(stage *types.Document) (aggregations.Stage, error) {
 	if !ok {
 		return nil, commonerrors.NewCommandErrorMsgWithArgument(
 			commonerrors.ErrSetBadExpression,
-			fmt.Sprintf("%s specification stage must be an object, got %T", stageName, fields),
-			fmt.Sprintf("%s (stage)", stageName),
+			fmt.Sprintf("$set specification stage must be an object, got %T", fields),
+			"$set (stage)",
 		)
 	}
 
-	if err := common.ValidateArrayAndDocExpression(fieldsDoc, stageName); err != nil {
+	if err := common.ValidateArrayAndDocExpression(fieldsDoc, "$set"); err != nil {
 		return nil, err
 	}
 

--- a/internal/handlers/common/aggregations/stages/stages.go
+++ b/internal/handlers/common/aggregations/stages/stages.go
@@ -29,12 +29,14 @@ type newStageFunc func(stage *types.Document) (aggregations.Stage, error)
 // Stages maps all supported aggregation Stages.
 var Stages = map[string]newStageFunc{
 	// sorted alphabetically
+	"$addFields": newAddFields,
 	"$collStats": newCollStats,
 	"$count":     newCount,
 	"$group":     newGroup,
 	"$limit":     newLimit,
 	"$match":     newMatch,
 	"$project":   newProject,
+	"$set":       newSet,
 	"$skip":      newSkip,
 	"$sort":      newSort,
 	"$unwind":    newUnwind,
@@ -44,7 +46,6 @@ var Stages = map[string]newStageFunc{
 // unsupportedStages maps all unsupported yet stages.
 var unsupportedStages = map[string]struct{}{
 	// sorted alphabetically
-	"$addFields":              {},
 	"$bucket":                 {},
 	"$bucketAuto":             {},
 	"$changeStream":           {},
@@ -68,7 +69,6 @@ var unsupportedStages = map[string]struct{}{
 	"$sample":                 {},
 	"$search":                 {},
 	"$searchMeta":             {},
-	"$set":                    {},
 	"$setWindowFields":        {},
 	"$sharedDataDistribution": {},
 	"$sortByCount":            {},

--- a/internal/handlers/common/validate.go
+++ b/internal/handlers/common/validate.go
@@ -16,10 +16,15 @@ package common
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
 
 	"go.uber.org/zap"
 
+	"github.com/FerretDB/FerretDB/internal/handlers/commonerrors"
 	"github.com/FerretDB/FerretDB/internal/types"
+	"github.com/FerretDB/FerretDB/internal/util/iterator"
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
 	"github.com/FerretDB/FerretDB/internal/util/must"
 	"github.com/FerretDB/FerretDB/internal/wire"
@@ -68,4 +73,64 @@ func Validate(ctx context.Context, msg *wire.OpMsg, l *zap.Logger) (*wire.OpMsg,
 	}))
 
 	return &reply, nil
+}
+
+// ValidateDocumentExpression returns error when there is unsupported expression present in the document.
+// Currently it raises error if there is any expression(which have a prefix $).
+func ValidateDocumentExpression(doc *types.Document, stageName string) error {
+	iter := doc.Iterator()
+	defer iter.Close()
+
+	for {
+		k, v, err := iter.Next()
+		if errors.Is(err, iterator.ErrIteratorDone) {
+			return nil
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if strings.HasPrefix(k, "$") {
+			// TODO: https://github.com/FerretDB/FerretDB/issues/2165
+			return commonerrors.NewCommandErrorMsgWithArgument(
+				commonerrors.ErrNotImplemented,
+				fmt.Sprintf("%s operator is not implemented for %s key expression yet", k, stageName),
+				fmt.Sprintf("%s (stage)", stageName),
+			)
+		}
+
+		if docVal, ok := v.(*types.Document); ok {
+			if err = ValidateDocumentExpression(docVal, stageName); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// ValidateArrayExpression returns error when there is unsupported expression present in the array.
+// Currently it raises error if there is any expression(which have a prefix $) inside the array.
+func ValidateArrayExpression(arr *types.Array, stageName string) error {
+	iter := arr.Iterator()
+	defer iter.Close()
+
+	for {
+		_, arrDoc, err := iter.Next()
+		if errors.Is(err, iterator.ErrIteratorDone) {
+			return nil
+		}
+
+		if err != nil {
+			return err
+		}
+
+		doc, ok := arrDoc.(*types.Document)
+		if !ok {
+			return nil
+		}
+
+		if err := ValidateDocumentExpression(doc, stageName); err != nil {
+			return err
+		}
+	}
 }

--- a/internal/handlers/common/validate.go
+++ b/internal/handlers/common/validate.go
@@ -151,5 +151,6 @@ func ValidateArrayAndDocExpression(fieldsDoc *types.Document, expression string)
 			}
 		}
 	}
+
 	return nil
 }

--- a/internal/handlers/common/validate.go
+++ b/internal/handlers/common/validate.go
@@ -134,3 +134,22 @@ func ValidateArrayExpression(arr *types.Array, stageName string) error {
 		}
 	}
 }
+
+// ValidateArrayAndDocExpression returns error when there is unsupported expression present either in the array/document.
+// Currently it raises error if there is any expression(which have a prefix $) inside the array/document.
+func ValidateArrayAndDocExpression(fieldsDoc *types.Document, expression string) error {
+	for _, key := range fieldsDoc.Keys() {
+		val := must.NotFail(fieldsDoc.Get(key))
+		switch value := val.(type) {
+		case *types.Document:
+			if err := ValidateDocumentExpression(value, expression); err != nil {
+				return lazyerrors.Error(err)
+			}
+		case *types.Array:
+			if err := ValidateArrayExpression(value, expression); err != nil {
+				return lazyerrors.Error(err)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/handlers/commonerrors/error.go
+++ b/internal/handlers/commonerrors/error.go
@@ -110,6 +110,9 @@ const (
 	// ErrDuplicateKey indicates duplicate key violation.
 	ErrDuplicateKey = ErrorCode(11000) // Location11000
 
+	// ErrSetBadExpression indicates set expression is not object.
+	ErrSetBadExpression = ErrorCode(40272) // Location40272
+
 	// ErrStageGroupInvalidFields indicates group's fields must be an object.
 	ErrStageGroupInvalidFields = ErrorCode(15947) // Location15947
 

--- a/internal/handlers/commonerrors/errorcode_string.go
+++ b/internal/handlers/commonerrors/errorcode_string.go
@@ -35,6 +35,7 @@ func _() {
 	_ = x[ErrDocumentValidationFailure-121]
 	_ = x[ErrNotImplemented-238]
 	_ = x[ErrDuplicateKey-11000]
+	_ = x[ErrSetBadExpression-40272]
 	_ = x[ErrStageGroupInvalidFields-15947]
 	_ = x[ErrStageGroupID-15948]
 	_ = x[ErrStageGroupMissingID-15955]
@@ -87,7 +88,7 @@ func _() {
 	_ = x[ErrStageCollStatsInvalidArg-5447000]
 }
 
-const _ErrorCode_name = "UnsetInternalErrorBadValueFailedToParseTypeMismatchAuthenticationFailedIllegalOperationNamespaceNotFoundIndexNotFoundPathNotViableConflictingUpdateOperatorsCursorNotFoundNamespaceExistsDollarPrefixedFieldNameInvalidIDEmptyFieldNameCommandNotFoundImmutableFieldCannotCreateIndexInvalidOptionsInvalidNamespaceIndexOptionsConflictIndexKeySpecsConflictOperationFailedDocumentValidationFailureNotImplementedLocation11000Location15947Location15948Location15955Location15958Location15959Location15969Location15973Location15974Location15975Location15976Location15981Location15998Location16410Location16872Location17276Location28667Location28724Location28812Location28818Location31253Location31254Location31324Location31394Location31395Location40156Location40157Location40158Location40160Location40234Location40237Location40238Location40323Location40352Location40353Location40414Location40415Location50840Location51024Location51075Location51091Location51108Location51246Location51247Location51270Location51272Location4822819Location5107200Location5107201Location5447000"
+const _ErrorCode_name = "UnsetInternalErrorBadValueFailedToParseTypeMismatchAuthenticationFailedIllegalOperationNamespaceNotFoundIndexNotFoundPathNotViableConflictingUpdateOperatorsCursorNotFoundNamespaceExistsDollarPrefixedFieldNameInvalidIDEmptyFieldNameCommandNotFoundImmutableFieldCannotCreateIndexInvalidOptionsInvalidNamespaceIndexOptionsConflictIndexKeySpecsConflictOperationFailedDocumentValidationFailureNotImplementedLocation11000Location15947Location15948Location15955Location15958Location15959Location15969Location15973Location15974Location15975Location15976Location15981Location15998Location16410Location16872Location17276Location28667Location28724Location28812Location28818Location31253Location31254Location31324Location31394Location31395Location40156Location40157Location40158Location40160Location40234Location40237Location40238Location40272Location40323Location40352Location40353Location40414Location40415Location50840Location51024Location51075Location51091Location51108Location51246Location51247Location51270Location51272Location4822819Location5107200Location5107201Location5447000"
 
 var _ErrorCode_map = map[ErrorCode]string{
 	0:       _ErrorCode_name[0:5],
@@ -148,24 +149,25 @@ var _ErrorCode_map = map[ErrorCode]string{
 	40234:   _ErrorCode_name[779:792],
 	40237:   _ErrorCode_name[792:805],
 	40238:   _ErrorCode_name[805:818],
-	40323:   _ErrorCode_name[818:831],
-	40352:   _ErrorCode_name[831:844],
-	40353:   _ErrorCode_name[844:857],
-	40414:   _ErrorCode_name[857:870],
-	40415:   _ErrorCode_name[870:883],
-	50840:   _ErrorCode_name[883:896],
-	51024:   _ErrorCode_name[896:909],
-	51075:   _ErrorCode_name[909:922],
-	51091:   _ErrorCode_name[922:935],
-	51108:   _ErrorCode_name[935:948],
-	51246:   _ErrorCode_name[948:961],
-	51247:   _ErrorCode_name[961:974],
-	51270:   _ErrorCode_name[974:987],
-	51272:   _ErrorCode_name[987:1000],
-	4822819: _ErrorCode_name[1000:1015],
-	5107200: _ErrorCode_name[1015:1030],
-	5107201: _ErrorCode_name[1030:1045],
-	5447000: _ErrorCode_name[1045:1060],
+	40272:   _ErrorCode_name[818:831],
+	40323:   _ErrorCode_name[831:844],
+	40352:   _ErrorCode_name[844:857],
+	40353:   _ErrorCode_name[857:870],
+	40414:   _ErrorCode_name[870:883],
+	40415:   _ErrorCode_name[883:896],
+	50840:   _ErrorCode_name[896:909],
+	51024:   _ErrorCode_name[909:922],
+	51075:   _ErrorCode_name[922:935],
+	51091:   _ErrorCode_name[935:948],
+	51108:   _ErrorCode_name[948:961],
+	51246:   _ErrorCode_name[961:974],
+	51247:   _ErrorCode_name[974:987],
+	51270:   _ErrorCode_name[987:1000],
+	51272:   _ErrorCode_name[1000:1013],
+	4822819: _ErrorCode_name[1013:1028],
+	5107200: _ErrorCode_name[1028:1043],
+	5107201: _ErrorCode_name[1043:1058],
+	5447000: _ErrorCode_name[1058:1073],
 }
 
 func (i ErrorCode) String() string {


### PR DESCRIPTION
# Description

Closes #2590 .
Implemented [$addFields](https://www.mongodb.com/docs/manual/reference/operator/aggregation/addFields/) / [$set ](https://www.mongodb.com/docs/manual/reference/operator/aggregation/set/)aggregation pipeline.
I have added support only for literal values.  Expressions will be implemented as part of https://github.com/FerretDB/FerretDB/issues/1413

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

- [ ] I added/updated unit tests.
- [x] I added/updated integration/compatibility tests.
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [ ] I ensured that PR title is good enough for the changelog.
- [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
