### PR TITLE
Remove `findAndModify` integration tests with `$` prefixed key for MongoDB 6.0.6 compatibility

### DIFF
--- a/integration/findandmodify_compat_test.go
+++ b/integration/findandmodify_compat_test.go
@@ -117,23 +117,6 @@ func TestFindAndModifyCompatErrors(t *testing.T) {
 			},
 			resultType: emptyResult,
 		},
-		"DollarPrefixedFieldName": {
-			command: bson.D{
-				{"query", bson.D{{"_id", bson.D{{"key", bson.D{{"$eq", "val"}}}}}}},
-				{"upsert", true},
-				{"update", bson.D{{"v", "replaced"}}},
-			},
-			resultType: emptyResult,
-		},
-		"DollarPrefixedNestedFieldName": {
-			command: bson.D{
-				{"query", bson.D{{"_id", bson.D{{"key", bson.D{{"nestedKey", bson.D{{"$eq", "val"}}}}}}}}},
-				{"upsert", true},
-				{"update", bson.D{{"v", "replaced"}}},
-			},
-			skipForTigris: "schema validation would fail",
-			resultType:    emptyResult,
-		},
 	}
 
 	testFindAndModifyCompat(t, testCases)


### PR DESCRIPTION
# Description

Closes #2736.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

Previous PR https://github.com/FerretDB/FerretDB/pull/2779 actually did not fix it for MongoDB 6.0.6. See https://github.com/FerretDB/FerretDB/pull/2727.

* Any `$` prefixed keys are valid in MongoDB 6.0.6. Let's remove those tests, we have diff documented in https://github.com/FerretDB/FerretDB/blob/main/website/docs/diff.md?plain=1#L19.
* Diff test created in https://github.com/FerretDB/dance/pull/466

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

- [ ] I added/updated unit tests.
- [x] I added/updated integration/compatibility tests.
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
