### PR TITLE
Make `testutil.Logger` easier to use

### DIFF
--- a/.golangci-new.yml
+++ b/.golangci-new.yml
@@ -15,6 +15,8 @@ linters-settings:
     check-type-assertions: false
     check-blank: false
     disable-default-exclusions: false
+    exclude-functions:
+      - (*database/sql.Rows).Close
   errorlint:
     # see caveats at https://github.com/polyfloyd/go-errorlint#fmterrorf-wrapping-verb
     errorf: false

--- a/cmd/envtool/envtool_test.go
+++ b/cmd/envtool/envtool_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
 
 	"github.com/FerretDB/FerretDB/internal/util/testutil"
 )
@@ -29,7 +28,7 @@ func TestPrintDiagnosticData(t *testing.T) {
 	t.Parallel()
 
 	assert.NotPanics(t, func() {
-		l := testutil.Logger(t, zap.NewAtomicLevelAt(zap.DebugLevel))
+		l := testutil.Logger(t)
 		printDiagnosticData(nil, l.Sugar())
 	})
 }

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -128,7 +128,7 @@ func SetupWithOpts(tb testing.TB, opts *SetupOpts) *SetupResult {
 	if *debugSetupF {
 		level = zap.NewAtomicLevelAt(zap.DebugLevel)
 	}
-	logger := testutil.Logger(tb, level)
+	logger := testutil.LevelLogger(tb, level)
 
 	var client *mongo.Client
 	var uri string

--- a/integration/setup/setup_compat.go
+++ b/integration/setup/setup_compat.go
@@ -92,7 +92,7 @@ func SetupCompatWithOpts(tb testing.TB, opts *SetupCompatOpts) *SetupCompatResul
 	if *debugSetupF {
 		level = zap.NewAtomicLevelAt(zap.DebugLevel)
 	}
-	logger := testutil.Logger(tb, level)
+	logger := testutil.LevelLogger(tb, level)
 
 	var targetClient *mongo.Client
 	if *targetURLF == "" {

--- a/internal/handlers/pg/pgdb/pgdb_test.go
+++ b/internal/handlers/pg/pgdb/pgdb_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 
 	"github.com/FerretDB/FerretDB/internal/util/state"
 	"github.com/FerretDB/FerretDB/internal/util/testutil"
@@ -32,7 +31,7 @@ import (
 func getPool(ctx context.Context, tb testing.TB) *Pool {
 	tb.Helper()
 
-	logger := testutil.Logger(tb, zap.NewAtomicLevelAt(zap.DebugLevel))
+	logger := testutil.Logger(tb)
 
 	p, err := state.NewProvider("")
 	require.NoError(tb, err)

--- a/internal/handlers/tigris/tigrisdb/query_test.go
+++ b/internal/handlers/tigris/tigrisdb/query_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tigrisdata/tigris-client-go/config"
 	"github.com/tigrisdata/tigris-client-go/driver"
-	"go.uber.org/zap"
 
 	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/util/iterator"
@@ -384,7 +383,7 @@ func setup(t *testing.T) (string, string, context.Context, *TigrisDB) {
 	p, err := state.NewProvider("")
 	require.NoError(t, err)
 
-	logger := testutil.Logger(t, zap.NewAtomicLevelAt(zap.DebugLevel))
+	logger := testutil.Logger(t)
 	tdb, err := New(ctx, cfg, logger, p)
 	require.NoError(t, err)
 

--- a/internal/handlers/tigris/tigrisdb/tigrisdb_test.go
+++ b/internal/handlers/tigris/tigrisdb/tigrisdb_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tigrisdata/tigris-client-go/config"
 	"github.com/tigrisdata/tigris-client-go/driver"
-	"go.uber.org/zap"
 
 	"github.com/FerretDB/FerretDB/internal/util/state"
 	"github.com/FerretDB/FerretDB/internal/util/testutil"
@@ -40,7 +39,7 @@ func TestCreateCollectionIfNotExist(t *testing.T) {
 	p, err := state.NewProvider("")
 	require.NoError(t, err)
 
-	logger := testutil.Logger(t, zap.NewAtomicLevelAt(zap.DebugLevel))
+	logger := testutil.Logger(t)
 	tdb, err := New(ctx, cfg, logger, p)
 	require.NoError(t, err)
 

--- a/internal/util/telemetry/telemetry_test.go
+++ b/internal/util/telemetry/telemetry_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/AlekSi/pointer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 
 	"github.com/FerretDB/FerretDB/internal/util/testutil"
 )
@@ -72,7 +71,7 @@ func TestState(t *testing.T) {
 			err := f.UnmarshalText([]byte(tc.flag))
 			require.NoError(t, err)
 
-			logger := testutil.Logger(t, zap.NewAtomicLevelAt(zap.DebugLevel))
+			logger := testutil.Logger(t)
 
 			state, locked, err := initialState(&f, tc.dnt, tc.execName, tc.prev, logger)
 			if tc.err != "" {

--- a/internal/util/testutil/testutil.go
+++ b/internal/util/testutil/testutil.go
@@ -45,8 +45,9 @@ func Ctx(tb testing.TB) context.Context {
 		tb.Log("Stopping...")
 		stop()
 
-		// There is a weird interaction between terminal's process group/session,
-		// Task's signal handling, and this attempt to handle signals gracefully fails miserably.
+		// There is a weird interaction between terminal's process group/session signal handling,
+		// Task's signal handling,
+		// and this attempt to handle signals gracefully.
 		// It may cause tests to continue running in the background
 		// while terminal shows command-line prompt already.
 		//
@@ -58,7 +59,12 @@ func Ctx(tb testing.TB) context.Context {
 }
 
 // Logger returns zap test logger with valid configuration.
-func Logger(tb testing.TB, level zap.AtomicLevel) *zap.Logger {
+func Logger(tb testing.TB) *zap.Logger {
+	return LevelLogger(tb, zap.NewAtomicLevelAt(zap.DebugLevel))
+}
+
+// LevelLogger returns zap test logger with given level and valid configuration.
+func LevelLogger(tb testing.TB, level zap.AtomicLevel) *zap.Logger {
 	opts := []zaptest.LoggerOption{
 		zaptest.Level(level),
 		zaptest.WrapOptions(zap.AddCaller(), zap.Development()),


### PR DESCRIPTION
## Readiness checklist

- [ ] I added/updated unit tests.
- [ ] I added/updated integration/compatibility tests.
- [ ] I added/updated comments and checked rendering.
- [x] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
