### PR TITLE
Add textlint rules for en dashes and em dashes

### DIFF
--- a/build/.textlintrc
+++ b/build/.textlintrc
@@ -30,7 +30,7 @@
                     "message": "Use en dashes with spaces",
                     "pattern": "/(\\S)–([\\S])/",
                     "replace": "$1 – $2",
-                    "force,Code": true
+                    "forceCode": true
                 }
             ]
         }

--- a/build/.textlintrc
+++ b/build/.textlintrc
@@ -5,17 +5,32 @@
         "one-sentence-per-line": true,
         "@textlint-rule/pattern": {
             "patterns": [
+                // mostly to keep JS/JSON snippets with correct
                 {
                     "message": "Use straight ASCII double quotes instead of curly double quotes",
-                    "pattern": "/(“|”)/",
+                    "pattern": "/“|”/",
                     "replace": "\"",
                     "forceCode": true
                 },
                 {
                     "message": "Use straight ASCII single quotes instead of curly single quotes",
-                    "pattern": "/(‘|’)/",
+                    "pattern": "/‘|’/",
                     "replace": "'",
                     "forceCode": true
+                },
+
+                // to prevent --flags from being converted to en dashes or em dashes
+                {
+                    "message": "Use en dashes with spaces instead of em dashes",
+                    "pattern": "/—/",
+                    "replace": " – ",
+                    "forceCode": true
+                },
+                {
+                    "message": "Use en dashes with spaces",
+                    "pattern": "/(\\S)–([\\S])/",
+                    "replace": "$1 – $2",
+                    "force,Code": true
                 }
             ]
         }

--- a/internal/bson/document.go
+++ b/internal/bson/document.go
@@ -230,7 +230,7 @@ func (doc *Document) ReadFrom(r *bufio.Reader) error {
 			fields = append(fields, field{key: key, value: types.Binary(v)})
 
 		case tagUndefined:
-			return lazyerrors.Errorf("bson.Document.ReadFrom: unhandled element type `Undefined (value) — Deprecated`")
+			return lazyerrors.Errorf("bson.Document.ReadFrom: unhandled element type `Undefined (value) Deprecated`")
 
 		case tagObjectID:
 			var v objectIDType

--- a/website/blog/2022-08-23-open-source-is-in-danger.md
+++ b/website/blog/2022-08-23-open-source-is-in-danger.md
@@ -20,16 +20,16 @@ And many of today's developers started out with a simple contribution to their f
 As for myself, I can't imagine a world without Open Source software.
 
 However, as with many things we benefit from in life, over time, we tend to take them for granted.
-And open source itself is definitely not a shiny new toy—we have Linux, SQLite, PostgreSQL, and an endless amount of tools that make our lives and work easier.
+And open source itself is definitely not a shiny new toy – we have Linux, SQLite, PostgreSQL, and an endless amount of tools that make our lives and work easier.
 We also have Open Source hardware.
 
-In 2018, when we heard about[MongoDB's changeover to the non-open source Server Side Public License, or SSPL](https://www.mongodb.com/blog/post/mongodb-now-released-under-the-server-side-public-license), our first thought was "wow, how stupid of MongoDB".
+In 2018, when we heard about [MongoDB's changeover to the non-open source Server Side Public License, or SSPL](https://www.mongodb.com/blog/post/mongodb-now-released-under-the-server-side-public-license), our first thought was "wow, how stupid of MongoDB".
 They will lose contributors and users.
 As it turned out, this knee-jerk reaction is not an accurate representation of the implications of MongoDB's move on Open Source.
 For some, this move may have not resulted in significant differences.
 
 Anyone, including MongoDB, Elastic or Graylog should be allowed to release their products under whatever license they would like to use, and the community should be free to continue if they want.
-Life happens, bad or strange decisions like this happen —- we can move on.
+Life happens, bad or strange decisions like this happen – we can move on.
 
 However, in terms of what MongoDB did, the impact is just different.
 No one should decide to come up with their own terms on what to call Open Source, and this is exactly what is happening.
@@ -51,7 +51,7 @@ However, [MongoDB proceeded to continue calling theselves Open Source](https://w
 They still do.
 They decided that they understand better what the definition of open source is.
 
-As [OpenUK](https://openuk.uk/)'s Amanda Brock[put it](https://www.computing.co.uk/analysis/4027028/elastic-stretched-patience-open-source) when Elastic adopted SSPL: "Let's be really clear - it's a move from open to proprietary as a consequence of a failed business model decision"
+As [OpenUK](https://openuk.uk/)'s Amanda Brock [put it](https://www.computing.co.uk/analysis/4027028/elastic-stretched-patience-open-source) when Elastic adopted SSPL: "Let's be really clear - it's a move from open to proprietary as a consequence of a failed business model decision"
 
 The compounding effect of this, in the long run, is the inevitable dilution of the true meaning, the true definition of Open Source.
 New generations of users will have a very different understanding of what open source is.

--- a/website/blog/2023-01-04-ferretdb-beta-version-authentication.md
+++ b/website/blog/2023-01-04-ferretdb-beta-version-authentication.md
@@ -26,7 +26,7 @@ There are numerous ways to dump and restore your data.
 For example, you can follow the following steps:
 
 1. Backup FerretDB databases with `mongodump`.
-   Set your FerretDB connection string in `-—uri` and run:
+   Set your FerretDB connection string in `--uri` and run:
    `mongodump --uri="mongodb://127.0.0.1:27017"`
    This command will create a directory with dumps for each FerretDB database on the given server.
    Later, we will use this dump to restore the database.

--- a/website/blog/2023-01-17-ferretdb-0-8-1-version-release.md
+++ b/website/blog/2023-01-17-ferretdb-0-8-1-version-release.md
@@ -66,7 +66,7 @@ And for that reason, we've also included a way to validate a client's TLS certif
 ## Documentation
 
 Our documentation is also not left out from this round of improvements.
-The biggest change is that addition of the FerretDB blog which was built on Docusaurus– an open source software - and which now resides in our centralized FerretDB repository.
+The biggest change is that addition of the FerretDB blog which was built on Docusaurus – an open source software – and which now resides in our centralized FerretDB repository.
 
 We've added a section for CLI flags and environment variables.
 On top of that, we've reformatted our documentation setup to ensure that the deployment URL is visible in logs and can be previewed, and we also added comments and warnings about Git LFS.


### PR DESCRIPTION
# Description

So we don't document `–handler` or `—handler` instead of `--handler`.

## Readiness checklist

- [ ] I added/updated unit tests.
- [ ] I added/updated integration/compatibility tests.
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [x] I updated user documentation.
- [x] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
