### PR TITLE
Fix `unimplemented-non-default` tag usages

### DIFF
--- a/internal/handlers/common/find.go
+++ b/internal/handlers/common/find.go
@@ -49,13 +49,13 @@ type FindParams struct {
 	Min          *types.Document `ferretdb:"min,ignored"`
 	Hint         any             `ferretdb:"hint,ignored"`
 
-	ReturnKey           bool `ferretdb:"returnKey,non-default"`
-	ShowRecordId        bool `ferretdb:"showRecordId,non-default"`
-	Tailable            bool `ferretdb:"tailable,non-default"`
-	OplogReplay         bool `ferretdb:"oplogReplay,non-default"`
-	NoCursorTimeout     bool `ferretdb:"noCursorTimeout,non-default"`
-	AwaitData           bool `ferretdb:"awaitData,non-default"`
-	AllowPartialResults bool `ferretdb:"allowPartialResults,non-default"`
+	ReturnKey           bool `ferretdb:"returnKey,unimplemented-non-default"`
+	ShowRecordId        bool `ferretdb:"showRecordId,unimplemented-non-default"`
+	Tailable            bool `ferretdb:"tailable,unimplemented-non-default"`
+	OplogReplay         bool `ferretdb:"oplogReplay,unimplemented-non-default"`
+	NoCursorTimeout     bool `ferretdb:"noCursorTimeout,unimplemented-non-default"`
+	AwaitData           bool `ferretdb:"awaitData,unimplemented-non-default"`
+	AllowPartialResults bool `ferretdb:"allowPartialResults,unimplemented-non-default"`
 }
 
 // GetFindParams returns `find` command parameters.

--- a/internal/handlers/commonparams/extract_params.go
+++ b/internal/handlers/commonparams/extract_params.go
@@ -205,7 +205,7 @@ func tagOptionsFromList(optionsList []string) *tagOptions {
 		switch tt {
 		case "opt":
 			to.optional = true
-		case "non-default":
+		case "unimplemented-non-default":
 			to.nonDefault = true
 		case "unimplemented":
 			to.unimplemented = true

--- a/internal/handlers/commonparams/extract_params_test.go
+++ b/internal/handlers/commonparams/extract_params_test.go
@@ -38,7 +38,7 @@ func TestParse(t *testing.T) {
 	}
 
 	type nonDefaultTag struct {
-		Find bool `ferretdb:"find,non-default"`
+		Find bool `ferretdb:"find,unimplemented-non-default"`
 	}
 
 	type update struct {


### PR DESCRIPTION
# Description

The description of the `unimplemented-non-default` tag was updated but usage was not.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

- [ ] I added/updated unit tests.
- [ ] I added/updated integration/compatibility tests.
- [ ] I added/updated comments and checked rendering.
- [x] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
