### PR TITLE
Unskip test that passes now

### DIFF
--- a/integration/commands_diagnostic_test.go
+++ b/integration/commands_diagnostic_test.go
@@ -346,8 +346,6 @@ func TestCommandsDiagnosticValidateError(t *testing.T) {
 }
 
 func TestCommandsDiagnosticWhatsMyURI(t *testing.T) {
-	t.Skip("https://github.com/FerretDB/FerretDB/issues/1759")
-
 	t.Parallel()
 
 	s := setup.SetupWithOpts(t, nil)

--- a/internal/handlers/common/aggregations/stages/group.go
+++ b/internal/handlers/common/aggregations/stages/group.go
@@ -117,6 +117,7 @@ func newGroup(stage *types.Document) (aggregations.Stage, error) {
 
 // Process implements Stage interface.
 func (g *group) Process(ctx context.Context, iter types.DocumentsIterator, closer *iterator.MultiCloser) (types.DocumentsIterator, error) { //nolint:lll // for readability
+	// TODO https://github.com/FerretDB/FerretDB/issues/2863
 	docs, err := iterator.ConsumeValues(iterator.Interface[struct{}, *types.Document](iter))
 	if err != nil {
 		return nil, lazyerrors.Error(err)


### PR DESCRIPTION
# Description

All TLS parameters are now a part of URI.

Closes #1759.

## Readiness checklist

- [ ] I added/updated unit tests.
- [x] I added/updated integration/compatibility tests.
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [x] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
