### PR TITLE
Fix `createIndexes` with unique false option

### DIFF
--- a/integration/indexes_compat_test.go
+++ b/integration/indexes_compat_test.go
@@ -845,6 +845,15 @@ func TestCreateIndexesCompatUnique(t *testing.T) {
 			insertDoc: bson.D{{"v", "value"}},
 			new:       true,
 		},
+		"NotUniqueIndex": {
+			models: []mongo.IndexModel{
+				{
+					Keys:    bson.D{{"v", 1}},
+					Options: options.Index().SetUnique(false),
+				},
+			},
+			insertDoc: bson.D{{"v", "value"}},
+		},
 		"NotExistingFieldIndex": {
 			models: []mongo.IndexModel{
 				{

--- a/internal/handlers/pg/msg_createindexes.go
+++ b/internal/handlers/pg/msg_createindexes.go
@@ -375,7 +375,7 @@ func processIndexOptions(indexDoc *types.Document) (*pgdb.Index, error) {
 		case "unique":
 			v := must.NotFail(indexDoc.Get("unique"))
 
-			_, ok := v.(bool)
+			unique, ok := v.(bool)
 			if !ok {
 				return nil, commonerrors.NewCommandErrorMsgWithArgument(
 					commonerrors.ErrTypeMismatch,
@@ -401,7 +401,9 @@ func processIndexOptions(indexDoc *types.Document) (*pgdb.Index, error) {
 				)
 			}
 
-			index.Unique = pointer.ToBool(true)
+			if unique {
+				index.Unique = pointer.ToBool(true)
+			}
 
 		case "background":
 			// ignore deprecated options

--- a/internal/handlers/pg/msg_createindexes.go
+++ b/internal/handlers/pg/msg_createindexes.go
@@ -166,6 +166,16 @@ func (h *Handler) MsgCreateIndexes(ctx context.Context, msg *wire.OpMsg) (*wire.
 				return err
 			}
 
+			if index.Unique != nil {
+				// when non-nil value is specified for unique, command response contains index count
+				isUniqueSpecified = true
+
+				if !*index.Unique {
+					// unique can be true or nil, so false is stored as nil
+					index.Unique = nil
+				}
+			}
+
 			if index.Name == "" {
 				return commonerrors.NewCommandErrorMsgWithArgument(
 					commonerrors.ErrCannotCreateIndex,
@@ -221,8 +231,6 @@ func (h *Handler) MsgCreateIndexes(ctx context.Context, msg *wire.OpMsg) (*wire.
 			if err != nil {
 				return err
 			}
-
-			isUniqueSpecified = index.Unique != nil
 		}
 	})
 
@@ -401,9 +409,7 @@ func processIndexOptions(indexDoc *types.Document) (*pgdb.Index, error) {
 				)
 			}
 
-			if unique {
-				index.Unique = pointer.ToBool(true)
-			}
+			index.Unique = pointer.ToBool(unique)
 
 		case "background":
 			// ignore deprecated options


### PR DESCRIPTION
# Description

Came across missing test case. I'm not sure if this is a bug or not...

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

- [ ] I added/updated unit tests.
- [x] I added/updated integration/compatibility tests.
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
