### PR TITLE
Replace `must.NotFail(types.NewDocument())` => `types.NewEmptyDocument()`

### DIFF
--- a/build/version/version.go
+++ b/build/version/version.go
@@ -120,7 +120,7 @@ func init() {
 		Dirty:               false,
 		Package:             unknown,
 		DebugBuild:          debugbuild.Enabled,
-		BuildEnvironment:    must.NotFail(types.NewDocument()),
+		BuildEnvironment:    types.NewEmptyDocument(),
 		MongoDBVersion:      mongoDBVersion,
 		MongoDBVersionArray: mongoDBVersionArray,
 	}

--- a/internal/bson/array_test.go
+++ b/internal/bson/array_test.go
@@ -36,7 +36,7 @@ var (
 			types.Binary{Subtype: types.BinaryUser, B: []byte{0x42}},
 			true,
 			time.Date(2021, 7, 27, 9, 35, 42, 123000000, time.UTC).Local(),
-			must.NotFail(types.NewDocument()),
+			types.NewEmptyDocument(),
 			42.13,
 			int32(42),
 			int64(42),

--- a/internal/handlers/common/aggregations/stages/unset.go
+++ b/internal/handlers/common/aggregations/stages/unset.go
@@ -43,7 +43,7 @@ func newUnset(stage *types.Document) (aggregations.Stage, error) {
 	fields := must.NotFail(stage.Get("$unset"))
 
 	// exclusion contains keys with `false` values to specify projection exclusion later.
-	exclusion := must.NotFail(types.NewDocument())
+	exclusion := types.NewEmptyDocument()
 
 	switch fields := fields.(type) {
 	case *types.Array:

--- a/internal/handlers/common/findandmodify.go
+++ b/internal/handlers/common/findandmodify.go
@@ -197,7 +197,7 @@ func PrepareDocumentForUpsert(docs []*types.Document, params *FindAndModifyParam
 // When inserting new document we must check that `_id` is present, so we must extract `_id`
 // from query or generate a new one.
 func prepareDocumentForInsert(params *FindAndModifyParams) (*types.Document, error) {
-	insert := must.NotFail(types.NewDocument())
+	insert := types.NewEmptyDocument()
 
 	if params.HasUpdateOperators {
 		if _, err := UpdateDocument("findAndModify", insert, params.Update); err != nil {

--- a/internal/handlers/commoncommands/msg_getcmdlineopts.go
+++ b/internal/handlers/commoncommands/msg_getcmdlineopts.go
@@ -28,7 +28,7 @@ func MsgGetCmdLineOpts(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error
 	must.NoError(reply.SetSections(wire.OpMsgSection{
 		Documents: []*types.Document{must.NotFail(types.NewDocument(
 			"argv", must.NotFail(types.NewArray("ferretdb")),
-			"parsed", must.NotFail(types.NewDocument()),
+			"parsed", types.NewEmptyDocument(),
 			"ok", float64(1),
 		))},
 	}))

--- a/internal/handlers/commoncommands/msg_hostinfo.go
+++ b/internal/handlers/commoncommands/msg_hostinfo.go
@@ -78,7 +78,7 @@ func MsgHostInfo(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error) {
 				"name", osName,
 				"version", osVersion,
 			)),
-			"extra", must.NotFail(types.NewDocument()),
+			"extra", types.NewEmptyDocument(),
 			"ok", float64(1),
 		))},
 	}))

--- a/internal/handlers/commoncommands/msg_listcommands.go
+++ b/internal/handlers/commoncommands/msg_listcommands.go
@@ -234,7 +234,7 @@ var Commands = map[string]command{
 
 // MsgListCommands is a common implementation of the listCommands command.
 func MsgListCommands(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error) {
-	cmdList := must.NotFail(types.NewDocument())
+	cmdList := types.NewEmptyDocument()
 	names := maps.Keys(Commands)
 	sort.Strings(names)
 

--- a/internal/handlers/commonerrors/write.go
+++ b/internal/handlers/commonerrors/write.go
@@ -75,7 +75,7 @@ func (we *WriteErrors) Document() *types.Document {
 	errs := must.NotFail(types.NewArray())
 
 	for _, e := range we.errs {
-		doc := must.NotFail(types.NewDocument())
+		doc := types.NewEmptyDocument()
 
 		if e.index != nil {
 			doc.Set("index", *e.index)

--- a/internal/handlers/hana/msg_dropdatabase.go
+++ b/internal/handlers/hana/msg_dropdatabase.go
@@ -49,7 +49,7 @@ func (h *Handler) MsgDropDatabase(ctx context.Context, msg *wire.OpMsg) (*wire.O
 		DB: db,
 	}
 
-	res := must.NotFail(types.NewDocument())
+	res := types.NewEmptyDocument()
 
 	err = dbPool.DropSchema(ctx, &qp)
 

--- a/internal/handlers/pg/msg_aggregate.go
+++ b/internal/handlers/pg/msg_aggregate.go
@@ -379,13 +379,13 @@ func processStagesStats(ctx context.Context, closer *iterator.MultiCloser, p *st
 				"storageSize", collStats.SizeCollection,
 				"freeStorageSize", int64(0), // TODO https://github.com/FerretDB/FerretDB/issues/2342
 				"capped", false, // TODO https://github.com/FerretDB/FerretDB/issues/2342
-				"wiredTiger", must.NotFail(types.NewDocument()), // TODO https://github.com/FerretDB/FerretDB/issues/2342
+				"wiredTiger", types.NewEmptyDocument(), // TODO https://github.com/FerretDB/FerretDB/issues/2342
 				"nindexes", collStats.CountIndexes,
-				"indexDetails", must.NotFail(types.NewDocument()), // TODO https://github.com/FerretDB/FerretDB/issues/2342
-				"indexBuilds", must.NotFail(types.NewDocument()), // TODO https://github.com/FerretDB/FerretDB/issues/2342
+				"indexDetails", types.NewEmptyDocument(), // TODO https://github.com/FerretDB/FerretDB/issues/2342
+				"indexBuilds", types.NewEmptyDocument(), // TODO https://github.com/FerretDB/FerretDB/issues/2342
 				"totalIndexSize", collStats.SizeIndexes,
 				"totalSize", collStats.SizeTotal,
-				"indexSizes", must.NotFail(types.NewDocument()), // TODO https://github.com/FerretDB/FerretDB/issues/2342
+				"indexSizes", types.NewEmptyDocument(), // TODO https://github.com/FerretDB/FerretDB/issues/2342
 			)),
 		)
 	}

--- a/internal/handlers/pg/msg_dropdatabase.go
+++ b/internal/handlers/pg/msg_dropdatabase.go
@@ -54,7 +54,7 @@ func (h *Handler) MsgDropDatabase(ctx context.Context, msg *wire.OpMsg) (*wire.O
 		}
 	}
 
-	res := must.NotFail(types.NewDocument())
+	res := types.NewEmptyDocument()
 
 	err = dbPool.InTransaction(ctx, func(tx pgx.Tx) error {
 		return pgdb.DropDatabase(ctx, tx, db)

--- a/internal/handlers/pg/msg_getparameter.go
+++ b/internal/handlers/pg/msg_getparameter.go
@@ -78,7 +78,7 @@ func (h *Handler) MsgGetParameter(ctx context.Context, msg *wire.OpMsg) (*wire.O
 
 // selectUnit is makes a selection of requested parameters.
 func selectUnit(document, resDB *types.Document, showDetails, allParameters bool) (doc *types.Document, err error) {
-	doc = must.NotFail(types.NewDocument())
+	doc = types.NewEmptyDocument()
 
 	iter := resDB.Iterator()
 	defer iter.Close()

--- a/internal/handlers/pg/msg_listindexes.go
+++ b/internal/handlers/pg/msg_listindexes.go
@@ -88,7 +88,8 @@ func (h *Handler) MsgListIndexes(ctx context.Context, msg *wire.OpMsg) (*wire.Op
 	firstBatch := types.MakeArray(len(indexes))
 
 	for _, index := range indexes {
-		indexKey := must.NotFail(types.NewDocument())
+		// TODO(quasilyte): MakeDocument(len(index.Key))?
+		indexKey := types.NewEmptyDocument()
 
 		for _, key := range index.Key {
 			indexKey.Set(key.Field, int32(key.Order))

--- a/internal/handlers/sjson/array_test.go
+++ b/internal/handlers/sjson/array_test.go
@@ -35,7 +35,7 @@ var arrayTestCases = []testCase{
 			types.Binary{Subtype: types.BinaryUser, B: []byte{0x42}},
 			true,
 			time.Date(2021, 7, 27, 9, 35, 42, 123000000, time.UTC).Local(),
-			must.NotFail(types.NewDocument()),
+			types.NewEmptyDocument(),
 			42.13,
 			int32(42),
 			int64(42),

--- a/internal/handlers/sjson/document.go
+++ b/internal/handlers/sjson/document.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
-	"github.com/FerretDB/FerretDB/internal/util/must"
 )
 
 // documentType represents BSON Document type.
@@ -62,7 +61,8 @@ func (doc *documentType) UnmarshalJSONWithSchema(data []byte, sch *schema) error
 		)
 	}
 
-	td := must.NotFail(types.NewDocument())
+	// TODO(quasilyte): MakeDocument(len(sch.Keys))?
+	td := types.NewEmptyDocument()
 
 	for _, key := range sch.Keys {
 		b, ok := rawMessages[key]

--- a/internal/handlers/sjson/schema_test.go
+++ b/internal/handlers/sjson/schema_test.go
@@ -118,7 +118,7 @@ func TestSchemaMarshalUnmarshal(t *testing.T) {
 			doc: must.NotFail(types.NewDocument(
 				"obj", must.NotFail(types.NewDocument(
 					"arr", must.NotFail(types.NewArray(
-						must.NotFail(types.NewDocument()),
+						types.NewEmptyDocument(),
 						must.NotFail(types.NewDocument("foo", must.NotFail(types.NewArray()))),
 					)),
 					"empty-arr", must.NotFail(types.NewArray()),

--- a/internal/handlers/sjson/sjson.go
+++ b/internal/handlers/sjson/sjson.go
@@ -75,7 +75,6 @@ import (
 
 	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
-	"github.com/FerretDB/FerretDB/internal/util/must"
 )
 
 // sjsontype is a type that can be marshaled from/to sjson.
@@ -218,7 +217,8 @@ func Unmarshal(data []byte) (*types.Document, error) {
 		)
 	}
 
-	d := must.NotFail(types.NewDocument())
+	// TODO(quasilyte): MakeDocument(len(sch.Keys))?
+	d := types.NewEmptyDocument()
 
 	for _, key := range sch.Keys {
 		b, ok := v[key]

--- a/internal/handlers/sjson/sjson_marshal_unmarshal_test.go
+++ b/internal/handlers/sjson/sjson_marshal_unmarshal_test.go
@@ -34,7 +34,7 @@ func TestMarshalUnmarshal(t *testing.T) {
 	}{
 		"Empty": {
 			json: `{"$s":{}}`,
-			doc:  must.NotFail(types.NewDocument()),
+			doc:  types.NewEmptyDocument(),
 		},
 		"Filled": {
 			json: `{

--- a/internal/handlers/sqlite/msg_dropdatabase.go
+++ b/internal/handlers/sqlite/msg_dropdatabase.go
@@ -54,7 +54,7 @@ func (h *Handler) MsgDropDatabase(ctx context.Context, msg *wire.OpMsg) (*wire.O
 		Name: dbName,
 	})
 
-	res := must.NotFail(types.NewDocument())
+	res := types.NewEmptyDocument()
 
 	switch {
 	case err == nil:

--- a/internal/types/document.go
+++ b/internal/types/document.go
@@ -89,6 +89,14 @@ func MakeDocument(capacity int) *Document {
 	}
 }
 
+// NewEmptyDocument creates an empty document with zero capacity.
+//
+// Prefer this to the must.NotFail(types.NewDocument()) alternative.
+// Prefer the MakeDocument function if you can specify a document size hint.
+func NewEmptyDocument() *Document {
+	return MakeDocument(0)
+}
+
 // NewDocument creates a document with the given key/value pairs.
 func NewDocument(pairs ...any) (*Document, error) {
 	l := len(pairs)

--- a/internal/types/fjson/array_test.go
+++ b/internal/types/fjson/array_test.go
@@ -34,7 +34,7 @@ var arrayTestCases = []testCase{{
 		types.Binary{Subtype: types.BinaryUser, B: []byte{0x42}},
 		true,
 		time.Date(2021, 7, 27, 9, 35, 42, 123000000, time.UTC).Local(),
-		must.NotFail(types.NewDocument()),
+		types.NewEmptyDocument(),
 		42.13,
 		int32(42),
 		int64(42),


### PR DESCRIPTION
# Description

Added a new helper function, `types.NewDocument`.
This function is identical to `types.MakeDocument(0)`, but it doesn't require the user to specify the capacity.

The main benefit is making the simple operation of creating a new (empty) document easier to read (not `must` package involved).

Some use cases can be further improved by using appropriate size hints (see TODO comments), but I tried to avoid the unrelated changes in this PR (plus it doesn't matter if these use sites are not on the hot path).

## Readiness checklist

- [ ] I added/updated unit tests.
- [ ] I added/updated integration/compatibility tests.
- [ ] I added/updated comments and checked rendering.
- [x] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
- [ ] I marked all done items in this checklist.
