### PR TITLE
Remove double decoding in unmarshalSingleValue()

### DIFF
--- a/internal/handlers/sjson/sjson.go
+++ b/internal/handlers/sjson/sjson.go
@@ -239,25 +239,13 @@ func Unmarshal(data []byte) (*types.Document, error) {
 }
 
 // unmarshalSingleValue decodes the given sjson-encoded data element by the given schema.
-func unmarshalSingleValue(data []byte, sch *elem) (any, error) {
+func unmarshalSingleValue(data json.RawMessage, sch *elem) (any, error) {
 	if bytes.Equal(data, []byte("null")) {
 		return fromSJSON(new(nullType)), nil
 	}
 
 	if sch == nil {
 		return nil, lazyerrors.Errorf("schema is not set")
-	}
-
-	var v json.RawMessage
-	r := bytes.NewReader(data)
-	dec := json.NewDecoder(r)
-
-	if err := dec.Decode(&v); err != nil {
-		return nil, lazyerrors.Error(err)
-	}
-
-	if err := checkConsumed(dec, r); err != nil {
-		return nil, lazyerrors.Error(err)
 	}
 
 	var res sjsontype


### PR DESCRIPTION
# Description

The callers of unmarshalSingleValue() always unmarshal the inputs of this function into `json.RawMessage`.

These `json.RawMessage` contain valid JSON data
that can be parsed directly. Doing an Unmarshal of `json.RawMessage` into `json.RawMessage` looks confusing and not very useful.

This change is mostly about readability and code clarity.

As a side note, it also improves `sjson` unmarshalling performance.

    name                             old time/op    new time/op    delta
    Array/array_all/UnmarshalJSON-8    34.6µs ± 1%    21.7µs ± 1%  -37.36%  (p=0.000 n=10+9)
    Document/all/UnmarshalJSON-8        120µs ± 0%      77µs ± 1%  -36.04%  (p=0.000 n=9+10)
    [Geo mean]                         64.5µs         40.8µs       -36.70%

    name                             old speed      new speed      delta
    Array/array_all/UnmarshalJSON-8  1.62MB/s ± 1%  2.58MB/s ± 1%        ~  (p=0.000 n=10+9)
    Document/all/UnmarshalJSON-8     2.15MB/s ± 1%  3.37MB/s ± 1%  +56.37%  (p=0.000 n=9+10)
    [Geo mean]                       1.87MB/s       2.95MB/s       +57.97%

    name                             old alloc/op   new alloc/op   delta
    Array/array_all/UnmarshalJSON-8    41.4kB ± 0%    22.0kB ± 0%  -46.92%  (p=0.000 n=10+10)
    Document/all/UnmarshalJSON-8        117kB ± 0%      62kB ± 0%  -46.89%  (p=0.000 n=10+10)
    [Geo mean]                         69.6kB         37.0kB       -46.91%

    name                             old allocs/op  new allocs/op  delta
    Array/array_all/UnmarshalJSON-8       184 ± 0%       119 ± 0%  -35.33%  (p=0.000 n=10+10)
    Document/all/UnmarshalJSON-8          580 ± 0%       374 ± 0%  -35.52%  (p=0.000 n=10+10)
    [Geo mean]                            327            211       -35.42%

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

- [ ] I added/updated unit tests.
- [ ] I added/updated integration/compatibility tests.
- [ ] I added/updated comments and checked rendering.
- [x] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
- [ ] I marked all done items in this checklist.
