### PR TITLE
Move `testutil.TB` to `testtb.TB`

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/util/testutil"
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 )
 
 //go:generate ../bin/stringer  -type compatTestCaseResultType
@@ -49,7 +50,7 @@ const (
 // convert converts given driver value (bson.D, bson.A, etc) to FerretDB types package value.
 //
 // It then can be used with all types helpers such as testutil.AssertEqual.
-func convert(t testutil.TB, v any) any {
+func convert(t testtb.TB, v any) any {
 	t.Helper()
 
 	switch v := v.(type) {
@@ -103,7 +104,7 @@ func convert(t testutil.TB, v any) any {
 }
 
 // ConvertDocument converts given driver's document to FerretDB's *types.Document.
-func ConvertDocument(t testutil.TB, doc bson.D) *types.Document {
+func ConvertDocument(t testtb.TB, doc bson.D) *types.Document {
 	t.Helper()
 
 	v := convert(t, doc)
@@ -114,7 +115,7 @@ func ConvertDocument(t testutil.TB, doc bson.D) *types.Document {
 }
 
 // ConvertDocuments converts given driver's documents slice to FerretDB's []*types.Document.
-func ConvertDocuments(t testutil.TB, docs []bson.D) []*types.Document {
+func ConvertDocuments(t testtb.TB, docs []bson.D) []*types.Document {
 	t.Helper()
 
 	res := make([]*types.Document, len(docs))
@@ -128,7 +129,7 @@ func ConvertDocuments(t testutil.TB, docs []bson.D) []*types.Document {
 // (NaNs are equal, etc).
 //
 // See testutil.AssertEqual for details.
-func AssertEqualDocuments(t testutil.TB, expected, actual bson.D) bool {
+func AssertEqualDocuments(t testtb.TB, expected, actual bson.D) bool {
 	t.Helper()
 
 	expectedDoc := ConvertDocument(t, expected)
@@ -140,7 +141,7 @@ func AssertEqualDocuments(t testutil.TB, expected, actual bson.D) bool {
 // (NaNs are equal, etc).
 //
 // See testutil.AssertEqual for details.
-func AssertEqualDocumentsSlice(t testutil.TB, expected, actual []bson.D) bool {
+func AssertEqualDocumentsSlice(t testtb.TB, expected, actual []bson.D) bool {
 	t.Helper()
 
 	expectedDocs := ConvertDocuments(t, expected)
@@ -149,7 +150,7 @@ func AssertEqualDocumentsSlice(t testutil.TB, expected, actual []bson.D) bool {
 }
 
 // AssertEqualCommandError asserts that the expected error is the same as the actual (ignoring the Raw part).
-func AssertEqualCommandError(t testutil.TB, expected mongo.CommandError, actual error) bool {
+func AssertEqualCommandError(t testtb.TB, expected mongo.CommandError, actual error) bool {
 	t.Helper()
 
 	a, ok := actual.(mongo.CommandError)
@@ -165,7 +166,7 @@ func AssertEqualCommandError(t testutil.TB, expected mongo.CommandError, actual 
 }
 
 // AssertEqualWriteError asserts that actual is a WriteException containing exactly one expected error (ignoring the Raw part).
-func AssertEqualWriteError(t testutil.TB, expected mongo.WriteError, actual error) bool {
+func AssertEqualWriteError(t testtb.TB, expected mongo.WriteError, actual error) bool {
 	t.Helper()
 
 	we, ok := actual.(mongo.WriteException) //nolint:errorlint // do not inspect error chain
@@ -188,7 +189,7 @@ func AssertEqualWriteError(t testutil.TB, expected mongo.WriteError, actual erro
 
 // AssertMatchesCommandError asserts that both errors are equal CommandErrors,
 // except messages (and ignoring the Raw part).
-func AssertMatchesCommandError(t testutil.TB, expected, actual error) {
+func AssertMatchesCommandError(t testtb.TB, expected, actual error) {
 	t.Helper()
 
 	a, ok := actual.(mongo.CommandError) //nolint:errorlint // do not inspect error chain
@@ -210,7 +211,7 @@ func AssertMatchesCommandError(t testutil.TB, expected, actual error) {
 
 // AssertMatchesWriteError asserts that both errors are WriteExceptions containing exactly one WriteError,
 // and those WriteErrors are equal, except messages (and ignoring the Raw part).
-func AssertMatchesWriteError(t testutil.TB, expected, actual error) {
+func AssertMatchesWriteError(t testtb.TB, expected, actual error) {
 	t.Helper()
 
 	a, ok := actual.(mongo.WriteException) //nolint:errorlint // do not inspect error chain
@@ -237,7 +238,7 @@ func AssertMatchesWriteError(t testutil.TB, expected, actual error) {
 
 // AssertMatchesBulkException asserts that both errors are BulkWriteExceptions containing the same number of WriteErrors,
 // and those WriteErrors are equal, except messages (and ignoring the Raw part).
-func AssertMatchesBulkException(t testutil.TB, expected, actual error) {
+func AssertMatchesBulkException(t testtb.TB, expected, actual error) {
 	t.Helper()
 
 	a, ok := actual.(mongo.BulkWriteException) //nolint:errorlint // do not inspect error chain
@@ -266,7 +267,7 @@ func AssertMatchesBulkException(t testutil.TB, expected, actual error) {
 //     `{ $slice: { a: { b: 3 }, b: "string" } }` exactly the same way).
 //
 // In any case, the alternative error message returned by FerretDB should not mislead users.
-func AssertEqualAltCommandError(t testutil.TB, expected mongo.CommandError, altMessage string, actual error) bool {
+func AssertEqualAltCommandError(t testtb.TB, expected mongo.CommandError, altMessage string, actual error) bool {
 	t.Helper()
 
 	a, ok := actual.(mongo.CommandError)
@@ -323,7 +324,7 @@ func AssertEqualAltWriteError(t *testing.T, expected mongo.WriteError, altMessag
 // UnsetRaw returns error with all Raw fields unset. It returns nil if err is nil.
 //
 // Error is checked using a regular type assertion; wrapped errors (errors.As) are not checked.
-func UnsetRaw(t testutil.TB, err error) error {
+func UnsetRaw(t testtb.TB, err error) error {
 	t.Helper()
 
 	switch err := err.(type) {
@@ -362,7 +363,7 @@ func UnsetRaw(t testutil.TB, err error) error {
 // CollectIDs returns all _id values from given documents.
 //
 // The order is preserved.
-func CollectIDs(t testutil.TB, docs []bson.D) []any {
+func CollectIDs(t testtb.TB, docs []bson.D) []any {
 	t.Helper()
 
 	ids := make([]any, len(docs))
@@ -378,7 +379,7 @@ func CollectIDs(t testutil.TB, docs []bson.D) []any {
 // CollectKeys returns document keys.
 //
 // The order is preserved.
-func CollectKeys(t testutil.TB, doc bson.D) []string {
+func CollectKeys(t testtb.TB, doc bson.D) []string {
 	t.Helper()
 
 	res := make([]string, len(doc))
@@ -390,7 +391,7 @@ func CollectKeys(t testutil.TB, doc bson.D) []string {
 }
 
 // FetchAll fetches all documents from the cursor, closing it.
-func FetchAll(t testutil.TB, ctx context.Context, cursor *mongo.Cursor) []bson.D {
+func FetchAll(t testtb.TB, ctx context.Context, cursor *mongo.Cursor) []bson.D {
 	var res []bson.D
 	err := cursor.All(ctx, &res)
 	require.NoError(t, cursor.Close(ctx))
@@ -399,7 +400,7 @@ func FetchAll(t testutil.TB, ctx context.Context, cursor *mongo.Cursor) []bson.D
 }
 
 // FindAll returns all documents from the given collection sorted by _id.
-func FindAll(t testutil.TB, ctx context.Context, collection *mongo.Collection) []bson.D {
+func FindAll(t testtb.TB, ctx context.Context, collection *mongo.Collection) []bson.D {
 	opts := options.Find().SetSort(bson.D{{"_id", 1}})
 	cursor, err := collection.Find(ctx, bson.D{}, opts)
 	require.NoError(t, err)

--- a/integration/setup/client.go
+++ b/integration/setup/client.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
 	"github.com/FerretDB/FerretDB/internal/util/observability"
-	"github.com/FerretDB/FerretDB/internal/util/testutil"
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 )
 
 // makeClient returns new client for the given working MongoDB URI.
@@ -55,7 +55,7 @@ func makeClient(ctx context.Context, uri string) (*mongo.Client, error) {
 //
 // If the connection can't be established, it panics,
 // as it doesn't make sense to proceed with other tests if we couldn't connect in one of them.
-func setupClient(tb testutil.TB, ctx context.Context, uri string) *mongo.Client {
+func setupClient(tb testtb.TB, ctx context.Context, uri string) *mongo.Client {
 	tb.Helper()
 
 	ctx, span := otel.Tracer("").Start(ctx, "setupClient")

--- a/integration/setup/listener.go
+++ b/integration/setup/listener.go
@@ -29,11 +29,11 @@ import (
 	"github.com/FerretDB/FerretDB/internal/handlers/registry"
 	"github.com/FerretDB/FerretDB/internal/util/observability"
 	"github.com/FerretDB/FerretDB/internal/util/state"
-	"github.com/FerretDB/FerretDB/internal/util/testutil"
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 )
 
 // unixSocketPath returns temporary Unix domain socket path for that test.
-func unixSocketPath(tb testutil.TB) string {
+func unixSocketPath(tb testtb.TB) string {
 	tb.Helper()
 
 	// do not use tb.TempDir() because generated path is too long on macOS
@@ -50,7 +50,7 @@ func unixSocketPath(tb testutil.TB) string {
 }
 
 // listenerMongoDBURI builds MongoDB URI for in-process FerretDB.
-func listenerMongoDBURI(tb testutil.TB, hostPort, unixSocketPath string, tlsAndAuth bool) string {
+func listenerMongoDBURI(tb testtb.TB, hostPort, unixSocketPath string, tlsAndAuth bool) string {
 	tb.Helper()
 
 	var host string
@@ -92,7 +92,7 @@ func listenerMongoDBURI(tb testutil.TB, hostPort, unixSocketPath string, tlsAndA
 
 // setupListener starts in-process FerretDB server that runs until ctx is canceled.
 // It returns basic MongoDB URI for that listener.
-func setupListener(tb testutil.TB, ctx context.Context, logger *zap.Logger) string {
+func setupListener(tb testtb.TB, ctx context.Context, logger *zap.Logger) string {
 	tb.Helper()
 
 	_, span := otel.Tracer("").Start(ctx, "setupListener")

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -35,6 +35,7 @@ import (
 	"github.com/FerretDB/FerretDB/internal/util/iterator"
 	"github.com/FerretDB/FerretDB/internal/util/observability"
 	"github.com/FerretDB/FerretDB/internal/util/testutil"
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 )
 
 // Flags.
@@ -97,7 +98,7 @@ type SetupResult struct {
 }
 
 // IsUnixSocket returns true if MongoDB URI is a Unix socket.
-func (s *SetupResult) IsUnixSocket(tb testutil.TB) bool {
+func (s *SetupResult) IsUnixSocket(tb testtb.TB) bool {
 	tb.Helper()
 
 	// we can't use a regular url.Parse because
@@ -113,7 +114,7 @@ func (s *SetupResult) IsUnixSocket(tb testutil.TB) bool {
 }
 
 // SetupWithOpts setups the test according to given options.
-func SetupWithOpts(tb testutil.TB, opts *SetupOpts) *SetupResult {
+func SetupWithOpts(tb testtb.TB, opts *SetupOpts) *SetupResult {
 	tb.Helper()
 
 	ctx, cancel := context.WithCancel(testutil.Ctx(tb))
@@ -172,7 +173,7 @@ func SetupWithOpts(tb testutil.TB, opts *SetupOpts) *SetupResult {
 }
 
 // Setup setups a single collection for all providers, if the are present.
-func Setup(tb testutil.TB, providers ...shareddata.Provider) (context.Context, *mongo.Collection) {
+func Setup(tb testtb.TB, providers ...shareddata.Provider) (context.Context, *mongo.Collection) {
 	tb.Helper()
 
 	s := SetupWithOpts(tb, &SetupOpts{
@@ -182,7 +183,7 @@ func Setup(tb testutil.TB, providers ...shareddata.Provider) (context.Context, *
 }
 
 // setupCollection setups a single collection for all providers, if they are present.
-func setupCollection(tb testutil.TB, ctx context.Context, client *mongo.Client, opts *SetupOpts) *mongo.Collection {
+func setupCollection(tb testtb.TB, ctx context.Context, client *mongo.Client, opts *SetupOpts) *mongo.Collection {
 	tb.Helper()
 
 	ctx, span := otel.Tracer("").Start(ctx, "setupCollection")
@@ -251,7 +252,7 @@ func setupCollection(tb testutil.TB, ctx context.Context, client *mongo.Client, 
 }
 
 // insertProviders inserts documents from specified Providers into collection. It returns true if any document was inserted.
-func insertProviders(tb testutil.TB, ctx context.Context, collection *mongo.Collection, providers ...shareddata.Provider) (inserted bool) {
+func insertProviders(tb testtb.TB, ctx context.Context, collection *mongo.Collection, providers ...shareddata.Provider) (inserted bool) {
 	tb.Helper()
 
 	collectionName := collection.Name()
@@ -280,7 +281,7 @@ func insertProviders(tb testutil.TB, ctx context.Context, collection *mongo.Coll
 // It returns true if any document was inserted.
 //
 // The function calculates the checksum of all inserted documents and compare them with provider's hash.
-func insertBenchmarkProvider(tb testutil.TB, ctx context.Context, collection *mongo.Collection, provider shareddata.BenchmarkProvider) (inserted bool) {
+func insertBenchmarkProvider(tb testtb.TB, ctx context.Context, collection *mongo.Collection, provider shareddata.BenchmarkProvider) (inserted bool) {
 	tb.Helper()
 
 	collectionName := collection.Name()

--- a/integration/setup/setup_compat.go
+++ b/integration/setup/setup_compat.go
@@ -28,6 +28,7 @@ import (
 	"github.com/FerretDB/FerretDB/integration/shareddata"
 	"github.com/FerretDB/FerretDB/internal/util/observability"
 	"github.com/FerretDB/FerretDB/internal/util/testutil"
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 )
 
 // SetupCompatOpts represents setup options for compatibility test.
@@ -54,7 +55,7 @@ type SetupCompatResult struct {
 }
 
 // SetupCompatWithOpts setups the compatibility test according to given options.
-func SetupCompatWithOpts(tb testutil.TB, opts *SetupCompatOpts) *SetupCompatResult {
+func SetupCompatWithOpts(tb testtb.TB, opts *SetupCompatOpts) *SetupCompatResult {
 	tb.Helper()
 
 	if *compatURLF == "" {
@@ -115,7 +116,7 @@ func SetupCompatWithOpts(tb testutil.TB, opts *SetupCompatOpts) *SetupCompatResu
 }
 
 // SetupCompat setups compatibility test.
-func SetupCompat(tb testutil.TB) (context.Context, []*mongo.Collection, []*mongo.Collection) {
+func SetupCompat(tb testtb.TB) (context.Context, []*mongo.Collection, []*mongo.Collection) {
 	tb.Helper()
 
 	s := SetupCompatWithOpts(tb, &SetupCompatOpts{
@@ -125,7 +126,7 @@ func SetupCompat(tb testutil.TB) (context.Context, []*mongo.Collection, []*mongo
 }
 
 // setupCompatCollections setups a single database with one collection per provider for compatibility tests.
-func setupCompatCollections(tb testutil.TB, ctx context.Context, client *mongo.Client, opts *SetupCompatOpts, backend string) []*mongo.Collection {
+func setupCompatCollections(tb testtb.TB, ctx context.Context, client *mongo.Client, opts *SetupCompatOpts, backend string) []*mongo.Collection {
 	tb.Helper()
 
 	ctx, span := otel.Tracer("").Start(ctx, "setupCompatCollections")

--- a/integration/setup/test_helpers.go
+++ b/integration/setup/test_helpers.go
@@ -18,12 +18,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/FerretDB/FerretDB/internal/util/testutil"
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 )
 
-// FailsForFerretDB return testutil.TB that expects test to fail for FerretDB and pass for MongoDB.
+// FailsForFerretDB return testtb.TB that expects test to fail for FerretDB and pass for MongoDB.
 //
 // This function should not be used lightly and always with an issue URL.
-func FailsForFerretDB(tb testutil.TB, reason string) testutil.TB {
+func FailsForFerretDB(tb testtb.TB, reason string) testtb.TB {
 	tb.Helper()
 
 	if *targetBackendF == "mongodb" {
@@ -36,7 +37,7 @@ func FailsForFerretDB(tb testutil.TB, reason string) testutil.TB {
 // SkipForMongoDB skips the current test for MongoDB.
 //
 // This function should not be used lightly.
-func SkipForMongoDB(tb testutil.TB, reason string) {
+func SkipForMongoDB(tb testtb.TB, reason string) {
 	tb.Helper()
 
 	if *targetBackendF == "mongodb" {

--- a/internal/bson/bson_test.go
+++ b/internal/bson/bson_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/FerretDB/FerretDB/internal/types/fjson"
-	"github.com/FerretDB/FerretDB/internal/util/testutil"
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 )
 
 type testCase struct {
@@ -38,7 +38,7 @@ type testCase struct {
 }
 
 // assertEqual is assert.Equal that also can compare NaNs and ±0.
-func assertEqual(tb testutil.TB, expected, actual any, msgAndArgs ...any) bool {
+func assertEqual(tb testtb.TB, expected, actual any, msgAndArgs ...any) bool {
 	tb.Helper()
 
 	switch expected := expected.(type) {

--- a/internal/handlers/pg/pgdb/pgdb_test.go
+++ b/internal/handlers/pg/pgdb/pgdb_test.go
@@ -25,10 +25,11 @@ import (
 
 	"github.com/FerretDB/FerretDB/internal/util/state"
 	"github.com/FerretDB/FerretDB/internal/util/testutil"
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 )
 
 // getPool creates a new connection's connection pool for testing.
-func getPool(ctx context.Context, tb testutil.TB) *Pool {
+func getPool(ctx context.Context, tb testtb.TB) *Pool {
 	tb.Helper()
 
 	logger := testutil.Logger(tb)
@@ -45,7 +46,7 @@ func getPool(ctx context.Context, tb testutil.TB) *Pool {
 
 // setupDatabase ensures that test-specific FerretDB database / PostgreSQL schema does not exist
 // before and after the test.
-func setupDatabase(ctx context.Context, tb testutil.TB, pool *Pool, db string) {
+func setupDatabase(ctx context.Context, tb testtb.TB, pool *Pool, db string) {
 	dropDatabase := func() {
 		pool.InTransaction(ctx, func(tx pgx.Tx) error {
 			return DropDatabase(ctx, tx, db)

--- a/internal/handlers/sjson/sjson_test.go
+++ b/internal/handlers/sjson/sjson_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/util/must"
-	"github.com/FerretDB/FerretDB/internal/util/testutil"
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 	"github.com/FerretDB/FerretDB/internal/wire"
 )
 
@@ -42,7 +42,7 @@ type testCase struct {
 }
 
 // assertEqual is assert.Equal that also can compare NaNs and ±0.
-func assertEqual(tb testutil.TB, expected, actual any, msgAndArgs ...any) bool {
+func assertEqual(tb testtb.TB, expected, actual any, msgAndArgs ...any) bool {
 	tb.Helper()
 
 	switch expected := expected.(type) {

--- a/internal/util/testutil/db.go
+++ b/internal/util/testutil/db.go
@@ -20,6 +20,8 @@ import (
 	"sync"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 )
 
 var (
@@ -33,7 +35,7 @@ var (
 // DatabaseName returns a stable FerretDB database name for that test.
 //
 // It should be called only once per test.
-func DatabaseName(tb TB) string {
+func DatabaseName(tb testtb.TB) string {
 	tb.Helper()
 
 	// database names may contain lowercase and uppercase characters
@@ -61,7 +63,7 @@ func DatabaseName(tb TB) string {
 // CollectionName returns a stable FerretDB collection name for that test.
 //
 // It should be called only once per test.
-func CollectionName(tb TB) string {
+func CollectionName(tb testtb.TB) string {
 	tb.Helper()
 
 	// do not use strings.ToLower because collection names can contain uppercase letters

--- a/internal/util/testutil/dump.go
+++ b/internal/util/testutil/dump.go
@@ -22,10 +22,11 @@ import (
 
 	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/types/fjson"
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 )
 
 // Dump returns string representation for debugging.
-func Dump[T types.Type](tb TB, o T) string {
+func Dump[T types.Type](tb testtb.TB, o T) string {
 	tb.Helper()
 
 	// We might switch to go-spew or something else later.
@@ -36,7 +37,7 @@ func Dump[T types.Type](tb TB, o T) string {
 }
 
 // DumpSlice returns string representation for debugging.
-func DumpSlice[T types.Type](tb TB, s []T) string {
+func DumpSlice[T types.Type](tb testtb.TB, s []T) string {
 	tb.Helper()
 
 	// We might switch to go-spew or something else later.
@@ -59,7 +60,7 @@ func DumpSlice[T types.Type](tb TB, s []T) string {
 }
 
 // IndentJSON returns an indented form of the JSON input.
-func IndentJSON(tb TB, b []byte) []byte {
+func IndentJSON(tb testtb.TB, b []byte) []byte {
 	tb.Helper()
 
 	dst := bytes.NewBuffer(make([]byte, 0, len(b)))

--- a/internal/util/testutil/equal.go
+++ b/internal/util/testutil/equal.go
@@ -26,10 +26,11 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/FerretDB/FerretDB/internal/types"
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 )
 
 // AssertEqual asserts that two BSON values are equal.
-func AssertEqual[T types.Type](tb TB, expected, actual T) bool {
+func AssertEqual[T types.Type](tb testtb.TB, expected, actual T) bool {
 	tb.Helper()
 
 	if equal(tb, expected, actual) {
@@ -42,7 +43,7 @@ func AssertEqual[T types.Type](tb TB, expected, actual T) bool {
 }
 
 // AssertEqualSlices asserts that two BSON slices are equal.
-func AssertEqualSlices[T types.Type](tb TB, expected, actual []T) bool {
+func AssertEqualSlices[T types.Type](tb testtb.TB, expected, actual []T) bool {
 	tb.Helper()
 
 	allEqual := len(expected) == len(actual)
@@ -66,7 +67,7 @@ func AssertEqualSlices[T types.Type](tb TB, expected, actual []T) bool {
 }
 
 // AssertNotEqual asserts that two BSON values are not equal.
-func AssertNotEqual[T types.Type](tb TB, expected, actual T) bool {
+func AssertNotEqual[T types.Type](tb testtb.TB, expected, actual T) bool {
 	tb.Helper()
 
 	if !equal(tb, expected, actual) {
@@ -80,7 +81,7 @@ func AssertNotEqual[T types.Type](tb TB, expected, actual T) bool {
 }
 
 // AssertNotEqualSlices asserts that two BSON slices are not equal.
-func AssertNotEqualSlices[T types.Type](tb TB, expected, actual []T) bool {
+func AssertNotEqualSlices[T types.Type](tb testtb.TB, expected, actual []T) bool {
 	tb.Helper()
 
 	allEqual := len(expected) == len(actual)
@@ -104,7 +105,7 @@ func AssertNotEqualSlices[T types.Type](tb TB, expected, actual []T) bool {
 }
 
 // diffValues returns a readable form of given values and the difference between them.
-func diffValues[T types.Type](tb TB, expected, actual T) (expectedS string, actualS string, diff string) {
+func diffValues[T types.Type](tb testtb.TB, expected, actual T) (expectedS string, actualS string, diff string) {
 	expectedS = Dump(tb, expected)
 	actualS = Dump(tb, actual)
 
@@ -122,7 +123,7 @@ func diffValues[T types.Type](tb TB, expected, actual T) (expectedS string, actu
 }
 
 // diffSlices returns a readable form of given slices and the difference between them.
-func diffSlices[T types.Type](tb TB, expected, actual []T) (expectedS string, actualS string, diff string) {
+func diffSlices[T types.Type](tb testtb.TB, expected, actual []T) (expectedS string, actualS string, diff string) {
 	expectedS = DumpSlice(tb, expected)
 	actualS = DumpSlice(tb, actual)
 
@@ -147,7 +148,7 @@ func diffSlices[T types.Type](tb TB, expected, actual []T) (expectedS string, ac
 // This function is for tests; it should not try to convert values to different types before comparing them.
 //
 // Compare and contrast with types.Compare function.
-func equal(tb TB, v1, v2 any) bool {
+func equal(tb testtb.TB, v1, v2 any) bool {
 	tb.Helper()
 
 	switch v1 := v1.(type) {
@@ -171,7 +172,7 @@ func equal(tb TB, v1, v2 any) bool {
 }
 
 // equalDocuments compares BSON documents.
-func equalDocuments(tb TB, v1, v2 *types.Document) bool {
+func equalDocuments(tb testtb.TB, v1, v2 *types.Document) bool {
 	tb.Helper()
 
 	require.NotNil(tb, v1)
@@ -198,7 +199,7 @@ func equalDocuments(tb TB, v1, v2 *types.Document) bool {
 }
 
 // equalArrays compares BSON arrays.
-func equalArrays(tb TB, v1, v2 *types.Array) bool {
+func equalArrays(tb testtb.TB, v1, v2 *types.Array) bool {
 	tb.Helper()
 
 	require.NotNil(tb, v1)
@@ -225,7 +226,7 @@ func equalArrays(tb TB, v1, v2 *types.Array) bool {
 }
 
 // equalScalars compares BSON scalar values.
-func equalScalars(tb TB, v1, v2 any) bool {
+func equalScalars(tb testtb.TB, v1, v2 any) bool {
 	tb.Helper()
 
 	require.NotNil(tb, v1)

--- a/internal/util/testutil/hexdump.go
+++ b/internal/util/testutil/hexdump.go
@@ -22,10 +22,11 @@ import (
 
 	"github.com/FerretDB/FerretDB/internal/util/hex"
 	"github.com/FerretDB/FerretDB/internal/util/must"
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 )
 
 // ParseDump parses string to bytes, in tests.
-func ParseDump(tb TB, s string) []byte {
+func ParseDump(tb testtb.TB, s string) []byte {
 	tb.Helper()
 
 	b, err := hex.ParseDump(s)
@@ -34,7 +35,7 @@ func ParseDump(tb TB, s string) []byte {
 }
 
 // ParseDumpFile parses file input to bytes, in tests.
-func ParseDumpFile(tb TB, path ...string) []byte {
+func ParseDumpFile(tb testtb.TB, path ...string) []byte {
 	tb.Helper()
 
 	b, err := os.ReadFile(filepath.Join(path...))

--- a/internal/util/testutil/path.go
+++ b/internal/util/testutil/path.go
@@ -23,10 +23,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/FerretDB/FerretDB/internal/types"
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 )
 
 // GetByPath returns a value by path - a sequence of indexes and keys.
-func GetByPath[T types.CompositeTypeInterface](tb TB, comp T, path types.Path) any {
+func GetByPath[T types.CompositeTypeInterface](tb testtb.TB, comp T, path types.Path) any {
 	tb.Helper()
 
 	res, err := comp.GetByPath(path)
@@ -37,7 +38,7 @@ func GetByPath[T types.CompositeTypeInterface](tb TB, comp T, path types.Path) a
 // SetByPath sets the value by path - a sequence of indexes and keys.
 //
 // The path must exist.
-func SetByPath[T types.CompositeTypeInterface](tb TB, comp T, value any, path types.Path) {
+func SetByPath[T types.CompositeTypeInterface](tb testtb.TB, comp T, value any, path types.Path) {
 	tb.Helper()
 
 	l := path.Len()
@@ -76,7 +77,7 @@ func SetByPath[T types.CompositeTypeInterface](tb TB, comp T, value any, path ty
 
 // CompareAndSetByPathNum asserts that two values with the same path in two objects (documents or arrays)
 // are within a given numerical delta, then updates the expected object with the actual value.
-func CompareAndSetByPathNum[T types.CompositeTypeInterface](tb TB, expected, actual T, delta float64, path types.Path) {
+func CompareAndSetByPathNum[T types.CompositeTypeInterface](tb testtb.TB, expected, actual T, delta float64, path types.Path) {
 	tb.Helper()
 
 	expectedV := GetByPath(tb, expected, path)
@@ -89,7 +90,9 @@ func CompareAndSetByPathNum[T types.CompositeTypeInterface](tb TB, expected, act
 
 // CompareAndSetByPathTime asserts that two values with the same path in two objects (documents or arrays)
 // are within a given time delta, then updates the expected object with the actual value.
-func CompareAndSetByPathTime[T types.CompositeTypeInterface](tb TB, expected, actual T, delta time.Duration, path types.Path) {
+//
+//nolint:lll // for readability
+func CompareAndSetByPathTime[T types.CompositeTypeInterface](tb testtb.TB, expected, actual T, delta time.Duration, path types.Path) {
 	tb.Helper()
 
 	expectedV := GetByPath(tb, expected, path)

--- a/internal/util/testutil/pg.go
+++ b/internal/util/testutil/pg.go
@@ -17,6 +17,8 @@ package testutil
 import (
 	"net/url"
 	"testing"
+
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 )
 
 // PostgreSQLURLOpts represents PostgreSQLURL options.
@@ -34,7 +36,7 @@ type PostgreSQLURLOpts struct {
 // PostgreSQLURL returns PostgreSQL URL for testing.
 //
 // TODO remove this function https://github.com/FerretDB/FerretDB/issues/1568
-func PostgreSQLURL(tb TB, opts *PostgreSQLURLOpts) string {
+func PostgreSQLURL(tb testtb.TB, opts *PostgreSQLURLOpts) string {
 	tb.Helper()
 
 	if testing.Short() {

--- a/internal/util/testutil/testtb/tb.go
+++ b/internal/util/testutil/testtb/tb.go
@@ -20,6 +20,7 @@ package testtb
 import "testing"
 
 // TB is a copy of testing.TB without a private method.
+// It allows us to implement it.
 //
 //nolint:interfacebloat // that's a copy of existing interface
 type TB interface {

--- a/internal/util/testutil/testtb/tb.go
+++ b/internal/util/testutil/testtb/tb.go
@@ -1,0 +1,52 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testtb provides a common testing interface.
+//
+// It is a separate package to avoid dependency cycles.
+package testtb
+
+import "testing"
+
+// TB is a copy of testing.TB without a private method.
+//
+//nolint:interfacebloat // that's a copy of existing interface
+type TB interface {
+	Cleanup(func())
+	Error(args ...any)
+	Errorf(format string, args ...any)
+	Fail()
+	FailNow()
+	Failed() bool
+	Fatal(args ...any)
+	Fatalf(format string, args ...any)
+	Helper()
+	Log(args ...any)
+	Logf(format string, args ...any)
+	Name() string
+	Setenv(key, value string)
+	Skip(args ...any)
+	SkipNow()
+	Skipf(format string, args ...any)
+	Skipped() bool
+	TempDir() string
+}
+
+// check interfaces
+var (
+	_ TB = (*testing.T)(nil)
+	_ TB = (*testing.B)(nil)
+	_ TB = (*testing.F)(nil)
+	_ TB = (testing.TB)(nil)
+)

--- a/internal/util/testutil/testutil.go
+++ b/internal/util/testutil/testutil.go
@@ -22,11 +22,13 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
+
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 )
 
 // Ctx returns test context.
 // It is canceled when test is finished or interrupted.
-func Ctx(tb TB) context.Context {
+func Ctx(tb testtb.TB) context.Context {
 	tb.Helper()
 
 	signalsCtx, signalsCancel := notifyTestsTermination(context.Background())
@@ -66,12 +68,12 @@ func Ctx(tb TB) context.Context {
 }
 
 // Logger returns zap test logger with valid configuration.
-func Logger(tb TB) *zap.Logger {
+func Logger(tb testtb.TB) *zap.Logger {
 	return LevelLogger(tb, zap.NewAtomicLevelAt(zap.DebugLevel))
 }
 
 // LevelLogger returns zap test logger with given level and valid configuration.
-func LevelLogger(tb TB, level zap.AtomicLevel) *zap.Logger {
+func LevelLogger(tb testtb.TB, level zap.AtomicLevel) *zap.Logger {
 	opts := []zaptest.LoggerOption{
 		zaptest.Level(level),
 		zaptest.WrapOptions(zap.AddCaller(), zap.Development()),

--- a/internal/util/testutil/xfail.go
+++ b/internal/util/testutil/xfail.go
@@ -16,40 +16,17 @@ package testutil
 
 import (
 	"sync/atomic"
-	"testing"
 
 	"github.com/stretchr/testify/require"
-)
 
-// TB is a copy of testing.TB without a private method.
-//
-//nolint:interfacebloat // that's a copy of existing interface
-type TB interface {
-	Cleanup(func())
-	Error(args ...any)
-	Errorf(format string, args ...any)
-	Fail()
-	FailNow()
-	Failed() bool
-	Fatal(args ...any)
-	Fatalf(format string, args ...any)
-	Helper()
-	Log(args ...any)
-	Logf(format string, args ...any)
-	Name() string
-	Setenv(key, value string)
-	Skip(args ...any)
-	SkipNow()
-	Skipf(format string, args ...any)
-	Skipped() bool
-	TempDir() string
-}
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
+)
 
 // XFail return a new TB instance that expects the test to fail.
 //
 // At the end of the test, if it was marked as failed, it will pass instead.
 // If it passes, it will be failed, so that XFail call can be removed.
-func XFail(t TB, reason string) TB {
+func XFail(t testtb.TB, reason string) testtb.TB {
 	t.Helper()
 
 	require.NotEmpty(t, reason, "reason must not be empty")
@@ -72,7 +49,7 @@ func XFail(t TB, reason string) TB {
 
 // xfail wraps TB with expected failure logic.
 type xfail struct {
-	t      TB
+	t      testtb.TB
 	failed atomic.Bool
 }
 
@@ -153,11 +130,3 @@ func (x *xfail) Skipped() bool { return x.t.Skipped() }
 
 // TempDir returns a temporary directory for the test to use.
 func (x *xfail) TempDir() string { return x.t.TempDir() }
-
-// check interfaces
-var (
-	_ TB = (*testing.T)(nil)
-	_ TB = (*testing.B)(nil)
-	_ TB = (*testing.F)(nil)
-	_ TB = (testing.TB)(nil)
-)

--- a/internal/util/testutil/xfail.go
+++ b/internal/util/testutil/xfail.go
@@ -22,7 +22,7 @@ import (
 	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 )
 
-// XFail return a new TB instance that expects the test to fail.
+// XFail return a new testtb.TB instance that expects the test to fail.
 //
 // At the end of the test, if it was marked as failed, it will pass instead.
 // If it passes, it will be failed, so that XFail call can be removed.
@@ -47,7 +47,7 @@ func XFail(t testtb.TB, reason string) testtb.TB {
 	return x
 }
 
-// xfail wraps TB with expected failure logic.
+// xfail wraps testtb.TB with expected failure logic.
 type xfail struct {
 	t      testtb.TB
 	failed atomic.Bool

--- a/internal/wire/wire_test.go
+++ b/internal/wire/wire_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/FerretDB/FerretDB/internal/util/testutil"
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 )
 
 // lastErr returns the last error in error chain.
@@ -53,7 +53,7 @@ type testCase struct {
 }
 
 // setExpectedB checks and sets expectedB fields from headerB and bodyB.
-func (tc *testCase) setExpectedB(tb testutil.TB) {
+func (tc *testCase) setExpectedB(tb testtb.TB) {
 	tb.Helper()
 
 	if (len(tc.headerB) == 0) != (len(tc.bodyB) == 0) {


### PR DESCRIPTION
# Description

That removes the import cycle in the next PR.

## Readiness checklist

- [x] I added/updated unit tests.
- [x] I added/updated integration/compatibility tests.
- [x] I added/updated comments and checked rendering.
- [x] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
