### PR TITLE
Ignore `count.fields` argument

### DIFF
--- a/internal/handlers/common/count.go
+++ b/internal/handlers/common/count.go
@@ -32,6 +32,8 @@ type CountParams struct {
 
 	Collation *types.Document `ferretdb:"collation,unimplemented"`
 
+	Fields any `ferretdb:"fields,ignored"` // legacy MongoDB shell adds it, but it is never actually used
+
 	Hint        any             `ferretdb:"hint,ignored"`
 	ReadConcern *types.Document `ferretdb:"readConcern,ignored"`
 	Comment     string          `ferretdb:"comment,ignored"`


### PR DESCRIPTION
# Description

Needed for NoSQLBooster.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [x] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [x] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
