### PR TITLE
Do not import `commonerrors` in tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,6 +51,13 @@ linters-settings:
           - "!**/cmd/envtool/*.go"
         deny:
           - pkg: github.com/FerretDB/FerretDB/internal/handlers/pg/pgdb
+      commonerrors:
+        files:
+          - $all
+          - "!**/internal/clientconn/*.go"
+          - "!**/internal/handlers/**/*.go"
+        deny:
+          - pkg: github.com/FerretDB/FerretDB/internal/handlers/commonerrors
   exhaustive:
     default-signifies-exhaustive: false
   gci:

--- a/integration/.golangci-new.yml
+++ b/integration/.golangci-new.yml
@@ -49,6 +49,7 @@ linters:
   disable:
     # checked by the other configuration
     - asciicheck
+    - depguard
     - exhaustive
     - gci
     - goconst
@@ -74,7 +75,6 @@ linters:
     - cyclop
     - deadcode
     - decorder
-    - depguard
     - dogsled
     - dupl
     - durationcheck

--- a/integration/.golangci.yml
+++ b/integration/.golangci.yml
@@ -6,6 +6,13 @@ run:
 
 linters-settings:
   # asciicheck
+  depguard:
+    rules:
+      commonerrors:
+        files:
+          - $all
+        deny:
+          - pkg: github.com/FerretDB/FerretDB/internal/handlers/commonerrors
   exhaustive:
     default-signifies-exhaustive: false
   gci:
@@ -96,6 +103,7 @@ linters:
   disable-all: true
   enable:
     - asciicheck
+    - depguard
     - exhaustive
     - gci
     - goconst

--- a/integration/delete_test.go
+++ b/integration/delete_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/FerretDB/FerretDB/integration/setup"
 	"github.com/FerretDB/FerretDB/integration/shareddata"
-	"github.com/FerretDB/FerretDB/internal/handlers/commonerrors"
 )
 
 // TestDeleteSimple checks simple cases of doc deletion.
@@ -69,16 +68,16 @@ func TestDelete(t *testing.T) {
 		"QueryNotSet": {
 			deletes: bson.A{bson.D{}},
 			err: &mongo.CommandError{
-				Code:    int32(commonerrors.ErrMissingField),
-				Name:    commonerrors.ErrMissingField.String(),
+				Code:    40414,
+				Name:    "Location40414",
 				Message: "BSON field 'delete.deletes.q' is missing but a required field",
 			},
 		},
 		"NotSet": {
 			deletes: bson.A{bson.D{{"q", bson.D{{"v", "foo"}}}}},
 			err: &mongo.CommandError{
-				Code:    int32(commonerrors.ErrMissingField),
-				Name:    commonerrors.ErrMissingField.String(),
+				Code:    40414,
+				Name:    "Location40414",
 				Message: "BSON field 'delete.deletes.limit' is missing but a required field",
 			},
 		},
@@ -92,8 +91,8 @@ func TestDelete(t *testing.T) {
 		"InvalidFloat": {
 			deletes: bson.A{bson.D{{"q", bson.D{{"v", "foo"}}}, {"limit", 42.13}}},
 			err: &mongo.CommandError{
-				Code:    int32(commonerrors.ErrFailedToParse),
-				Name:    commonerrors.ErrFailedToParse.String(),
+				Code:    9,
+				Name:    "FailedToParse",
 				Message: "The limit field in delete objects must be 0 or 1. Got 42.13",
 			},
 			altMessage: "The 'delete.deletes.limit' field must be 0 or 1. Got 42.13",
@@ -101,8 +100,8 @@ func TestDelete(t *testing.T) {
 		"InvalidInt": {
 			deletes: bson.A{bson.D{{"q", bson.D{{"v", "foo"}}}, {"limit", 100}}},
 			err: &mongo.CommandError{
-				Code:    int32(commonerrors.ErrFailedToParse),
-				Name:    commonerrors.ErrFailedToParse.String(),
+				Code:    9,
+				Name:    "FailedToParse",
 				Message: "The limit field in delete objects must be 0 or 1. Got 100",
 			},
 			altMessage: "The 'delete.deletes.limit' field must be 0 or 1. Got 100",


### PR DESCRIPTION
# Description

We use values in all other tests.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [x] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [x] I made spot refactorings.
- [ ] I updated user documentation.
- [x] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
