### PR TITLE
Add wire.LoadDataDocuments function

### DIFF
--- a/internal/wire/record.go
+++ b/internal/wire/record.go
@@ -22,7 +22,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
+	"github.com/FerretDB/FerretDB/internal/util/must"
 )
 
 // Record represents a single recorded wire protocol message, loaded from a .bin file.
@@ -36,26 +38,61 @@ type Record struct {
 	BodyB   []byte
 }
 
+// LoadDataDocuments is like LoadRecords, but instead of loading raw records,
+// it extracts valid data documents.
+func LoadDataDocuments(dir string, limit int) ([]*types.Document, error) {
+	files, err := findBinFiles(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	var docs []*types.Document
+
+	// We can't tell whether a record have any data documents or
+	// not before parsing the bin file.
+	// Parsing all files and then using some shuffling is slow,
+	// so we're using a random window to collect the results.
+
+	i := 0
+
+	if limit == 0 {
+		limit = len(files)
+	} else {
+		i = rand.Intn(len(files))
+	}
+	for j := 0; j < len(files); j, i = j+1, i+1 {
+		if i > len(files) {
+			i = 0 // wrap around
+		}
+		f := files[i]
+
+		recs, err := loadRecordFile(f)
+		if err != nil {
+			return nil, lazyerrors.Errorf("%s: %w", f, err)
+		}
+
+		for i, r := range recs {
+			rDocs, err := extractRecordDataDocuments(r)
+			if err != nil {
+				return nil, lazyerrors.Errorf("%s record[%d]: %w", f, i, err)
+			}
+
+			docs = append(docs, rDocs...)
+			if len(docs) >= limit {
+				docs = docs[:limit]
+				return docs, nil
+			}
+		}
+	}
+
+	return docs, nil
+}
+
 // LoadRecords finds all .bin files recursively, selects up to the limit at random (or all if limit <= 0), and parses them.
 func LoadRecords(dir string, limit int) ([]Record, error) {
-	var files []string
-	err := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, err error) error {
-		if err != nil {
-			return lazyerrors.Error(err)
-		}
-
-		if filepath.Ext(entry.Name()) == ".bin" {
-			files = append(files, path)
-		}
-
-		return nil
-	})
-
-	switch {
-	case errors.Is(err, fs.ErrNotExist):
-		return nil, nil
-	case err != nil:
-		return nil, lazyerrors.Error(err)
+	files, err := findBinFiles(dir)
+	if err != nil {
+		return nil, err
 	}
 
 	if limit > 0 && len(files) > limit {
@@ -78,6 +115,90 @@ func LoadRecords(dir string, limit int) ([]Record, error) {
 	}
 
 	return res, nil
+}
+
+// findBinFiles collects the filenames inside dir that have ".bin" suffix.
+func findBinFiles(dir string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return lazyerrors.Error(err)
+		}
+
+		if filepath.Ext(entry.Name()) == ".bin" {
+			files = append(files, path)
+		}
+
+		return nil
+	})
+
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return nil, nil
+	case err != nil:
+		return nil, lazyerrors.Error(err)
+	default:
+		return files, nil
+	}
+}
+
+// extractRecordDataDocuments collects all data documents from a given record.
+func extractRecordDataDocuments(r Record) ([]*types.Document, error) {
+	var docs []*types.Document
+
+	switch b := r.Body.(type) {
+	case *OpMsg:
+		doc, err := b.Document()
+		if err != nil {
+			return nil, err
+		}
+		docs, err = appendDataDocuments(docs, doc)
+		if err != nil {
+			return nil, lazyerrors.Errorf("OpMsg: %w", err)
+		}
+
+	case *OpReply:
+		var err error
+		for i, d := range b.Documents {
+			docs, err = appendDataDocuments(docs, d)
+			if err != nil {
+				return nil, lazyerrors.Errorf("OpReply.documents[%d]: %w", i, err)
+			}
+		}
+		docs = append(docs, b.Documents...)
+	}
+
+	return docs, nil
+}
+
+// appendDataDocuments finds all valid data documents in v and pushes them to dst.
+func appendDataDocuments(dst []*types.Document, v any) ([]*types.Document, error) {
+	var err error
+
+	switch v := v.(type) {
+	case *types.Document:
+		if v.ValidateData() == nil {
+			dst = append(dst, v)
+			return dst, nil
+		}
+
+		if v.Has("insert") && v.Has("documents") {
+			dst, err = appendDataDocuments(dst, must.NotFail(v.Get("documents")))
+			if err != nil {
+				return nil, lazyerrors.Errorf("insert.documents: %w", err)
+			}
+		}
+
+	case *types.Array:
+		for i := 0; i < v.Len(); i++ {
+			dst, err = appendDataDocuments(dst, must.NotFail(v.Get(i)))
+			if err != nil {
+				return nil, lazyerrors.Errorf("[%d]: %w", i, err)
+			}
+		}
+	}
+
+	return dst, nil
 }
 
 // loadRecordFile parses a single .bin file.


### PR DESCRIPTION
# Description

Unlike wire.LoadRecords, it tries to find valid data documents.

This new function is used in sjson package fuzz testing.

Closes #3067

- [x] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [x] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
