### PR TITLE
Simplify `checkdocs` linter

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -587,10 +587,10 @@ tasks:
     desc: "Format and lint documentation"
     run: once
     cmds:
-      - bin/checkdocs
       - docker compose run --rm textlint --fix --config build/.textlintrc "**/*.md" ".github/**/*.md"
       - docker compose run --rm prettier --write --parser markdown --no-semi --single-quote --trailing-comma none "**/*.md"
       - docker compose run --rm markdownlint "build/.markdownlint.yml" "**/*.md"
+      - bin/checkdocs
 
   docs-dev:
     desc: "Start documentation development server"

--- a/tools/checkdocs/checkdocs.go
+++ b/tools/checkdocs/checkdocs.go
@@ -12,201 +12,192 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package contains linter for blog posts.
+// Package main contains linter for blog posts.
 package main
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
-	"io"
-	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
-	"unicode"
 )
 
-// fileSlug describes the file name and expected slug of blog posts.
-type fileSlug struct {
-	slug     string
-	fileName string
-}
-
 func main() {
-	dir := filepath.Join("website", "blog")
-
-	fs, err := os.ReadDir(dir)
+	files, err := filepath.Glob(filepath.Join("website", "blog", "*.md"))
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	slugs := getBlogSlugs(fs)
+	checkFiles(files, log.Printf, log.Fatalf)
+}
 
-	pass := true
-
-	for _, slug := range slugs {
-		// wrap in func to avoid possible resource leak of calling defer in the loop.
-		func() {
-			fo, err := os.Open(filepath.Join(dir, slug.fileName))
-			if err != nil {
-				log.Fatalf("Couldn't open file: %s", slug.fileName)
-			}
-
-			defer fo.Close()
-
-			_, err = fo.Seek(0, 0)
-			if err != nil {
-				log.Fatalf("Error resetting file pointer: %v", err)
-			}
-			if err = verifySlug(slug, fo); err != nil {
-				log.Print(err)
-				pass = false
-			}
-
-			_, err = fo.Seek(0, 0)
-			if err != nil {
-				log.Fatalf("Error resetting file pointer: %v", err)
-			}
-
-			err = verifyDateNotPresent(fo)
-			if err != nil {
-				log.Print(err)
-				pass = false
-			}
-
-			_, err = fo.Seek(0, 0)
-			if err != nil {
-				log.Fatalf("Error resetting file pointer: %v", err)
-			}
-
-			err = verifyTags(fo)
-			if err != nil {
-				log.Print(err)
-				pass = false
-			}
-		}()
+func checkFiles(files []string, logf, fatalf func(string, ...any)) {
+	if len(files) == 0 {
+		fatalf("No blog posts found")
 	}
 
-	if !pass {
-		log.Fatal("One or more blog posts are not correctly formatted")
+	var failed bool
+
+	for _, file := range files {
+		b, err := os.ReadFile(file)
+		if err != nil {
+			fatalf("Couldn't read file %s: %s", file, err)
+		}
+
+		if b, err = extractFrontMatter(b); err != nil {
+			fatalf("Couldn't extract front matter from %s: %s", file, err)
+		}
+
+		if err = verifySlug(filepath.Base(file), b); err != nil {
+			logf("%q: %s", file, err)
+			failed = true
+		}
+
+		if err = verifyDateNotPresent(b); err != nil {
+			logf("%q: %s", file, err)
+			failed = true
+		}
+
+		if err = verifyTags(b); err != nil {
+			logf("%q: %s", file, err)
+			failed = true
+		}
+	}
+
+	if failed {
+		fatalf("One or more blog posts are not correctly formatted")
 	}
 }
 
-// getBlogSlugs returns slice containing fileSlug for each DirEntry.
-func getBlogSlugs(fs []fs.DirEntry) []fileSlug {
-	// start with 4 digits then a 0[1-9] or 1 [0 1 or 2]
-	// then - and either 0 [1-9] or [1 or 2][0-9] or 3[0 or 1] - slug(any) and end with .md.
-	fnRegex := regexp.MustCompile(`^\d{4}\-(?:0[1-9]|1[012])\-(?:0[1-9]|[12][0-9]|3[01])-(.*).md$`)
-	mdRegex := regexp.MustCompile(`.md$`)
+// extractFrontMatter returns the front matter of a blog post.
+func extractFrontMatter(fm []byte) ([]byte, error) {
+	var in bool
+	var res []byte
 
-	var fileSlugs []fileSlug
+	s := bufio.NewScanner(bytes.NewReader(fm))
+	for s.Scan() {
+		if !in {
+			if s.Text() != "---" {
+				return nil, fmt.Errorf("expected front matter start on the first line, got %q", s.Text())
+			}
 
-	for _, f := range fs {
-		fn := f.Name()
-
-		if !mdRegex.MatchString(fn) {
+			in = true
 			continue
 		}
 
-		sm := fnRegex.FindStringSubmatch(fn)
-
-		if len(sm) > 2 {
-			log.Fatalf("File %s is not correctly formatted (yyyy-mm-dd-'slug'.md)", fn)
-			continue
+		if s.Text() == "---" {
+			return res, nil
 		}
 
-		fileSlugs = append(fileSlugs, fileSlug{sm[len(sm)-1], fn})
+		res = append(res, s.Bytes()...)
+		res = append(res, '\n')
 	}
 
-	return fileSlugs
+	return nil, fmt.Errorf("front matter end not found")
 }
 
-// verifySlug returns error if file doesn't contain expected slug.
-func verifySlug(fS fileSlug, f io.Reader) error {
-	r := regexp.MustCompile("^slug: (.*)")
+// verifySlug checks that file name and slug match each other.
+func verifySlug(fn string, fm []byte) error {
+	fnRe := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}-(.*)\.md$`)
 
-	pass := false
+	sm := fnRe.FindStringSubmatch(fn)
+	if len(sm) != 2 {
+		return fmt.Errorf("file name doesn't match the expected pattern")
+	}
 
-	scanner := bufio.NewScanner(f)
+	fnSlug := sm[1]
 
-	for scanner.Scan() {
-		sm := r.FindStringSubmatch(scanner.Text())
-		if len(sm) > 1 && sm[len(sm)-1] == fS.slug {
-			pass = true
+	re := regexp.MustCompile("^slug: (.*)")
+
+	var slug string
+
+	s := bufio.NewScanner(bytes.NewReader(fm))
+	for s.Scan() {
+		if sm = re.FindStringSubmatch(s.Text()); len(sm) > 1 {
+			slug = sm[1]
+			break
 		}
 	}
 
-	if !pass {
-		return fmt.Errorf("slug is not correctly formated in file %s", fS.fileName)
+	if err := s.Err(); err != nil {
+		return err
+	}
+
+	if slug == "" {
+		return fmt.Errorf("slug field should be present in the front matter")
+	}
+
+	if slug != fnSlug {
+		return fmt.Errorf("slug %q doesn't match the file name", slug)
 	}
 
 	return nil
 }
 
-func verifyDateNotPresent(f io.Reader) error {
-	r := regexp.MustCompile("^date:")
+// verifyDateNotPresent checks date field is not present.
+func verifyDateNotPresent(fm []byte) error {
+	re := regexp.MustCompile("^date:")
 
-	pass := true
+	var found bool
 
-	scanner := bufio.NewScanner(f)
-
-	for scanner.Scan() {
-		if r.MatchString(scanner.Text()) {
-			pass = false
+	s := bufio.NewScanner(bytes.NewReader(fm))
+	for s.Scan() {
+		if re.MatchString(s.Text()) {
+			found = true
 			break
 		}
 	}
 
-	if !pass {
+	if err := s.Err(); err != nil {
+		return err
+	}
+
+	if found {
 		return fmt.Errorf("date field should not be present in the front matter")
 	}
 
 	return nil
 }
 
-func verifyTags(f io.Reader) error {
-	r := regexp.MustCompile(`^tags:\s*\[([^\]]+)\]`)
+// verifyTags checks that tags are in the allowed list.
+func verifyTags(fm []byte) error {
+	// tags may span multiple lines after formatting
+	re := regexp.MustCompile(`(?ms)^tags:\s+\[(.+)\]`)
 
-	scanner := bufio.NewScanner(f)
-	var tags []string
-
-	for scanner.Scan() {
-		sm := r.FindStringSubmatch(scanner.Text())
-		if len(sm) > 1 {
-			tags = strings.FieldsFunc(sm[1], func(r rune) bool { return r == ',' || unicode.IsSpace(r) })
-			break
-		}
+	sm := re.FindStringSubmatch(string(fm))
+	if len(sm) != 2 {
+		return fmt.Errorf("tags field should be present in the front matter")
 	}
 
-	expectedTags := map[string]bool{
-		"cloud":         true,
-		"community":     true,
-		"compatible":    true,
-		"applications":  true,
-		"demo":          true,
-		"document":      true,
-		"databases":     true,
-		"events":        true,
-		"hacktoberfest": true,
-		"javascript":    true,
-		"frameworks":    true,
-		"mongodb":       true,
-		"gui":           true,
-		"open":          true,
-		"source":        true,
-		"postgresql":    true,
-		"tools":         true,
-		"product":       true,
-		"release":       true,
-		"sspl":          true,
-		"tutorial":      true,
+	// keep in sync with writing-guide.md
+	expectedTags := map[string]struct{}{
+		"cloud":                   {},
+		"community":               {},
+		"compatible applications": {},
+		"demo":                    {},
+		"document databases":      {},
+		"events":                  {},
+		"hacktoberfest":           {},
+		"javascript frameworks":   {},
+		"mongodb compatible":      {},
+		"mongodb gui":             {},
+		"open source":             {},
+		"postgresql tools":        {},
+		"product":                 {},
+		"release":                 {},
+		"sspl":                    {},
+		"tutorial":                {},
 	}
 
-	for _, tag := range tags {
+	for _, tag := range strings.Split(sm[1], ",") {
+		tag = strings.TrimSpace(tag)
+
 		if _, ok := expectedTags[tag]; !ok {
-			return fmt.Errorf("tag '%s' is not in the allowed list", tag)
+			return fmt.Errorf("tag %q is not in the allowed list", tag)
 		}
 	}
 

--- a/tools/checkdocs/checkdocs.go
+++ b/tools/checkdocs/checkdocs.go
@@ -35,6 +35,8 @@ func main() {
 	checkFiles(files, log.Printf, log.Fatalf)
 }
 
+// checkFiles verifies that blog posts are correctly formatted,
+// using logf for progress reporting and fatalf for errors.
 func checkFiles(files []string, logf, fatalf func(string, ...any)) {
 	if len(files) == 0 {
 		fatalf("No blog posts found")

--- a/tools/checkdocs/checkdocs_test.go
+++ b/tools/checkdocs/checkdocs_test.go
@@ -15,178 +15,50 @@
 package main
 
 import (
+	"bytes"
+	"path/filepath"
 	"testing"
-	"testing/fstest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetBlogSlugs(t *testing.T) {
-	m := fstest.MapFS{
-		"2022-05-16-using-cla-assistant-with-ferretdb.md": {
-			Data: []byte(`---
-slug: using-cla-assistant-with-ferretdb
-title: "Using CLA Assistant with FerretDB"
-author: Alexey Palazhchenko
-description: Like many other open-source projects FerretDB 
-image: /img/blog/cla3.jpg
-date: 2022-05-16
----
-Finally, we need a web server that would handle HTTPS for us.
-For that, we will use
-Caddy will listen on both HTTP and
-`),
-		},
-	}
-
-	dirs, err := m.ReadDir(".")
+func TestReal(t *testing.T) {
+	files, err := filepath.Glob(filepath.Join("..", "..", "website", "blog", "*.md"))
 	require.NoError(t, err)
 
-	slugs := getBlogSlugs(dirs)
-	tSlug := fileSlug{fileName: "2022-05-16-using-cla-assistant-with-ferretdb.md", slug: "using-cla-assistant-with-ferretdb"}
-	assert.Equal(t, slugs[0], tSlug, "should be equal")
+	checkFiles(files, t.Logf, t.Fatalf)
 }
 
-func TestVerifySlugs(t *testing.T) {
-	m := fstest.MapFS{
-		"2022-05-16-using-cla-assistant-with-ferretdb.md": {
-			Data: []byte(`---
-slug: using-cla-assistant-with-ferretdb
-title: "Using CLA Assistant with FerretDB"
-author: Alexey Palazhchenko
-description: Like many other open-source projects
-image: /img/blog/cla3.jpg
-date: 2022-05-16
----
-Finally, we need a web server that would handle HTTPS for us.
-For that, we will use [Caddy](https://caddyserver.com):
-Caddy will listen on both HTTP and HTTPS ports, 
-`),
-		},
-	}
+var fm = bytes.TrimSpace([]byte(`
+slug: using-ferretdb-with-studio-3t
+date: 2023-04-18
+title: Using FerretDB 1.0 with Studio 3T
+authors: [alex]
+description: >
+	Discover how to use FerretDB 1.0 with Studio 3T, and explore ways to leverage FerretDB for MongoDB GUI applications.
+image: /img/blog/ferretdb-studio3t.png
+tags:
+	[
+		tutorial,
+		mongodb compatible,
+		mongodb gui,
+		compatible applications,
+		documents databases
+	]
+	`))
 
-	dirs, err := m.ReadDir(".")
-	require.NoError(t, err)
-
-	slugs := getBlogSlugs(dirs)
-
-	f, err := m.Open("2022-05-16-using-cla-assistant-with-ferretdb.md")
-	require.NoError(t, err)
-
-	err = verifySlug(slugs[0], f)
-	require.NoError(t, err)
+func TestVerifySlug(t *testing.T) {
+	err := verifySlug("2023-04-18-using-ferretdb-with-studio.md", fm)
+	assert.EqualError(t, err, `slug "using-ferretdb-with-studio-3t" doesn't match the file name`)
 }
 
 func TestVerifyDateNotPresent(t *testing.T) {
-	m := fstest.MapFS{
-		"2022-05-16-using-cla-assistant-with-ferretdb.md": {
-			Data: []byte(`---
-slug: using-cla-assistant-with-ferretdb
-title: "Using CLA Assistant with FerretDB"
-author: Alexey Palazhchenko
-description: Like many other open-source projects
-image: /img/blog/cla3.jpg
----
-Finally, we need a web server that would handle HTTPS for us.
-For that, we will use [Caddy](https://caddyserver.com):
-Caddy will listen on both HTTP and HTTPS ports, 
-`),
-		},
-	}
-
-	_, err := m.ReadDir(".")
-	require.NoError(t, err)
-
-	f, err := m.Open("2022-05-16-using-cla-assistant-with-ferretdb.md")
-	require.NoError(t, err)
-
-	err = verifyDateNotPresent(f)
-	require.NoError(t, err)
-}
-
-func TestVerifyDateNotPresentForError(t *testing.T) {
-	m := fstest.MapFS{
-		"2022-05-16-using-cla-assistant-with-ferretdb.md": {
-			Data: []byte(`---
-slug: using-cla-assistant-with-ferretdb
-title: "Using CLA Assistant with FerretDB"
-author: Alexey Palazhchenko
-description: Like many other open-source projects
-image: /img/blog/cla3.jpg
-date: 2022-05-16
----
-Finally, we need a web server that would handle HTTPS for us.
-For that, we will use [Caddy](https://caddyserver.com):
-Caddy will listen on both HTTP and HTTPS ports, 
-`),
-		},
-	}
-
-	_, err := m.ReadDir(".")
-	require.NoError(t, err)
-
-	f, err := m.Open("2022-05-16-using-cla-assistant-with-ferretdb.md")
-	require.NoError(t, err)
-
-	err = verifyDateNotPresent(f)
-	assert.Equal(t, err.Error(), "date field should not be present in the front matter")
+	err := verifyDateNotPresent(fm)
+	assert.EqualError(t, err, `date field should not be present in the front matter`)
 }
 
 func TestVerifyTags(t *testing.T) {
-	m := fstest.MapFS{
-		"2022-05-16-using-cla-assistant-with-ferretdb.md": {
-			Data: []byte(`---
-slug: using-cla-assistant-with-ferretdb
-title: "Using CLA Assistant with FerretDB"
-author: Alexey Palazhchenko
-description: Like many other open-source projects
-image: /img/blog/cla3.jpg
-date: 2022-05-16
-tags: [events, document databases, hacktoberfest]
----
-Finally, we need a web server that would handle HTTPS for us.
-For that, we will use [Caddy](https://caddyserver.com):
-Caddy will listen on both HTTP and HTTPS ports, 
-`),
-		},
-	}
-
-	_, err := m.ReadDir(".")
-	require.NoError(t, err)
-
-	f, err := m.Open("2022-05-16-using-cla-assistant-with-ferretdb.md")
-	require.NoError(t, err)
-
-	err = verifyTags(f)
-	require.NoError(t, err)
-}
-
-func TestVerifyTagsForError(t *testing.T) {
-	m := fstest.MapFS{
-		"2022-05-16-using-cla-assistant-with-ferretdb.md": {
-			Data: []byte(`---
-slug: using-cla-assistant-with-ferretdb
-title: "Using CLA Assistant with FerretDB"
-author: Alexey Palazhchenko
-description: Like many other open-source projects
-image: /img/blog/cla3.jpg
-date: 2022-05-16
-tags: [events, documentss databases, hacktoberfest]
----
-Finally, we need a web server that would handle HTTPS for us.
-For that, we will use [Caddy](https://caddyserver.com):
-Caddy will listen on both HTTP and HTTPS ports, 
-`),
-		},
-	}
-
-	_, err := m.ReadDir(".")
-	require.NoError(t, err)
-
-	f, err := m.Open("2022-05-16-using-cla-assistant-with-ferretdb.md")
-	require.NoError(t, err)
-
-	err = verifyTags(f)
-	assert.Equal(t, err.Error(), "tag 'documentss' is not in the allowed list")
+	err := verifyTags(fm)
+	assert.EqualError(t, err, `tag "documents databases" is not in the allowed list`)
 }

--- a/website/blog/2022-10-03-introducing-ferretdb-beacon-telemetry-service.md
+++ b/website/blog/2022-10-03-introducing-ferretdb-beacon-telemetry-service.md
@@ -4,7 +4,7 @@ title: 'Introducing FerretDB Beacon: Help Us Increase Compatibility'
 author: Peter Farkas
 description: Introducing FerretDB Beacon – a service to help us effectively identify compatibility issues and prioritize solutions based on user interaction with FerretDB.
 image: /img/blog/allen-cai-Y4RxCIaYaSk-unsplash-1024x683.jpg
-tags: []
+tags: [product]
 ---
 
 Introducing FerretDB Beacon – a service to help us effectively identify compatibility issues and prioritize solutions based on user interaction with FerretDB.

--- a/website/blog/2022-10-03-introducing-ferretdb-beacon-telemetry-service.md
+++ b/website/blog/2022-10-03-introducing-ferretdb-beacon-telemetry-service.md
@@ -4,6 +4,7 @@ title: 'Introducing FerretDB Beacon: Help Us Increase Compatibility'
 author: Peter Farkas
 description: Introducing FerretDB Beacon – a service to help us effectively identify compatibility issues and prioritize solutions based on user interaction with FerretDB.
 image: /img/blog/allen-cai-Y4RxCIaYaSk-unsplash-1024x683.jpg
+tags: []
 ---
 
 Introducing FerretDB Beacon – a service to help us effectively identify compatibility issues and prioritize solutions based on user interaction with FerretDB.

--- a/website/blog/_guide/content-process.md
+++ b/website/blog/_guide/content-process.md
@@ -30,6 +30,48 @@ The file name should be in the format `YYYY-MM-DD-title-in-kebab-case-with-dashe
 where `YYYY-MM-DD` is the date of the post, and `title-in-kebab-case-with-dashes` is a descriptive title of the post.
 Please do not underscores or spaces in the file names, directory names, or slugs because URL paths typically use dashes.
 
+### Tags
+
+Tags are an important part of every blog post, and they appear at the top of the front matter.
+They make it easy for readers to search and identify related blog posts based on their categories or subject matter.
+You can view all [currently listed tags here](https://blog.ferretdb.io/tags/).
+
+Please note that all tags must be in small-case, such that `FerretDB` should be written as `ferretdb`.
+
+Hyphens should be disregarded when writing tags, e.g. `mongodb-compatible database` should be written as `mongodb compatible database`.
+
+A blog post can have as many tags as possible, as long as it is relevant to the post.
+Please only include the following tags (and keep them in sync with the `checkdocs` linter):
+
+- cloud
+- community
+- compatible applications
+- demo
+- document databases
+- events
+- hacktoberfest
+- javascript frameworks
+- mongodb compatible
+- mongodb gui
+- open source
+- postgresql tools
+- product
+- release
+- sspl
+- tutorial
+
+This is not an exhaustive list, and the direction of our blog posts can surely expand.
+If a blog post calls for a new tag or you would like to suggest more tags, please ensure to add it to this list.
+This helps to maintain consistency across all blog posts.
+
+### Keywords (optional)
+
+Keywords in the front matter are displayed as meta keywords tag in HTML.
+Meta keywords tag are not so important for SEO anymore, but they can help with focusing the content on specific keywords that should be used (appear at least once) in the blog content, meta description, title, or alt images.
+
+The use of meta keywords is not mandatory, but if you want to add them, please ensure that they are relevant to the blog post.
+All keywords must be in small-case.
+
 ### Writing Guide
 
 We have a writing guide that provides guidelines for creating clear, concise, and engaging content.
@@ -37,10 +79,10 @@ Please see our [writing guide](writing-guide.md) for help formatting your blog p
 
 ## Setting Front Matter and Publishing Options
 
-Front matter is the metadata that appears at the top of the markdown file and provides information about the post, such as the title, author, and date.
+Front matter is the metadata that appears at the top of the markdown file and provides information about the post, such as the title and author.
 
 In the front matter, ensure to set the `draft: true` in the front matter until it's ready to publish.
-Make sure to include all necessary information in the front matter, such as the title, author, and date.
+Make sure to include all necessary information in the front matter, such as the title and author.
 
 ## Reviewing and Editing Content
 
@@ -57,7 +99,7 @@ Once the content is ready for review, please open a PR and assign it to @Ferretd
 ## Final Approval and Publishing
 
 The final approval for publishing content is given once it has passed through all reviews and approved by the team.
-To publish the content, change the date in the front matter to the proposed published date, and then remove `draft: true` from the front matter.
+To publish the content, change the date in file name to the proposed published date, and then remove `draft: true` from the front matter.
 
 ## Post Publishing
 

--- a/website/docs/contributing/writing-guide.md
+++ b/website/docs/contributing/writing-guide.md
@@ -77,48 +77,6 @@ Rather than use relative paths, we strongly suggest the following approach, sinc
 
 `![FerretDB logo](/img/logo-dark.png)`.
 
-## Tags
-
-Tags are an important part of every blog post, and they appear at the top of the front matter.
-They make it easy for readers to search and identify related blog posts based on their categories or subject matter.
-You can view all [currently listed tags here](https://blog.ferretdb.io/tags/).
-
-Please note that all tags must be in small-case, such that `FerretDB` should be written as `ferretdb`.
-
-Hyphens should be disregarded when writing tags, e.g. `mongodb-compatible database` should be written as `mongodb compatible database`.
-
-A blog post can have as many tags as possible, as long as it is relevant to the post.
-Please only include the following tags:
-
-- cloud
-- community
-- compatible applications
-- demo
-- document databases
-- events
-- hacktoberfest
-- javascript frameworks
-- mongodb compatible
-- mongodb gui
-- open source
-- postgresql tools
-- product
-- release
-- sspl
-- tutorial
-
-This is not an exhaustive list, and the direction of our blog posts can surely expand.
-If a blog post calls for a new tag or you would like to suggest more tags, please ensure to add it to this list.
-This helps to maintain consistency across all blog posts.
-
-## Keywords (optional)
-
-Keywords in the front matter are displayed as meta keywords tag in HTML.
-Meta keywords tag are not so important for SEO anymore, but they can help with focusing the content on specific keywords that should be used (appear at least once) in the blog content, meta description, title, or alt images.
-
-The use of meta keywords is not mandatory, but if you want to add them, please ensure that they are relevant to the blog post.
-All keywords must be in small-case.
-
 ## Code blocks
 
 Always specify the language in Markdown code blocks.


### PR DESCRIPTION
# Description

That PR simplifies the linter's code to make it easier to add new checks.

It also fixes the checking of tags with spaces.

Closes #3078.

## Readiness checklist

- [x] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [x] I added/updated comments and checked rendering.
- [x] I made spot refactorings.
- [x] I updated user documentation.
- [x] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
