### PR TITLE
Compat tests failure check proof of concept

### DIFF
--- a/integration/aggregate_documents_compat_test.go
+++ b/integration/aggregate_documents_compat_test.go
@@ -99,7 +99,6 @@ func testAggregateStagesCompatWithProviders(t *testing.T, providers shareddata.P
 			}
 
 			e := setup.NewFailCatcher(t, "ferretdb-sqlite", tc.failsForSQLite)
-			defer e.Catch()
 
 			var nonEmptyResults bool
 			for i := range targetCollections {
@@ -155,6 +154,10 @@ func testAggregateStagesCompatWithProviders(t *testing.T, providers shareddata.P
 						nonEmptyResults = true
 					}
 				})
+			}
+
+			if e.Catch() {
+				return
 			}
 
 			switch tc.resultType {

--- a/integration/basic_test.go
+++ b/integration/basic_test.go
@@ -638,9 +638,22 @@ func TestPingCommand(t *testing.T) {
 	})
 }
 
-type expect struct{}
+type expect struct {
+	tcs []testing.TB
+}
 
 func (e *expect) NewChecker(t testing.TB) {
+	e.tcs = append(e.tcs, t)
+}
+
+func (e *expect) Check(t testing.TB) {
+	for _, tc := range e.tcs {
+		if tc.Failed() {
+			return
+		}
+	}
+
+	return
 }
 
 func TestDemonstrateIssue(t *testing.T) {
@@ -665,6 +678,7 @@ func TestDemonstrateIssue(t *testing.T) {
 		name, tc := name, tc
 
 		e := expect{}
+		defer e.Check()
 
 		// As usual we call subtest per test case
 		t.Run(name, func(t *testing.T) {

--- a/integration/basic_test.go
+++ b/integration/basic_test.go
@@ -20,9 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/FerretDB/FerretDB/internal/util/testutil/testfail"
-	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
@@ -640,34 +637,6 @@ func TestPingCommand(t *testing.T) {
 	})
 }
 
-type expect struct {
-	parent testtb.TB
-	tcs    []testtb.TB
-}
-
-func NewExpect(t testing.TB) *expect {
-	return &expect{
-		parent: t,
-	}
-}
-
-func (e *expect) NewChecker(t testtb.TB) testtb.TB {
-	t = testfail.New(t)
-	e.tcs = append(e.tcs, t)
-
-	return t
-}
-
-func (e *expect) Check() {
-	for _, tc := range e.tcs {
-		if tc.Failed() {
-			return
-		}
-	}
-
-	e.parent.Fail()
-}
-
 func TestDemonstrateIssue(t *testing.T) {
 	t.Parallel()
 
@@ -694,7 +663,7 @@ func TestDemonstrateIssue(t *testing.T) {
 			t.Parallel()
 			t.Helper()
 
-			e := NewExpect(t)
+			e := setup.NewExpect(t)
 			defer e.Check()
 
 			// As in every compat test we call multiple subtests for single test case

--- a/integration/basic_test.go
+++ b/integration/basic_test.go
@@ -663,7 +663,7 @@ func TestDemonstrateIssue(t *testing.T) {
 			t.Parallel()
 			t.Helper()
 
-			e := setup.NewFailCatcher(t)
+			e := setup.NewFailCatcher(t, "ferretdb-sqlite", "TODO")
 			defer e.Catch()
 
 			// As in every compat test we call multiple subtests for single test case

--- a/integration/basic_test.go
+++ b/integration/basic_test.go
@@ -658,13 +658,13 @@ func TestDemonstrateIssue(t *testing.T) {
 	} {
 		name, tc := name, tc
 
-		// As usual we call subtest per test case
+		// As usual, we call subtest per test case
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			t.Helper()
 
-			e := setup.NewExpect(t)
-			defer e.Check()
+			e := setup.NewFailCatcher(t)
+			defer e.Catch()
 
 			// As in every compat test we call multiple subtests for single test case
 			for i := range targetCollections {
@@ -676,7 +676,7 @@ func TestDemonstrateIssue(t *testing.T) {
 				t.Run(targetCollection.Name(), func(tt *testing.T) {
 					tt.Helper()
 
-					t := e.NewChecker(tt)
+					t := e.Wrap(tt)
 
 					if tc.fail {
 						t.Fail()

--- a/integration/basic_test.go
+++ b/integration/basic_test.go
@@ -16,10 +16,12 @@ package integration
 
 import (
 	"fmt"
-	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 	"math"
 	"strings"
 	"testing"
+
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testfail"
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,7 +31,6 @@ import (
 
 	"github.com/FerretDB/FerretDB/integration/setup"
 	"github.com/FerretDB/FerretDB/integration/shareddata"
-	"github.com/FerretDB/FerretDB/internal/util/testutil/testfail"
 )
 
 func TestMostCommandsAreCaseSensitive(t *testing.T) {
@@ -650,8 +651,11 @@ func NewExpect(t testing.TB) *expect {
 	}
 }
 
-func (e *expect) NewChecker(t testtb.TB) {
+func (e *expect) NewChecker(t testtb.TB) testtb.TB {
+	t = testfail.New(t)
 	e.tcs = append(e.tcs, t)
+
+	return t
 }
 
 func (e *expect) Check() {
@@ -703,8 +707,7 @@ func TestDemonstrateIssue(t *testing.T) {
 				t.Run(targetCollection.Name(), func(tt *testing.T) {
 					tt.Helper()
 
-					t := testfail.New(tt)
-					e.NewChecker(t)
+					t := e.NewChecker(tt)
 
 					if tc.fail {
 						t.Fail()

--- a/integration/setup/test_helpers.go
+++ b/integration/setup/test_helpers.go
@@ -82,6 +82,10 @@ type failCatcher struct {
 // NewFailCatcher returns failCatcher that should be used to handle expected failures
 // for subtests of t TB.
 func NewFailCatcher(t testing.TB, backend, reason string) *failCatcher {
+	if backend == "" {
+		return &failCatcher{}
+	}
+
 	require.Contains(t, allBackends, backend)
 
 	return &failCatcher{

--- a/integration/setup/test_helpers.go
+++ b/integration/setup/test_helpers.go
@@ -15,6 +15,8 @@
 package setup
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/FerretDB/FerretDB/internal/util/testutil/testfail"
@@ -68,4 +70,43 @@ func IsPushdownDisabled() bool {
 // IsSortPushdownEnabled returns true if sort pushdown is enabled.
 func IsSortPushdownEnabled() bool {
 	return *enableSortPushdownF
+}
+
+type expect struct {
+	parent        testtb.TB
+	tcs           []testtb.TB
+	targetBackend string
+}
+
+func NewExpect(t testing.TB) *expect {
+	return &expect{
+		parent:        t,
+		targetBackend: "ferretdb-sqlite",
+	}
+}
+
+func (e *expect) NewChecker(tb testtb.TB) testtb.TB {
+	if *targetBackendF != e.targetBackend {
+		return tb
+	}
+
+	t := testfail.New(tb)
+
+	e.tcs = append(e.tcs, t)
+
+	return t
+}
+
+func (e *expect) Check() {
+	if len(e.tcs) == 0 {
+		return
+	}
+
+	for _, tc := range e.tcs {
+		if tc.Failed() {
+			return
+		}
+	}
+
+	e.parent.Fail()
 }

--- a/integration/setup/test_helpers.go
+++ b/integration/setup/test_helpers.go
@@ -117,17 +117,18 @@ func (e *failCatcher) Wrap(tb testtb.TB) testtb.TB {
 //
 // If it's called for different backend than provided in failCatcher, it won't
 // do anything.
-func (e *failCatcher) Catch() {
+func (e *failCatcher) Catch() bool {
 	if *targetBackendF != e.targetBackend {
-		return
+		return false
 	}
 
 	for _, tc := range e.tcs {
 		if tc.Failed() {
 			e.parent.Logf("Test failed as expected: %s", e.reason)
-			return
+			return true
 		}
 	}
 
 	e.parent.Fatalf("Test passed unexpectedly: %s", e.reason)
+	return true
 }

--- a/integration/setup/test_helpers.go
+++ b/integration/setup/test_helpers.go
@@ -76,14 +76,16 @@ type failCatcher struct {
 	parent        testtb.TB
 	tcs           []testtb.TB
 	targetBackend string
+	reason        string
 }
 
-func NewFailCatcher(t testing.TB, backend string) *failCatcher {
+func NewFailCatcher(t testing.TB, backend, reason string) *failCatcher {
 	require.Contains(t, allBackends, backend)
 
 	return &failCatcher{
 		parent:        t,
 		targetBackend: backend,
+		reason:        reason,
 	}
 }
 
@@ -106,9 +108,10 @@ func (e *failCatcher) Catch() {
 
 	for _, tc := range e.tcs {
 		if tc.Failed() {
+			e.parent.Logf("Test failed as expected: %s", e.reason)
 			return
 		}
 	}
 
-	e.parent.Fail()
+	e.parent.Fatalf("Test passed unexpectedly: %s", e.reason)
 }

--- a/integration/setup/test_helpers.go
+++ b/integration/setup/test_helpers.go
@@ -72,20 +72,20 @@ func IsSortPushdownEnabled() bool {
 	return *enableSortPushdownF
 }
 
-type expect struct {
+type failCatcher struct {
 	parent        testtb.TB
 	tcs           []testtb.TB
 	targetBackend string
 }
 
-func NewExpect(t testing.TB) *expect {
-	return &expect{
+func NewFailCatcher(t testing.TB) *failCatcher {
+	return &failCatcher{
 		parent:        t,
 		targetBackend: "ferretdb-sqlite",
 	}
 }
 
-func (e *expect) NewChecker(tb testtb.TB) testtb.TB {
+func (e *failCatcher) Wrap(tb testtb.TB) testtb.TB {
 	if *targetBackendF != e.targetBackend {
 		return tb
 	}
@@ -97,7 +97,7 @@ func (e *expect) NewChecker(tb testtb.TB) testtb.TB {
 	return t
 }
 
-func (e *expect) Check() {
+func (e *failCatcher) Catch() {
 	if len(e.tcs) == 0 {
 		return
 	}

--- a/integration/setup/test_helpers.go
+++ b/integration/setup/test_helpers.go
@@ -78,10 +78,12 @@ type failCatcher struct {
 	targetBackend string
 }
 
-func NewFailCatcher(t testing.TB) *failCatcher {
+func NewFailCatcher(t testing.TB, backend string) *failCatcher {
+	require.Contains(t, allBackends, backend)
+
 	return &failCatcher{
 		parent:        t,
-		targetBackend: "ferretdb-sqlite",
+		targetBackend: backend,
 	}
 }
 
@@ -98,7 +100,7 @@ func (e *failCatcher) Wrap(tb testtb.TB) testtb.TB {
 }
 
 func (e *failCatcher) Catch() {
-	if len(e.tcs) == 0 {
+	if *targetBackendF != e.targetBackend {
 		return
 	}
 

--- a/internal/util/testutil/testfail/expected.go
+++ b/internal/util/testutil/testfail/expected.go
@@ -48,6 +48,16 @@ func Expected(t testtb.TB, reason string) testtb.TB {
 	return x
 }
 
+func New(t testtb.TB) testtb.TB {
+	t.Helper()
+
+	x := &expected{
+		t: t,
+	}
+
+	return x
+}
+
 // expected wraps TB with expected failure logic.
 type expected struct {
 	t      testtb.TB


### PR DESCRIPTION
# Description

That's just a draft of solution to the issue with checking for SQLite failure of compat tests. It still needs some changes (like merging it into the `expected` struct, or somehow extracting the Fail() logic between `expected` and `failChecker`, although this'll be covered as soon as we agree to specific architecture).

I'd be grateful for any opinions 

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [ ] I ensured that PR title is good enough for the changelog.
- [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
- [ ] I marked all done items in this checklist.
