### PR TITLE
Make `getMore` integration tests pass for SQLite

### DIFF
--- a/integration/getmore_test.go
+++ b/integration/getmore_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/FerretDB/FerretDB/integration/shareddata"
 	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/util/must"
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 )
 
 func TestGetMoreCommand(t *testing.T) {
@@ -312,9 +313,14 @@ func TestGetMoreCommand(t *testing.T) {
 		},
 	} {
 		name, tc := name, tc
-		t.Run(name, func(t *testing.T) {
+		t.Run(name, func(tt *testing.T) {
 			if tc.skip != "" {
-				t.Skip(tc.skip)
+				tt.Skip(tc.skip)
+			}
+
+			var t testtb.TB = tt
+			if tc.failsForSQLite != "" {
+				t = setup.FailsForSQLite(tt, tc.failsForSQLite)
 			}
 
 			// Do not run subtests in t.Parallel() to eliminate the occurrence
@@ -485,8 +491,10 @@ func TestGetMoreBatchSizeCursor(t *testing.T) {
 
 	cursorFuncs := []func(batchSize *int32) (*mongo.Cursor, error){findFunc, aggregateFunc}
 
-	t.Run("SetBatchSize", func(t *testing.T) {
-		t.Parallel()
+	t.Run("SetBatchSize", func(tt *testing.T) {
+		tt.Parallel()
+
+		t := setup.FailsForSQLite(tt, "https://github.com/FerretDB/FerretDB/issues/3148")
 
 		for _, f := range cursorFuncs {
 			cursor, err := f(pointer.ToInt32(2))
@@ -527,8 +535,10 @@ func TestGetMoreBatchSizeCursor(t *testing.T) {
 		}
 	})
 
-	t.Run("DefaultBatchSize", func(t *testing.T) {
-		t.Parallel()
+	t.Run("DefaultBatchSize", func(tt *testing.T) {
+		tt.Parallel()
+
+		t := setup.FailsForSQLite(tt, "https://github.com/FerretDB/FerretDB/issues/3148")
 
 		for _, f := range cursorFuncs {
 			// unset batchSize uses default batchSize 101 for the first batch
@@ -553,8 +563,10 @@ func TestGetMoreBatchSizeCursor(t *testing.T) {
 		}
 	})
 
-	t.Run("ZeroBatchSize", func(t *testing.T) {
-		t.Parallel()
+	t.Run("ZeroBatchSize", func(tt *testing.T) {
+		tt.Parallel()
+
+		t := setup.FailsForSQLite(tt, "https://github.com/FerretDB/FerretDB/issues/3148")
 
 		for _, f := range cursorFuncs {
 			cursor, err := f(pointer.ToInt32(0))

--- a/integration/getmore_test.go
+++ b/integration/getmore_test.go
@@ -59,11 +59,12 @@ func TestGetMoreCommand(t *testing.T) {
 		collection       any // optional, nil to leave collection unset
 		cursorID         any // optional, defaults to cursorID from find()/aggregate()
 
-		firstBatch []*types.Document   // required, expected find firstBatch
-		nextBatch  []*types.Document   // optional, expected getMore nextBatch
-		err        *mongo.CommandError // optional, expected error from MongoDB
-		altMessage string              // optional, alternative error message for FerretDB, ignored if empty
-		skip       string              // optional, skip test with a specified reason
+		firstBatch     []*types.Document   // required, expected find firstBatch
+		nextBatch      []*types.Document   // optional, expected getMore nextBatch
+		err            *mongo.CommandError // optional, expected error from MongoDB
+		altMessage     string              // optional, alternative error message for FerretDB, ignored if empty
+		skip           string              // optional, skip test with a specified reason
+		failsForSQLite string              // optional, if set, the case is expected to fail for SQLite due to given issue
 	}{
 		"Int": {
 			firstBatchSize:   1,
@@ -71,6 +72,7 @@ func TestGetMoreCommand(t *testing.T) {
 			collection:       collection.Name(),
 			firstBatch:       ConvertDocuments(t, arr[:1]),
 			nextBatch:        ConvertDocuments(t, arr[1:2]),
+			failsForSQLite:   "https://github.com/FerretDB/FerretDB/issues/3148",
 		},
 		"IntNegative": {
 			firstBatchSize:   1,
@@ -89,6 +91,7 @@ func TestGetMoreCommand(t *testing.T) {
 			collection:       collection.Name(),
 			firstBatch:       ConvertDocuments(t, arr[:1]),
 			nextBatch:        ConvertDocuments(t, arr[1:]),
+			failsForSQLite:   "https://github.com/FerretDB/FerretDB/issues/3148",
 		},
 		"Long": {
 			firstBatchSize:   1,
@@ -96,6 +99,7 @@ func TestGetMoreCommand(t *testing.T) {
 			collection:       collection.Name(),
 			firstBatch:       ConvertDocuments(t, arr[:1]),
 			nextBatch:        ConvertDocuments(t, arr[1:2]),
+			failsForSQLite:   "https://github.com/FerretDB/FerretDB/issues/3148",
 		},
 		"LongNegative": {
 			firstBatchSize:   1,
@@ -114,6 +118,7 @@ func TestGetMoreCommand(t *testing.T) {
 			collection:       collection.Name(),
 			firstBatch:       ConvertDocuments(t, arr[:1]),
 			nextBatch:        ConvertDocuments(t, arr[1:]),
+			failsForSQLite:   "https://github.com/FerretDB/FerretDB/issues/3148",
 		},
 		"Double": {
 			firstBatchSize:   1,
@@ -121,6 +126,7 @@ func TestGetMoreCommand(t *testing.T) {
 			collection:       collection.Name(),
 			firstBatch:       ConvertDocuments(t, arr[:1]),
 			nextBatch:        ConvertDocuments(t, arr[1:2]),
+			failsForSQLite:   "https://github.com/FerretDB/FerretDB/issues/3148",
 		},
 		"DoubleNegative": {
 			firstBatchSize:   1,
@@ -139,6 +145,7 @@ func TestGetMoreCommand(t *testing.T) {
 			collection:       collection.Name(),
 			firstBatch:       ConvertDocuments(t, arr[:1]),
 			nextBatch:        ConvertDocuments(t, arr[1:]),
+			failsForSQLite:   "https://github.com/FerretDB/FerretDB/issues/3148",
 		},
 		"DoubleFloor": {
 			firstBatchSize:   1,
@@ -146,6 +153,7 @@ func TestGetMoreCommand(t *testing.T) {
 			collection:       collection.Name(),
 			firstBatch:       ConvertDocuments(t, arr[:1]),
 			nextBatch:        ConvertDocuments(t, arr[1:2]),
+			failsForSQLite:   "https://github.com/FerretDB/FerretDB/issues/3148",
 		},
 		"GetMoreCursorExhausted": {
 			firstBatchSize:   200,
@@ -177,6 +185,7 @@ func TestGetMoreCommand(t *testing.T) {
 			collection:       collection.Name(),
 			firstBatch:       ConvertDocuments(t, arr[:1]),
 			nextBatch:        ConvertDocuments(t, arr[1:]),
+			failsForSQLite:   "https://github.com/FerretDB/FerretDB/issues/3148",
 		},
 		"LargeBatchSize": {
 			firstBatchSize:   1,
@@ -184,6 +193,7 @@ func TestGetMoreCommand(t *testing.T) {
 			collection:       collection.Name(),
 			firstBatch:       ConvertDocuments(t, arr[:1]),
 			nextBatch:        ConvertDocuments(t, arr[1:106]),
+			failsForSQLite:   "https://github.com/FerretDB/FerretDB/issues/3148",
 		},
 		"StringCursorID": {
 			firstBatchSize:   1,
@@ -274,6 +284,7 @@ func TestGetMoreCommand(t *testing.T) {
 			collection:       collection.Name(),
 			firstBatch:       ConvertDocuments(t, arr[:101]),
 			nextBatch:        ConvertDocuments(t, arr[101:]),
+			failsForSQLite:   "https://github.com/FerretDB/FerretDB/issues/3148",
 		},
 		"UnsetFindBatchSize": {
 			firstBatchSize:   nil,
@@ -281,6 +292,7 @@ func TestGetMoreCommand(t *testing.T) {
 			collection:       collection.Name(),
 			firstBatch:       ConvertDocuments(t, arr[:101]),
 			nextBatch:        ConvertDocuments(t, arr[101:106]),
+			failsForSQLite:   "https://github.com/FerretDB/FerretDB/issues/3148",
 		},
 		"UnsetGetMoreBatchSize": {
 			firstBatchSize:   5,
@@ -288,6 +300,7 @@ func TestGetMoreCommand(t *testing.T) {
 			collection:       collection.Name(),
 			firstBatch:       ConvertDocuments(t, arr[:5]),
 			nextBatch:        ConvertDocuments(t, arr[5:]),
+			failsForSQLite:   "https://github.com/FerretDB/FerretDB/issues/3148",
 		},
 		"BatchSize": {
 			firstBatchSize:   3,
@@ -295,6 +308,7 @@ func TestGetMoreCommand(t *testing.T) {
 			collection:       collection.Name(),
 			firstBatch:       ConvertDocuments(t, arr[:3]),
 			nextBatch:        ConvertDocuments(t, arr[3:8]),
+			failsForSQLite:   "https://github.com/FerretDB/FerretDB/issues/3148",
 		},
 	} {
 		name, tc := name, tc

--- a/integration/indexes_command_compat_test.go
+++ b/integration/indexes_command_compat_test.go
@@ -112,13 +112,15 @@ func TestCreateIndexesCommandCompat(t *testing.T) {
 		},
 	} {
 		name, tc := name, tc
-		t.Run(name, func(t *testing.T) {
+		t.Run(name, func(tt *testing.T) {
 			if tc.skip != "" {
-				t.Skip(tc.skip)
+				tt.Skip(tc.skip)
 			}
 
-			t.Helper()
-			t.Parallel()
+			tt.Helper()
+			tt.Parallel()
+
+			t := setup.FailsForSQLite(tt, "https://github.com/FerretDB/FerretDB/issues/3175")
 
 			indexesDoc := bson.D{}
 
@@ -278,8 +280,8 @@ func TestCreateIndexesCommandCompatCheckFields(t *testing.T) {
 	AssertEqualDocuments(t, compatRes, targetRes)
 }
 
-func TestDropIndexesCommandCompat(t *testing.T) {
-	t.Parallel()
+func TestDropIndexesCommandCompat(tt *testing.T) {
+	tt.Parallel()
 
 	for name, tc := range map[string]struct { //nolint:vet // for readability
 		toCreate []mongo.IndexModel // optional, if set, create the given indexes before drop is called
@@ -350,18 +352,18 @@ func TestDropIndexesCommandCompat(t *testing.T) {
 		},
 	} {
 		name, tc := name, tc
-		t.Run(name, func(t *testing.T) {
+		tt.Run(name, func(tt *testing.T) {
 			if tc.skip != "" {
-				t.Skip(tc.skip)
+				tt.Skip(tc.skip)
 			}
 
-			t.Helper()
-			t.Parallel()
+			tt.Helper()
+			tt.Parallel()
 
-			require.NotNil(t, tc.toDrop, "toDrop must not be nil")
+			require.NotNil(tt, tc.toDrop, "toDrop must not be nil")
 
 			// It's enough to use a single provider for drop indexes test as indexes work the same for different collections.
-			s := setup.SetupCompatWithOpts(t, &setup.SetupCompatOpts{
+			s := setup.SetupCompatWithOpts(tt, &setup.SetupCompatOpts{
 				Providers:                []shareddata.Provider{shareddata.Composites},
 				AddNonExistentCollection: true,
 			})
@@ -372,8 +374,10 @@ func TestDropIndexesCommandCompat(t *testing.T) {
 				targetCollection := targetCollections[i]
 				compatCollection := compatCollections[i]
 
-				t.Run(targetCollection.Name(), func(t *testing.T) {
-					t.Helper()
+				tt.Run(targetCollection.Name(), func(tt *testing.T) {
+					tt.Helper()
+
+					t := setup.FailsForSQLite(tt, "https://github.com/FerretDB/FerretDB/issues/3175")
 
 					if tc.toCreate != nil {
 						_, targetErr := targetCollection.Indexes().CreateMany(ctx, tc.toCreate)
@@ -460,13 +464,18 @@ func TestDropIndexesCommandCompat(t *testing.T) {
 				})
 			}
 
+			// https://github.com/FerretDB/FerretDB/issues/3175
+			if setup.IsSQLite(tt) {
+				return
+			}
+
 			switch tc.resultType {
 			case nonEmptyResult:
-				require.True(t, nonEmptyResults, "expected non-empty results (some indexes should be deleted)")
+				require.True(tt, nonEmptyResults, "expected non-empty results (some indexes should be deleted)")
 			case emptyResult:
-				require.False(t, nonEmptyResults, "expected empty results (no indexes should be deleted)")
+				require.False(tt, nonEmptyResults, "expected empty results (no indexes should be deleted)")
 			default:
-				t.Fatalf("unknown result type %v", tc.resultType)
+				tt.Fatalf("unknown result type %v", tc.resultType)
 			}
 		})
 	}

--- a/integration/indexes_command_compat_test.go
+++ b/integration/indexes_command_compat_test.go
@@ -198,8 +198,10 @@ func TestCreateIndexesCommandCompat(t *testing.T) {
 // TestCreateIndexesCommandCompatCheckFields check that the response contains response's fields
 // such as numIndexBefore, numIndexAfter, createdCollectionAutomatically
 // contain the correct values.
-func TestCreateIndexesCommandCompatCheckFields(t *testing.T) {
-	t.Parallel()
+func TestCreateIndexesCommandCompatCheckFields(tt *testing.T) {
+	tt.Parallel()
+
+	t := setup.FailsForSQLite(tt, "https://github.com/FerretDB/FerretDB/issues/3176")
 
 	ctx, targetCollections, compatCollections := setup.SetupCompat(t)
 	targetCollection := targetCollections[0]

--- a/integration/indexes_compat_test.go
+++ b/integration/indexes_compat_test.go
@@ -15,8 +15,9 @@
 package integration
 
 import (
-	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 	"testing"
+
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -452,7 +453,8 @@ func TestCreateIndexesCompatUnique(tt *testing.T) {
 		insertDoc bson.D             // required, document to insert for uniqueness check
 		new       bool               // optional, insert new document before check uniqueness
 
-		skip string // optional, skip test with a specified reason
+		skip           string // optional, skip test with a specified reason
+		failsForSQLite string // optional, if set, the case is expected to fail for SQLite due to given issue
 	}{
 		"IDIndex": {
 			models: []mongo.IndexModel{


### PR DESCRIPTION
# Description

- `getmore_test.go`
- `indexes_command_compat_test.go`

Closes #3131.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [ ] I ensured that PR title is good enough for the changelog.
- [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
- [ ] I marked all done items in this checklist.
