### PR TITLE
Make `update` integration tests pass for SQLite

### DIFF
--- a/integration/insert_command_test.go
+++ b/integration/insert_command_test.go
@@ -15,8 +15,9 @@
 package integration
 
 import (
-	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 	"testing"
+
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/integration/insert_command_test.go
+++ b/integration/insert_command_test.go
@@ -15,6 +15,7 @@
 package integration
 
 import (
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,17 +27,18 @@ import (
 	"github.com/FerretDB/FerretDB/integration/shareddata"
 )
 
-func TestInsertCommandErrors(t *testing.T) {
-	t.Parallel()
+func TestInsertCommandErrors(tt *testing.T) {
+	tt.Parallel()
 
 	for name, tc := range map[string]struct { //nolint:vet // used for testing only
 		toInsert []any // required, slice of bson.D to insert
 		ordered  any   // required, sets it to `ordered`
 
-		cerr       *mongo.CommandError // optional, expected command error from MongoDB
-		werr       *mongo.WriteError   // optional, expected write error from MongoDB
-		altMessage string              // optional, alternative error message for FerretDB, ignored if empty
-		skip       string              // optional, skip test with a specified reason
+		cerr           *mongo.CommandError // optional, expected command error from MongoDB
+		werr           *mongo.WriteError   // optional, expected write error from MongoDB
+		altMessage     string              // optional, alternative error message for FerretDB, ignored if empty
+		skip           string              // optional, skip test with a specified reason
+		failsForSQLite string              // optional, if set, the case is expected to fail for SQLite due to given issue
 	}{
 		"InsertOrderedInvalid": {
 			toInsert: []any{
@@ -60,7 +62,8 @@ func TestInsertCommandErrors(t *testing.T) {
 				Message: `E11000 duplicate key error collection: ` +
 					`TestInsertCommandErrors-InsertDuplicateKey.TestInsertCommandErrors-InsertDuplicateKey index: _id_ dup key: { _id: "double" }`,
 			},
-			altMessage: "E11000 duplicate key error collection: TestInsertCommandErrors-InsertDuplicateKey.TestInsertCommandErrors-InsertDuplicateKey",
+			altMessage:     "E11000 duplicate key error collection: TestInsertCommandErrors-InsertDuplicateKey.TestInsertCommandErrors-InsertDuplicateKey",
+			failsForSQLite: "https://github.com/FerretDB/FerretDB/issues/3183",
 		},
 		"InsertDuplicateKeyOrdered": {
 			toInsert: []any{
@@ -74,7 +77,8 @@ func TestInsertCommandErrors(t *testing.T) {
 				Message: `E11000 duplicate key error collection: ` +
 					`TestInsertCommandErrors-InsertDuplicateKeyOrdered.TestInsertCommandErrors-InsertDuplicateKeyOrdered index: _id_ dup key: { _id: "double" }`,
 			},
-			altMessage: `E11000 duplicate key error collection: TestInsertCommandErrors-InsertDuplicateKeyOrdered.TestInsertCommandErrors-InsertDuplicateKeyOrdered`,
+			altMessage:     `E11000 duplicate key error collection: TestInsertCommandErrors-InsertDuplicateKeyOrdered.TestInsertCommandErrors-InsertDuplicateKeyOrdered`,
+			failsForSQLite: "https://github.com/FerretDB/FerretDB/issues/3183",
 		},
 		"InsertArray": {
 			toInsert: []any{
@@ -90,12 +94,17 @@ func TestInsertCommandErrors(t *testing.T) {
 		},
 	} {
 		name, tc := name, tc
-		t.Run(name, func(t *testing.T) {
+		tt.Run(name, func(tt *testing.T) {
 			if tc.skip != "" {
-				t.Skip(tc.skip)
+				tt.Skip(tc.skip)
 			}
 
-			t.Parallel()
+			tt.Parallel()
+
+			var t testtb.TB = tt
+			if tc.failsForSQLite != "" {
+				t = setup.FailsForSQLite(tt, tc.failsForSQLite)
+			}
 
 			require.NotNil(t, tc.toInsert, "toInsert must not be nil")
 			require.NotNil(t, tc.ordered, "ordered must not be nil")
@@ -112,12 +121,12 @@ func TestInsertCommandErrors(t *testing.T) {
 			assert.Nil(t, res)
 
 			if tc.cerr != nil {
-				AssertEqualAltCommandError(t, *tc.cerr, tc.altMessage, err)
+				AssertEqualAltCommandError(tt, *tc.cerr, tc.altMessage, err)
 				return
 			}
 
 			if tc.werr != nil {
-				AssertEqualAltWriteError(t, *tc.werr, tc.altMessage, err)
+				AssertEqualAltWriteError(tt, *tc.werr, tc.altMessage, err)
 				return
 			}
 

--- a/integration/insert_command_test.go
+++ b/integration/insert_command_test.go
@@ -17,8 +17,6 @@ package integration
 import (
 	"testing"
 
-	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
@@ -26,6 +24,7 @@ import (
 
 	"github.com/FerretDB/FerretDB/integration/setup"
 	"github.com/FerretDB/FerretDB/integration/shareddata"
+	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 )
 
 func TestInsertCommandErrors(tt *testing.T) {

--- a/integration/update_compat_test.go
+++ b/integration/update_compat_test.go
@@ -42,7 +42,8 @@ type updateCompatTestCase struct {
 	resultType  compatTestCaseResultType // defaults to nonEmptyResult
 	providers   []shareddata.Provider    // defaults to shareddata.AllProviders()
 
-	skip string // skips test if non-empty
+	skip           string // skips test if non-empty
+	failsForSQLite string // optional, if set, the case is expected to fail for SQLite due to given issue
 }
 
 // testUpdateCompat tests update compatibility test cases.
@@ -549,10 +550,11 @@ func TestUpdateCompat(t *testing.T) {
 			replace: bson.D{},
 		},
 		"ReplaceNonExistentUpsert": {
-			filter:      bson.D{{"non-existent", "no-match"}},
-			replace:     bson.D{{"_id", "new"}},
-			replaceOpts: options.Replace().SetUpsert(true),
-			resultType:  emptyResult,
+			filter:         bson.D{{"non-existent", "no-match"}},
+			replace:        bson.D{{"_id", "new"}},
+			replaceOpts:    options.Replace().SetUpsert(true),
+			resultType:     emptyResult,
+			failsForSQLite: "https://github.com/FerretDB/FerretDB/issues/3183",
 		},
 		"UpdateNonExistentUpsert": {
 			filter:     bson.D{{"_id", "non-existent"}},


### PR DESCRIPTION
# Description

- `update_compat_test.go`

`TestUpdateCompat` fails for some subtests and passes for other subtests, it seems impossible to catch failure correctly without overcomplicating.

Closes #3131.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [ ] I ensured that PR title is good enough for the changelog.
- [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Labels, Project and project's Sprint fields.
- [ ] I marked all done items in this checklist.
