### PR TITLE
Add more metrics for `*sql.DB`

### DIFF
--- a/internal/backends/sqlite/metadata/registry.go
+++ b/internal/backends/sqlite/metadata/registry.go
@@ -351,7 +351,7 @@ func (r *Registry) Collect(ch chan<- prometheus.Metric) {
 	r.p.Collect(ch)
 
 	r.rw.RLock()
-	defer r.rw.RLock()
+	defer r.rw.RUnlock()
 
 	ch <- prometheus.MustNewConstMetric(
 		prometheus.NewDesc(

--- a/internal/util/fsql/metrics.go
+++ b/internal/util/fsql/metrics.go
@@ -93,7 +93,7 @@ func (c *metricsCollector) Collect(ch chan<- prometheus.Metric) {
 
 	ch <- prometheus.MustNewConstMetric(
 		prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, subsystem, "wait_count"),
+			prometheus.BuildFQName(namespace, subsystem, "wait_count_total"),
 			"The total number of connections waited for.",
 			nil, c.labels,
 		),
@@ -103,7 +103,7 @@ func (c *metricsCollector) Collect(ch chan<- prometheus.Metric) {
 
 	ch <- prometheus.MustNewConstMetric(
 		prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, subsystem, "wait_duration_seconds"),
+			prometheus.BuildFQName(namespace, subsystem, "wait_duration_seconds_total"),
 			"The total time blocked waiting for a new connection.",
 			nil, c.labels,
 		),
@@ -113,7 +113,7 @@ func (c *metricsCollector) Collect(ch chan<- prometheus.Metric) {
 
 	ch <- prometheus.MustNewConstMetric(
 		prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, subsystem, "max_idle_closed"),
+			prometheus.BuildFQName(namespace, subsystem, "max_idle_closed_total"),
 			"The total number of connections closed due to SetMaxIdleConns.",
 			nil, c.labels,
 		),

--- a/internal/util/fsql/metrics.go
+++ b/internal/util/fsql/metrics.go
@@ -71,8 +71,65 @@ func (c *metricsCollector) Collect(ch chan<- prometheus.Metric) {
 		float64(stats.OpenConnections),
 	)
 
-	// Add other metrics from stats here.
-	// TODO https://github.com/FerretDB/FerretDB/issues/2909
+	ch <- prometheus.MustNewConstMetric(
+		prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "in_use"),
+			"The number of connections currently in use.",
+			nil, c.labels,
+		),
+		prometheus.GaugeValue,
+		float64(stats.InUse),
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "idle"),
+			"The number of idle connections.",
+			nil, c.labels,
+		),
+		prometheus.GaugeValue,
+		float64(stats.Idle),
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "wait_count"),
+			"The total number of connections waited for.",
+			nil, c.labels,
+		),
+		prometheus.CounterValue,
+		float64(stats.WaitCount),
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "wait_duration_seconds"),
+			"The total time blocked waiting for a new connection.",
+			nil, c.labels,
+		),
+		prometheus.CounterValue,
+		float64(stats.WaitDuration.Seconds()),
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "max_idle_closed"),
+			"The total number of connections closed due to SetMaxIdleConns.",
+			nil, c.labels,
+		),
+		prometheus.CounterValue,
+		float64(stats.MaxIdleClosed),
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "max_idle_time_closed_total"),
+			"The total number of connections closed due to SetConnMaxIdleTime.",
+			nil, c.labels,
+		),
+		prometheus.CounterValue,
+		float64(stats.MaxIdleTimeClosed),
+	)
 
 	ch <- prometheus.MustNewConstMetric(
 		prometheus.NewDesc(


### PR DESCRIPTION
# Description
Added missing metrics for the `*sql.DB` pool statistics. 

Closes #2909.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [x] I made spot refactorings.
- [ ] I updated user documentation.
- [x] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
