### PR TITLE
Skip tests for `enable` `setFreeMonitoring` for MongoDB

### DIFF
--- a/integration/commands_administration_test.go
+++ b/integration/commands_administration_test.go
@@ -1078,10 +1078,12 @@ func TestCommandsAdministrationServerStatusFreeMonitoring(t *testing.T) {
 	for name, tc := range map[string]struct {
 		command        bson.D // required, command to run
 		expectedStatus string // optional
+		skipForMongoDB string // optional, skip test for MongoDB backend with a specific reason
 	}{
 		"Enable": {
 			command:        bson.D{{"setFreeMonitoring", 1}, {"action", "enable"}},
 			expectedStatus: "enabled",
+			skipForMongoDB: "MongoDB decommissioned enabling free monitoring",
 		},
 		"Disable": {
 			command:        bson.D{{"setFreeMonitoring", 1}, {"action", "disable"}},
@@ -1091,6 +1093,10 @@ func TestCommandsAdministrationServerStatusFreeMonitoring(t *testing.T) {
 		name, tc := name, tc
 
 		t.Run(name, func(t *testing.T) {
+			if tc.skipForMongoDB != "" {
+				setup.SkipForMongoDB(t, tc.skipForMongoDB)
+			}
+
 			require.NotNil(t, tc.command, "command must not be nil")
 
 			res := s.Collection.Database().RunCommand(s.Ctx, tc.command)

--- a/integration/commands_freemonitoring_test.go
+++ b/integration/commands_freemonitoring_test.go
@@ -64,11 +64,13 @@ func TestCommandsFreeMonitoringSetFreeMonitoring(t *testing.T) {
 		err            *mongo.CommandError // optional, expected error from MongoDB
 		altMessage     string              // optional, alternative error message for FerretDB, ignored if empty
 		skip           string              // optional, skip test with a specified reason
+		skipForMongoDB string              // optional, skip test for MongoDB backend with a specific reason
 	}{
 		"Enable": {
 			command:        bson.D{{"setFreeMonitoring", 1}, {"action", "enable"}},
 			expectedRes:    bson.D{{"ok", float64(1)}},
 			expectedStatus: "enabled",
+			skipForMongoDB: "MongoDB decommissioned enabling free monitoring",
 		},
 		"Disable": {
 			command:        bson.D{{"setFreeMonitoring", 1}, {"action", "disable"}},
@@ -96,11 +98,13 @@ func TestCommandsFreeMonitoringSetFreeMonitoring(t *testing.T) {
 			command:        bson.D{{"setFreeMonitoring", bson.D{}}, {"action", "enable"}},
 			expectedRes:    bson.D{{"ok", float64(1)}},
 			expectedStatus: "enabled",
+			skipForMongoDB: "MongoDB decommissioned enabling free monitoring",
 		},
 		"NilCommand": {
 			command:        bson.D{{"setFreeMonitoring", nil}, {"action", "enable"}},
 			expectedRes:    bson.D{{"ok", float64(1)}},
 			expectedStatus: "enabled",
+			skipForMongoDB: "MongoDB decommissioned enabling free monitoring",
 		},
 		"ActionMissing": {
 			command: bson.D{{"setFreeMonitoring", nil}},
@@ -128,6 +132,10 @@ func TestCommandsFreeMonitoringSetFreeMonitoring(t *testing.T) {
 
 			if tc.skip != "" {
 				t.Skip(tc.skip)
+			}
+
+			if tc.skipForMongoDB != "" {
+				setup.SkipForMongoDB(t, tc.skipForMongoDB)
 			}
 
 			require.NotNil(t, tc.command, "command must not be nil")


### PR DESCRIPTION
# Description

Closes #{issue_number}.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

Free monitoring cannot be enabled anymore https://www.mongodb.com/docs/manual/reference/command/setFreeMonitoring/

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

- [ ] I added/updated unit tests (and they pass).
- [x] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
