### PR TITLE
Return correct response if unique index violation happened on SQLite backend

### DIFF
--- a/integration/update_compat_test.go
+++ b/integration/update_compat_test.go
@@ -558,14 +558,12 @@ func TestUpdateCompat(t *testing.T) {
 			replace:     bson.D{{"_id", "new"}},
 			replaceOpts: options.Replace().SetUpsert(true),
 			resultType:  emptyResult,
-			//	skipForSQLite: "https://github.com/FerretDB/FerretDB/issues/3183",
 		},
 		"UpdateNonExistentUpsert": {
 			filter:     bson.D{{"_id", "non-existent"}},
 			update:     bson.D{{"$set", bson.D{{"v", int32(42)}}}},
 			updateOpts: options.Update().SetUpsert(true),
 			resultType: emptyResult,
-			// skipForSQLite: "https://github.com/FerretDB/FerretDB/issues/3183",
 		},
 	}
 

--- a/integration/update_compat_test.go
+++ b/integration/update_compat_test.go
@@ -42,8 +42,7 @@ type updateCompatTestCase struct {
 	resultType  compatTestCaseResultType // defaults to nonEmptyResult
 	providers   []shareddata.Provider    // defaults to shareddata.AllProviders()
 
-	skip          string // skips test if non-empty
-	skipForSQLite string // optional, if set, the case is skipped for SQLite due to given issue
+	skip string // skips test if non-empty
 }
 
 // testUpdateCompat tests update compatibility test cases.
@@ -57,10 +56,6 @@ func testUpdateCompat(t *testing.T, testCases map[string]updateCompatTestCase) {
 
 			if tc.skip != "" {
 				t.Skip(tc.skip)
-			}
-
-			if tc.skipForSQLite != "" {
-				t.Skip(tc.skipForSQLite)
 			}
 
 			t.Parallel()

--- a/integration/update_compat_test.go
+++ b/integration/update_compat_test.go
@@ -554,18 +554,18 @@ func TestUpdateCompat(t *testing.T) {
 			replace: bson.D{},
 		},
 		"ReplaceNonExistentUpsert": {
-			filter:        bson.D{{"non-existent", "no-match"}},
-			replace:       bson.D{{"_id", "new"}},
-			replaceOpts:   options.Replace().SetUpsert(true),
-			resultType:    emptyResult,
-			skipForSQLite: "https://github.com/FerretDB/FerretDB/issues/3183",
+			filter:      bson.D{{"non-existent", "no-match"}},
+			replace:     bson.D{{"_id", "new"}},
+			replaceOpts: options.Replace().SetUpsert(true),
+			resultType:  emptyResult,
+			//	skipForSQLite: "https://github.com/FerretDB/FerretDB/issues/3183",
 		},
 		"UpdateNonExistentUpsert": {
-			filter:        bson.D{{"_id", "non-existent"}},
-			update:        bson.D{{"$set", bson.D{{"v", int32(42)}}}},
-			updateOpts:    options.Update().SetUpsert(true),
-			resultType:    emptyResult,
-			skipForSQLite: "https://github.com/FerretDB/FerretDB/issues/3183",
+			filter:     bson.D{{"_id", "non-existent"}},
+			update:     bson.D{{"$set", bson.D{{"v", int32(42)}}}},
+			updateOpts: options.Update().SetUpsert(true),
+			resultType: emptyResult,
+			// skipForSQLite: "https://github.com/FerretDB/FerretDB/issues/3183",
 		},
 	}
 

--- a/internal/handlers/sqlite/msg_update.go
+++ b/internal/handlers/sqlite/msg_update.go
@@ -44,14 +44,31 @@ func (h *Handler) MsgUpdate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 	// TODO https://github.com/FerretDB/FerretDB/issues/2612
 	_ = params.Ordered
 
+	var we *writeError
+
 	matched, modified, upserted, err := h.updateDocument(ctx, params)
 	if err != nil {
-		return nil, lazyerrors.Error(err)
+		switch {
+		case backends.ErrorCodeIs(err, backends.ErrorCodeInsertDuplicateID):
+			// TODO https://github.com/FerretDB/FerretDB/issues/3263
+			we = &writeError{
+				index:  int32(0),
+				code:   commonerrors.ErrDuplicateKeyInsert,
+				errmsg: fmt.Sprintf(`E11000 duplicate key error collection: %s.%s`, params.DB, params.Collection),
+			}
+
+		default:
+			return nil, lazyerrors.Error(err)
+		}
 	}
 
 	res := must.NotFail(types.NewDocument(
 		"n", matched,
 	))
+
+	if we != nil {
+		res.Set("writeErrors", must.NotFail(types.NewArray(we.Document())))
+	}
 
 	if upserted.Len() != 0 {
 		res.Set("upserted", upserted)


### PR DESCRIPTION
# Description

Closes #3183.

The approach with `WriteError` is the same as in `msg_insert` for consistency purposes.

<!--
    Write a short description to explain changes that are not mentioned in the initial issue.
    What were the reasons for those changes?
    Which decisions did you make and why?
    What else should reviewers know about your changes?
-->

## Readiness checklist

<!--
    If you want your changes to be merged quickly,
    please follow CONTRIBUTING.md.
-->

- [ ] I added/updated unit tests (and they pass).
- [x] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
