### PR TITLE
Use consistent spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -344,7 +344,7 @@ This and earlier versions of FerretDB with Tigris support will still be availabl
 - Tweak contributing guidelines by @AlekSi in https://github.com/FerretDB/FerretDB/pull/2886
 - Add handler's metrics registration by @AlekSi in https://github.com/FerretDB/FerretDB/pull/2895
 - Clean-up some code and comments by @AlekSi in https://github.com/FerretDB/FerretDB/pull/2904
-- Fix cancelation signals propagation by @AlekSi in https://github.com/FerretDB/FerretDB/pull/2908
+- Fix cancellation signals propagation by @AlekSi in https://github.com/FerretDB/FerretDB/pull/2908
 - Bump deps, add permissions monitoring by @AlekSi in https://github.com/FerretDB/FerretDB/pull/2930
 - Fix integration tests after bumping deps by @noisersup in https://github.com/FerretDB/FerretDB/pull/2934
 - Update benchmark to use cursors by @AlekSi in https://github.com/FerretDB/FerretDB/pull/2932

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,7 +212,8 @@ If, on the other hand, you see code that is inconsistent without apparent reason
 please improve it as you work on it.
 
 Our code follows most of the standard Go conventions,
-documented on [CodeReviewComments wiki page](https://github.com/golang/go/wiki/CodeReviewComments).
+documented on [CodeReviewComments wiki page](https://github.com/golang/go/wiki/CodeReviewComments)
+and some other pages such as [Spelling](https://github.com/golang/go/wiki/Spelling).
 Some of our idiosyncrasies:
 
 1. We use type switches over BSON types in many places in our code.

--- a/internal/bson/bson_test.go
+++ b/internal/bson/bson_test.go
@@ -118,7 +118,7 @@ func testBinary(t *testing.T, testCases []testCase, newFunc func() bsontype) {
 					err := v.ReadFrom(bufr)
 					assert.NoError(t, err)
 					if assertEqual(t, tc.v, v, "expected: %s\nactual  : %s", tc.v, v) {
-						t.Log("values are equal after unmarshalling")
+						t.Log("values are equal after unmarshaling")
 					}
 					assert.Zero(t, br.Len(), "not all br bytes were consumed")
 					assert.Zero(t, bufr.Buffered(), "not all bufr bytes were consumed")
@@ -180,7 +180,7 @@ func fuzzBinary(f *testing.F, testCases []testCase, newFunc func() bsontype) {
 				err = v2.ReadFrom(bufr2)
 				assert.NoError(t, err)
 				if assertEqual(t, v, v2, "expected: %s\nactual  : %s", v, v2) {
-					t.Log("values are equal after unmarshalling")
+					t.Log("values are equal after unmarshaling")
 				}
 				assert.Zero(t, br2.Len(), "not all br bytes were consumed")
 				assert.Zero(t, bufr2.Buffered(), "not all bufr bytes were consumed")

--- a/internal/handlers/pg/msg_aggregate.go
+++ b/internal/handlers/pg/msg_aggregate.go
@@ -362,7 +362,7 @@ func processStagesDocuments(ctx context.Context, closer *iterator.MultiCloser, p
 	closer.Add(iterator.CloserFunc(func() {
 		// It does not matter if we commit or rollback the read transaction,
 		// but we should close it.
-		// ctx could be cancelled already.
+		// ctx could be canceled already.
 		_ = keepTx.Rollback(context.Background())
 	}))
 

--- a/internal/handlers/pg/msg_find.go
+++ b/internal/handlers/pg/msg_find.go
@@ -143,7 +143,7 @@ func (h *Handler) MsgFind(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, er
 	closer.Add(iterator.CloserFunc(func() {
 		// It does not matter if we commit or rollback the read transaction,
 		// but we should close it.
-		// ctx could be cancelled already.
+		// ctx could be canceled already.
 		_ = keepTx.Rollback(context.Background())
 	}))
 


### PR DESCRIPTION
# Description

Speling is importent.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [x] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [x] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
