### PR TITLE
Remove the need to close `conninfo`

### DIFF
--- a/internal/clientconn/conn.go
+++ b/internal/clientconn/conn.go
@@ -134,14 +134,12 @@ func (c *conn) run(ctx context.Context) (err error) {
 		cancel(lazyerrors.Errorf("run exits: %w", err))
 	}()
 
-	connInfo := conninfo.NewConnInfo()
-	defer connInfo.Close()
-
+	connInfo := conninfo.New()
 	if c.netConn.RemoteAddr().Network() != "unix" {
 		connInfo.PeerAddr = c.netConn.RemoteAddr().String()
 	}
 
-	ctx = conninfo.WithConnInfo(ctx, connInfo)
+	ctx = conninfo.Ctx(ctx, connInfo)
 
 	done := make(chan struct{})
 

--- a/internal/clientconn/conninfo/conn_info.go
+++ b/internal/clientconn/conninfo/conn_info.go
@@ -18,8 +18,6 @@ package conninfo
 import (
 	"context"
 	"sync"
-
-	"github.com/FerretDB/FerretDB/internal/util/resource"
 )
 
 // contextKey is a named unexported type for the safe use of context.WithValue.
@@ -32,26 +30,14 @@ var connInfoKey = contextKey{}
 type ConnInfo struct {
 	PeerAddr string
 
-	token *resource.Token
-
 	rw       sync.RWMutex
 	username string
 	password string
 }
 
-// NewConnInfo return a new ConnInfo.
-func NewConnInfo() *ConnInfo {
-	connInfo := &ConnInfo{
-		token: resource.NewToken(),
-	}
-	resource.Track(connInfo, connInfo.token)
-
-	return connInfo
-}
-
-// Close frees resources.
-func (connInfo *ConnInfo) Close() {
-	resource.Untrack(connInfo, connInfo.token)
+// New returns a new ConnInfo.
+func New() *ConnInfo {
+	return new(ConnInfo)
 }
 
 // Auth returns stored username and password.
@@ -71,8 +57,8 @@ func (connInfo *ConnInfo) SetAuth(username, password string) {
 	connInfo.password = password
 }
 
-// WithConnInfo returns a new context with the given ConnInfo.
-func WithConnInfo(ctx context.Context, connInfo *ConnInfo) context.Context {
+// Ctx returns a derived context with the given ConnInfo.
+func Ctx(ctx context.Context, connInfo *ConnInfo) context.Context {
 	return context.WithValue(ctx, connInfoKey, connInfo)
 }
 

--- a/internal/clientconn/conninfo/conn_info_test.go
+++ b/internal/clientconn/conninfo/conn_info_test.go
@@ -42,7 +42,7 @@ func TestGet(t *testing.T) {
 			connInfo := &ConnInfo{
 				PeerAddr: tc.peerAddr,
 			}
-			ctx = WithConnInfo(ctx, connInfo)
+			ctx = Ctx(ctx, connInfo)
 			actual := Get(ctx)
 			assert.Equal(t, connInfo, actual)
 		})


### PR DESCRIPTION
# Description

It is a simple object now.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [x] I made spot refactorings.
- [ ] I updated user documentation.
- [x] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
