### PR TITLE
Show the problem with index names

### DIFF
--- a/internal/backends/postgresql/metadata/registry.go
+++ b/internal/backends/postgresql/metadata/registry.go
@@ -797,6 +797,7 @@ func (r *Registry) indexesCreate(ctx context.Context, p *pgxpool.Pool, dbName, c
 				break
 			}
 
+			r.l.Error("Index name is not unique, generating a new one", zap.String("name", pgIndexName), zap.Uint32("s", s))
 			s++
 		}
 


### PR DESCRIPTION
```
env GOFLAGS=-v task test-integration-postgresql TEST_RUN='TestAggregateCompatGroup'
```

```
=== NAME  TestAggregateCompatGroupCount
    logger.go:130: 2023-10-05T21:00:45.724+0400	ERROR	postgresql	metadata/registry.go:800	Index name is not unique, generating a new one	{"name": "testaggregatecompatgroupcount___id_", "s": 2303296858}
=== NAME  TestAggregateCompatGroupSum
    logger.go:130: 2023-10-05T21:00:45.724+0400	ERROR	postgresql	metadata/registry.go:800	Index name is not unique, generating a new one	{"name": "testaggregatecompatgroupsum_do__id_", "s": 2529296350}
=== NAME  TestAggregateCompatGroupDeterministicCollections
    logger.go:130: 2023-10-05T21:00:45.724+0400	ERROR	postgresql	metadata/registry.go:800	Index name is not unique, generating a new one	{"name": "testaggregatecompatgroupdeterm__id_", "s": 736613472}
=== NAME  TestAggregateCompatGroupCount
    logger.go:130: 2023-10-05T21:00:45.724+0400	ERROR	postgresql	metadata/registry.go:800	Index name is not unique, generating a new one	{"name": "testaggregatecompatgroupcount___id_", "s": 2303296859}
=== NAME  TestAggregateCompatGroupSum
    logger.go:130: 2023-10-05T21:00:45.724+0400	ERROR	postgresql	metadata/registry.go:800	Index name is not unique, generating a new one	{"name": "testaggregatecompatgroupsum_do__id_", "s": 2529296351}
=== NAME  TestAggregateCompatGroupCount
    logger.go:130: 2023-10-05T21:00:45.724+0400	ERROR	postgresql	metadata/registry.go:800	Index name is not unique, generating a new one	{"name": "testaggregatecompatgroupcount___id_", "s": 2303296860}
=== NAME  TestAggregateCompatGroupSum
    logger.go:130: 2023-10-05T21:00:45.724+0400	ERROR	postgresql	metadata/registry.go:800	Index name is not unique, generating a new one	{"name": "testaggregatecompatgroupsum_do__id_", "s": 2529296352}
```

Note that `s` hash is never included. I guess our math is broken after all.