### PR TITLE
Add filter pushdown for `_id: <string>` for SQLite

### DIFF
--- a/integration/pushdown.go
+++ b/integration/pushdown.go
@@ -21,7 +21,7 @@ import (
 )
 
 // resultPushdown stores the information about expected pushdown results for a single or multiple backends.
-// For example if both pg and SQlite backends are expected to pushdown, the `pgPushdown + sqlitePushdown` operation
+// For example if both pg and SQlite backends are expected to pushdown, the `pgPushdown | sqlitePushdown` operation
 // can be used.
 type resultPushdown uint8
 

--- a/integration/query_comparison_compat_test.go
+++ b/integration/query_comparison_compat_test.go
@@ -263,7 +263,7 @@ func TestQueryComparisonCompatImplicit(t *testing.T) {
 		},
 		"IDString": {
 			filter:         bson.D{{"_id", "string"}},
-			resultPushdown: pgPushdown,
+			resultPushdown: allPushdown,
 		},
 		"IDObjectID": {
 			filter:         bson.D{{"_id", primitive.NilObjectID}},

--- a/integration/query_compat_test.go
+++ b/integration/query_compat_test.go
@@ -211,7 +211,7 @@ func TestQueryCompatFilter(t *testing.T) {
 		},
 		"IDString": {
 			filter:         bson.D{{"_id", "string"}},
-			resultPushdown: pgPushdown,
+			resultPushdown: allPushdown,
 		},
 		"IDNilObjectID": {
 			filter:         bson.D{{"_id", primitive.NilObjectID}},

--- a/integration/query_projection_compat_test.go
+++ b/integration/query_projection_compat_test.go
@@ -238,7 +238,7 @@ func TestQueryProjectionPositionalOperatorCompat(t *testing.T) {
 			// e.g. missing {v: <val>} in the filter.
 			filter:         bson.D{{"_id", "array"}},
 			projection:     bson.D{{"v.$", true}},
-			resultPushdown: pgPushdown,
+			resultPushdown: allPushdown,
 		},
 		"Implicit": {
 			filter:         bson.D{{"v", float64(42)}},

--- a/integration/query_test.go
+++ b/integration/query_test.go
@@ -882,7 +882,7 @@ func TestQueryCommandLimitPushDown(t *testing.T) {
 			filter:        bson.D{{"_id", "array"}},
 			limit:         3,
 			len:           1,
-			queryPushdown: pgPushdown,
+			queryPushdown: allPushdown,
 			limitPushdown: false,
 		},
 		"ValueFilter": {
@@ -919,7 +919,7 @@ func TestQueryCommandLimitPushDown(t *testing.T) {
 			sort:          bson.D{{"_id", 1}},
 			limit:         3,
 			len:           1,
-			queryPushdown: pgPushdown,
+			queryPushdown: allPushdown,
 			limitPushdown: false,
 		},
 		"ValueFilterSort": {

--- a/internal/backends/sqlite/collection.go
+++ b/internal/backends/sqlite/collection.go
@@ -71,11 +71,10 @@ func (c *collection) Query(ctx context.Context, params *backends.QueryParams) (*
 	// TODO https://github.com/FerretDB/FerretDB/issues/3235
 	if params != nil && params.Filter.Len() == 1 {
 		v, _ := params.Filter.Get("_id")
-		if v != nil {
-			if id, ok := v.(types.ObjectID); ok {
-				whereClause = fmt.Sprintf(` WHERE %s = ?`, metadata.IDColumn)
-				args = []any{string(must.NotFail(sjson.MarshalSingleValue(id)))}
-			}
+		switch v.(type) {
+		case string, types.ObjectID:
+			whereClause = fmt.Sprintf(` WHERE %s = ?`, metadata.IDColumn)
+			args = []any{string(must.NotFail(sjson.MarshalSingleValue(v)))}
 		}
 	}
 
@@ -247,12 +246,11 @@ func (c *collection) Explain(ctx context.Context, params *backends.ExplainParams
 	// TODO https://github.com/FerretDB/FerretDB/issues/3235
 	if params != nil && params.Filter.Len() == 1 {
 		v, _ := params.Filter.Get("_id")
-		if v != nil {
-			if id, ok := v.(types.ObjectID); ok {
-				queryPushdown = true
-				whereClause = fmt.Sprintf(` WHERE %s = ?`, metadata.IDColumn)
-				args = []any{string(must.NotFail(sjson.MarshalSingleValue(id)))}
-			}
+		switch v.(type) {
+		case string, types.ObjectID:
+			queryPushdown = true
+			whereClause = fmt.Sprintf(` WHERE %s = ?`, metadata.IDColumn)
+			args = []any{string(must.NotFail(sjson.MarshalSingleValue(v)))}
 		}
 	}
 


### PR DESCRIPTION
# Description

It is an ad-hoc filter for an important use-case that covers only the `_id` field because it can't be an array.

Refs #3235.

Closes FerretDB/dance#625.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [x] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [x] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
