### PR TITLE
Optimize detection of duplicate fields

### DIFF
--- a/internal/types/document.go
+++ b/internal/types/document.go
@@ -276,6 +276,7 @@ func (d *Document) Command() string {
 	if d == nil || len(d.fields) == 0 {
 		return ""
 	}
+
 	return d.fields[0].key
 }
 
@@ -468,6 +469,7 @@ func (d *Document) moveIDToTheFirstIndex() {
 	}
 
 	var idIdx int
+
 	for i, field := range d.fields {
 		if field.key == "_id" {
 			idIdx = i

--- a/internal/types/document_test.go
+++ b/internal/types/document_test.go
@@ -112,7 +112,7 @@ func TestDocument(t *testing.T) {
 		assert.False(t, doc.Has("bar"))
 
 		assert.PanicsWithValue(t, "types.Document.Get: key is duplicated: foo", func() {
-			doc.Get("foo")
+			_, _ = doc.Get("foo")
 		})
 		assert.PanicsWithValue(t, "types.Document.Set: key is duplicated: foo", func() {
 			doc.Set("foo", int32(3))

--- a/internal/types/document_test.go
+++ b/internal/types/document_test.go
@@ -46,6 +46,7 @@ func TestDocument(t *testing.T) {
 
 		// to avoid {} != nil in tests
 		assert.Nil(t, must.NotFail(NewDocument()).fields)
+		assert.Nil(t, must.NotFail(NewDocument()).keys)
 
 		var doc Document
 		assert.Equal(t, 0, doc.Len())
@@ -99,6 +100,26 @@ func TestDocument(t *testing.T) {
 		a.Set("foo", "bar")
 		assert.NotEqual(t, a, b)
 		assert.Equal(t, int32(42), must.NotFail(b.Get("foo")))
+	})
+
+	t.Run("Duplicates", func(t *testing.T) {
+		t.Parallel()
+
+		doc, err := NewDocument("foo", int32(1), "foo", int32(2))
+		require.NoError(t, err)
+
+		assert.True(t, doc.Has("foo"))
+		assert.False(t, doc.Has("bar"))
+
+		assert.PanicsWithValue(t, "types.Document.Get: key is duplicated: foo", func() {
+			doc.Get("foo")
+		})
+		assert.PanicsWithValue(t, "types.Document.Set: key is duplicated: foo", func() {
+			doc.Set("foo", int32(3))
+		})
+		assert.PanicsWithValue(t, "types.Document.Remove: key is duplicated: foo", func() {
+			doc.Remove("foo")
+		})
 	})
 
 	t.Run("SortFieldsByKey", func(t *testing.T) {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -54,6 +54,7 @@ package types
 
 import (
 	"fmt"
+	"maps"
 	"time"
 )
 
@@ -137,6 +138,7 @@ func deepCopy(value any) any {
 
 		return &Document{
 			fields:   fields,
+			keys:     maps.Clone(value.keys),
 			recordID: value.recordID,
 		}
 


### PR DESCRIPTION
# Description

We don't want to fully remove or refactor that code just yet (that's #2412), but we can make it quicker… quickly.

```
task: [bench-postgresql] ../bin/benchstat old-postgresql.txt new-postgresql.txt
goos: darwin
goarch: arm64
pkg: github.com/FerretDB/FerretDB/integration
                                                          │ old-postgresql.txt │          new-postgresql.txt          │
                                                          │       sec/op       │    sec/op     vs base                │
Find/SmallDocuments/Docs1000/7dc4/Int32ID-10                      2.237m ±  6%   2.102m ± 14%        ~ (p=0.165 n=10)
Find/SmallDocuments/Docs1000/7dc4/Int32One-10                     2.337m ±  6%   1.902m ± 11%  -18.62% (p=0.000 n=10)
Find/SmallDocuments/Docs1000/7dc4/Int32Many-10                    7.425m ±  1%   7.161m ±  1%   -3.55% (p=0.000 n=10)
Find/SmallDocuments/Docs1000/7dc4/Int32ManyDotNotation-10         20.62m ±  0%   19.20m ±  3%   -6.90% (p=0.000 n=10)
ReplaceOne/SettingsDocuments/Docs1000/b34e-10                     36.25m ±  1%   25.30m ±  1%  -30.21% (p=0.000 n=10)
InsertMany/SmallDocuments/Docs1000/7dc4/Batch1-10                 550.9m ±  1%   551.7m ±  1%        ~ (p=0.971 n=10)
InsertMany/SmallDocuments/Docs1000/7dc4/Batch10-10                467.7m ±  3%   472.4m ±  5%        ~ (p=0.912 n=10)
InsertMany/SmallDocuments/Docs1000/7dc4/Batch100-10               474.2m ±  2%   483.0m ±  5%        ~ (p=0.089 n=10)
InsertMany/SmallDocuments/Docs1000/7dc4/Batch1000-10              471.8m ±  3%   467.3m ±  3%        ~ (p=0.105 n=10)
InsertMany/SettingsDocuments/Docs1000/b34e/Batch1-10               5.793 ±  5%    5.857 ± 10%        ~ (p=0.684 n=10)
InsertMany/SettingsDocuments/Docs1000/b34e/Batch10-10              1.578 ±  2%    1.532 ±  1%   -2.92% (p=0.000 n=10)
InsertMany/SettingsDocuments/Docs1000/b34e/Batch100-10             1.448 ±  3%    1.443 ±  2%        ~ (p=0.123 n=10)
InsertMany/SettingsDocuments/Docs1000/b34e/Batch1000-10            1.723 ± 31%    1.676 ±  3%        ~ (p=0.075 n=10)
geomean                                                           158.0m         148.9m         -5.71%

                                                          │ old-postgresql.txt │          new-postgresql.txt          │
                                                          │        B/op        │     B/op      vs base                │
Find/SmallDocuments/Docs1000/7dc4/Int32ID-10                      113.8Ki ± 0%   117.6Ki ± 0%   +3.31% (p=0.000 n=10)
Find/SmallDocuments/Docs1000/7dc4/Int32One-10                     113.9Ki ± 0%   117.7Ki ± 0%   +3.37% (p=0.000 n=10)
Find/SmallDocuments/Docs1000/7dc4/Int32Many-10                    6.670Mi ± 0%   6.947Mi ± 0%   +4.15% (p=0.000 n=10)
Find/SmallDocuments/Docs1000/7dc4/Int32ManyDotNotation-10         18.91Mi ± 0%   19.59Mi ± 0%   +3.62% (p=0.000 n=10)
ReplaceOne/SettingsDocuments/Docs1000/b34e-10                    36.159Mi ± 0%   1.547Mi ± 0%  -95.72% (p=0.000 n=10)
InsertMany/SmallDocuments/Docs1000/7dc4/Batch1-10                 65.81Mi ± 0%   68.32Mi ± 0%   +3.82% (p=0.000 n=10)
InsertMany/SmallDocuments/Docs1000/7dc4/Batch10-10                21.92Mi ± 0%   22.28Mi ± 0%   +1.60% (p=0.000 n=10)
InsertMany/SmallDocuments/Docs1000/7dc4/Batch100-10               17.60Mi ± 0%   17.73Mi ± 0%   +0.74% (p=0.000 n=10)
InsertMany/SmallDocuments/Docs1000/7dc4/Batch1000-10              17.30Mi ± 0%   17.42Mi ± 0%   +0.72% (p=0.000 n=10)
InsertMany/SettingsDocuments/Docs1000/b34e/Batch1-10              754.0Mi ± 0%   591.1Mi ± 0%  -21.60% (p=0.000 n=10)
InsertMany/SettingsDocuments/Docs1000/b34e/Batch10-10             804.4Mi ± 0%   639.6Mi ± 0%  -20.48% (p=0.000 n=10)
InsertMany/SettingsDocuments/Docs1000/b34e/Batch100-10            842.5Mi ± 0%   677.3Mi ± 0%  -19.60% (p=0.000 n=10)
InsertMany/SettingsDocuments/Docs1000/b34e/Batch1000-10           833.1Mi ± 0%   668.3Mi ± 0%  -19.78% (p=0.000 n=10)
geomean                                                           29.06Mi        21.61Mi       -25.65%

                                                          │ old-postgresql.txt │         new-postgresql.txt          │
                                                          │     allocs/op      │  allocs/op   vs base                │
Find/SmallDocuments/Docs1000/7dc4/Int32ID-10                       1.006k ± 0%   1.014k ± 0%   +0.79% (p=0.000 n=10)
Find/SmallDocuments/Docs1000/7dc4/Int32One-10                      1.010k ± 0%   1.020k ± 0%   +0.99% (p=0.000 n=10)
Find/SmallDocuments/Docs1000/7dc4/Int32Many-10                     58.17k ± 0%   58.43k ± 0%   +0.45% (p=0.000 n=10)
Find/SmallDocuments/Docs1000/7dc4/Int32ManyDotNotation-10          173.5k ± 0%   174.8k ± 0%   +0.73% (p=0.000 n=10)
ReplaceOne/SettingsDocuments/Docs1000/b34e-10                     26.750k ± 0%   6.419k ± 0%  -76.00% (p=0.000 n=10)
InsertMany/SmallDocuments/Docs1000/7dc4/Batch1-10                  693.7k ± 0%   698.3k ± 0%   +0.66% (p=0.000 n=10)
InsertMany/SmallDocuments/Docs1000/7dc4/Batch10-10                 301.6k ± 0%   300.1k ± 0%   -0.51% (p=0.000 n=10)
InsertMany/SmallDocuments/Docs1000/7dc4/Batch100-10                261.9k ± 0%   259.7k ± 0%   -0.83% (p=0.000 n=10)
InsertMany/SmallDocuments/Docs1000/7dc4/Batch1000-10               258.7k ± 0%   256.4k ± 0%   -0.87% (p=0.000 n=10)
InsertMany/SettingsDocuments/Docs1000/b34e/Batch1-10               3.071M ± 0%   2.980M ± 0%   -2.97% (p=0.000 n=10)
InsertMany/SettingsDocuments/Docs1000/b34e/Batch10-10              2.668M ± 0%   2.570M ± 0%   -3.68% (p=0.000 n=10)
InsertMany/SettingsDocuments/Docs1000/b34e/Batch100-10             2.620M ± 0%   2.521M ± 0%   -3.78% (p=0.000 n=10)
InsertMany/SettingsDocuments/Docs1000/b34e/Batch1000-10            2.613M ± 0%   2.515M ± 0%   -3.76% (p=0.000 n=10)
geomean                                                            180.7k        160.3k       -11.29%
```

Refs #3633.
Refs #2412.

## Readiness checklist

- [x] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [x] I made spot refactorings.
- [ ] I updated user documentation.
- [x] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
