### PR TITLE
Support limit pushdown when filter and sort can apply pushdown entirely

### DIFF
--- a/integration/pushdown.go
+++ b/integration/pushdown.go
@@ -65,6 +65,11 @@ func (res resultPushdown) SortPushdownExpected(t testtb.TB, cappedCollection boo
 	return res.pushdownExpected(t)
 }
 
+// LimitPushdownExpected returns true if the limit pushdown is expected for currently running backend.
+func (res resultPushdown) LimitPushdownExpected(t testtb.TB) bool {
+	return res.pushdownExpected(t)
+}
+
 // pushdownExpected returns true if pushdown is expected for currently running backend.
 func (res resultPushdown) pushdownExpected(t testtb.TB) bool {
 	switch {

--- a/integration/query_test.go
+++ b/integration/query_test.go
@@ -905,7 +905,14 @@ func TestQueryCommandLimitPushDown(t *testing.T) {
 			limit:         2,
 			len:           2,
 			queryPushdown: noPushdown,
-			limitPushdown: allPushdown,
+			limitPushdown: pgPushdown,
+		},
+		"MoreSort": {
+			sort:          bson.D{bson.E{"_id", 1}, bson.E{"v", -1}},
+			limit:         2,
+			len:           2,
+			queryPushdown: noPushdown,
+			limitPushdown: noPushdown,
 		},
 		"IDFilterSort": {
 			filter:        bson.D{{"_id", "array"}},
@@ -913,7 +920,7 @@ func TestQueryCommandLimitPushDown(t *testing.T) {
 			limit:         3,
 			len:           1,
 			queryPushdown: allPushdown,
-			limitPushdown: noPushdown,
+			limitPushdown: pgPushdown,
 		},
 		"ValueFilterSort": {
 			filter:        bson.D{{"v", 42}},
@@ -998,6 +1005,10 @@ func TestQueryCommandLimitPushDown(t *testing.T) {
 					tc.limitPushdown = noPushdown
 					msg = "Sort pushdown is disabled, but target resulted with limitPushdown"
 				}
+				if setup.IsPushdownDisabled() && tc.filter != nil {
+					tc.limitPushdown = noPushdown
+					msg = "Query pushdown is disabled, but target resulted with limitPushdown"
+				}
 
 				queryResultPushdown := tc.queryPushdown
 				limitResultPushdown := tc.limitPushdown
@@ -1009,7 +1020,7 @@ func TestQueryCommandLimitPushDown(t *testing.T) {
 
 				doc := ConvertDocument(t, res)
 				limitPushdown, _ := doc.Get("limitPushdown")
-				assert.Equal(t, limitResultPushdown.PushdownExpected(t), limitPushdown, msg)
+				assert.Equal(t, limitResultPushdown.LimitPushdownExpected(t), limitPushdown, msg)
 
 				queryPushdown, _ := doc.Get("pushdown")
 				assert.Equal(t, queryResultPushdown.PushdownExpected(t), queryPushdown, msg)

--- a/internal/backends/postgresql/query.go
+++ b/internal/backends/postgresql/query.go
@@ -211,8 +211,8 @@ func prepareWhereClause(p *metadata.Placeholder, sqlFilters *types.Document) (st
 }
 
 // prepareOrderByClause returns ORDER BY clause for given sort field and returns the query and arguments.
-// It returns false if pushdown for provided field couldn't be applied. Otherwise, if pushdown was applied, or field is nil, it returns true.
-//
+// It returns false if pushdown for provided field couldn't be applied.
+// Otherwise, if pushdown was applied, or field is nil, it returns true.
 // For capped collection, it returns ORDER BY recordID only if sort field is nil.
 func prepareOrderByClause(p *metadata.Placeholder, sort *backends.SortField, capped bool) (string, []any, bool) {
 	if sort == nil {

--- a/internal/backends/postgresql/query.go
+++ b/internal/backends/postgresql/query.go
@@ -210,6 +210,7 @@ func prepareWhereClause(p *metadata.Placeholder, sqlFilters *types.Document) (st
 }
 
 // prepareOrderByClause returns ORDER BY clause for given sort field and returns the query and arguments.
+// It returns false if pushdown for provided field couldn't be applied. Otherwise, if pushdown was applied, or field is nil, it returns true.
 //
 // For capped collection, it returns ORDER BY recordID only if sort field is nil.
 func prepareOrderByClause(p *metadata.Placeholder, sort *backends.SortField, capped bool) (string, []any, bool) {

--- a/internal/backends/postgresql/query.go
+++ b/internal/backends/postgresql/query.go
@@ -63,6 +63,7 @@ func prepareSelectClause(schema, table string, capped, onlyRecordIDs bool) strin
 }
 
 // prepareWhereClause adds WHERE clause with given filters to the query and returns the query and arguments.
+// It returns false if pushdown for at least one filter couldn't be applied.
 func prepareWhereClause(p *metadata.Placeholder, sqlFilters *types.Document) (string, []any, bool, error) {
 	var filters []string
 	var args []any

--- a/internal/backends/postgresql/query_test.go
+++ b/internal/backends/postgresql/query_test.go
@@ -241,7 +241,7 @@ func TestPrepareWhereClause(t *testing.T) {
 				t.Skip(tc.skip)
 			}
 
-			actual, args, err := prepareWhereClause(new(metadata.Placeholder), tc.filter)
+			actual, args, _, err := prepareWhereClause(new(metadata.Placeholder), tc.filter)
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.expected, actual)
@@ -306,7 +306,7 @@ func TestPrepareOrderByClause(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			orderBy, args := prepareOrderByClause(new(metadata.Placeholder), tc.sort, tc.capped)
+			orderBy, args, _ := prepareOrderByClause(new(metadata.Placeholder), tc.sort, tc.capped)
 			assert.Equal(t, tc.orderBy, orderBy)
 			assert.Equal(t, tc.args, args)
 		})

--- a/internal/handlers/sqlite/msg_explain.go
+++ b/internal/handlers/sqlite/msg_explain.go
@@ -107,13 +107,16 @@ func (h *Handler) MsgExplain(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg,
 
 	// Limit pushdown is not applied if:
 	//  - `filter` is set but can not be applied pushdown entirely,
+	//  or `filter` is set and `DisableFilterPushdown` is set,
 	//  it must fetch all documents to filter them in memory;
 	//  - `sort` is set but can not be applied pushdown entirely,
 	//  or `sort` is set but `EnableSortPushdown` is not set,
 	//  it must fetch all documents and sort them in memory;
 	//  - `skip` is non-zero value, skip pushdown is not supported yet.
 	// More checks are performed when preparing LIMIT clause.
-	if (params.Sort.Len() == 0 || h.EnableSortPushdown) && params.Skip == 0 {
+	if (params.Filter.Len() == 0 || !h.DisableFilterPushdown) &&
+		(params.Sort.Len() == 0 || (h.EnableSortPushdown && params.Sort.Len() == 1)) &&
+		params.Skip == 0 {
 		qp.Limit = params.Limit
 	}
 

--- a/internal/handlers/sqlite/msg_explain.go
+++ b/internal/handlers/sqlite/msg_explain.go
@@ -106,11 +106,14 @@ func (h *Handler) MsgExplain(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg,
 	}
 
 	// Limit pushdown is not applied if:
-	//  - `filter` is set, it must fetch all documents to filter them in memory;
-	//  - `sort` is set but `EnableSortPushdown` is not set, it must fetch all documents
-	//  and sort them in memory;
+	//  - `filter` is set but can not be applied pushdown entirely,
+	//  it must fetch all documents to filter them in memory;
+	//  - `sort` is set but can not be applied pushdown entirely,
+	//  or `sort` is set but `EnableSortPushdown` is not set,
+	//  it must fetch all documents and sort them in memory;
 	//  - `skip` is non-zero value, skip pushdown is not supported yet.
-	if params.Filter.Len() == 0 && (params.Sort.Len() == 0 || h.EnableSortPushdown) && params.Skip == 0 {
+	// More checks are performed when preparing LIMIT clause.
+	if (params.Sort.Len() == 0 || h.EnableSortPushdown) && params.Skip == 0 {
 		qp.Limit = params.Limit
 	}
 

--- a/internal/handlers/sqlite/msg_find.go
+++ b/internal/handlers/sqlite/msg_find.go
@@ -99,11 +99,14 @@ func (h *Handler) MsgFind(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, er
 	}
 
 	// Limit pushdown is not applied if:
-	//  - `filter` is set, it must fetch all documents to filter them in memory;
-	//  - `sort` is set but `EnableSortPushdown` is not set, it must fetch all documents
-	//  and sort them in memory;
+	//  - `filter` is set but can not be applied pushdown entirely,
+	//  it must fetch all documents to filter them in memory;
+	//  - `sort` is set but can not be applied pushdown entirely,
+	//  or `sort` is set but `EnableSortPushdown` is not set,
+	//  it must fetch all documents and sort them in memory;
 	//  - `skip` is non-zero value, skip pushdown is not supported yet.
-	if params.Filter.Len() == 0 && (params.Sort.Len() == 0 || h.EnableSortPushdown) && params.Skip == 0 {
+	// More checks are performed when preparing LIMIT clause.
+	if (params.Sort.Len() == 0 || h.EnableSortPushdown) && params.Skip == 0 {
 		qp.Limit = params.Limit
 	}
 

--- a/internal/handlers/sqlite/msg_find.go
+++ b/internal/handlers/sqlite/msg_find.go
@@ -100,13 +100,16 @@ func (h *Handler) MsgFind(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, er
 
 	// Limit pushdown is not applied if:
 	//  - `filter` is set but can not be applied pushdown entirely,
+	//  or `filter` is set and `DisableFilterPushdown` is set,
 	//  it must fetch all documents to filter them in memory;
 	//  - `sort` is set but can not be applied pushdown entirely,
 	//  or `sort` is set but `EnableSortPushdown` is not set,
 	//  it must fetch all documents and sort them in memory;
 	//  - `skip` is non-zero value, skip pushdown is not supported yet.
 	// More checks are performed when preparing LIMIT clause.
-	if (params.Sort.Len() == 0 || h.EnableSortPushdown) && params.Skip == 0 {
+	if (params.Filter.Len() == 0 || !h.DisableFilterPushdown) &&
+		(params.Sort.Len() == 0 || (h.EnableSortPushdown && params.Sort.Len() == 1)) &&
+		params.Skip == 0 {
 		qp.Limit = params.Limit
 	}
 


### PR DESCRIPTION


# Description

To support limit pushdown when filter and sort can apply pushdown entirely:
1. Loose limit pushdown conditions in handler.
2. Add a boolean return value to functions prepareWhereClause and prepareOrderByClause to reuse current logic to check if some filters or sort can not be applied pushdown. Only if prepareWhereClause and prepareOrderByClause does not find any parameters that cannot be pushed down, will apply limit pushdown.
3. Update some integration tests and add comments.

Closes #3644.

## Readiness checklist

<!-- Please check all items in this checklist that were done. -->

- [x] I added/updated unit tests (and they pass).
- [x] I added/updated integration/compatibility tests (and they pass).
- [x] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [x] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
