### PR TITLE
Add option to disable `--debug-addr`.

### DIFF
--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -331,12 +331,14 @@ func run() {
 
 	var wg sync.WaitGroup
 
-	wg.Add(1)
+	if cli.DebugAddr != "" {
+		wg.Add(1)
 
-	go func() {
-		defer wg.Done()
-		debug.RunHandler(ctx, cli.DebugAddr, metricsRegisterer, logger.Named("debug"))
-	}()
+		go func() {
+			defer wg.Done()
+			debug.RunHandler(ctx, cli.DebugAddr, metricsRegisterer, logger.Named("debug"))
+		}()
+	}
 
 	metrics := connmetrics.NewListenerMetrics()
 

--- a/website/docs/configuration/flags.md
+++ b/website/docs/configuration/flags.md
@@ -31,16 +31,16 @@ Some default values are overridden in [our Docker image](../quickstart-guide/doc
 
 ## Interfaces
 
-| Flag                     | Description                                                     | Environment Variable            | Default Value                                |
-| ------------------------ | --------------------------------------------------------------- | ------------------------------- | -------------------------------------------- |
-| `--listen-addr`          | Listen TCP address                                              | `FERRETDB_LISTEN_ADDR`          | `127.0.0.1:27017`<br />(`:27017` for Docker) |
-| `--listen-unix`          | Listen Unix domain socket path                                  | `FERRETDB_LISTEN_UNIX`          |                                              |
-| `--listen-tls`           | Listen TLS address (see [here](../security/tls-connections.md)) | `FERRETDB_LISTEN_TLS`           |                                              |
-| `--listen-tls-cert-file` | TLS cert file path                                              | `FERRETDB_LISTEN_TLS_CERT_FILE` |                                              |
-| `--listen-tls-key-file`  | TLS key file path                                               | `FERRETDB_LISTEN_TLS_KEY_FILE`  |                                              |
-| `--listen-tls-ca-file`   | TLS CA file path                                                | `FERRETDB_LISTEN_TLS_CA_FILE`   |                                              |
-| `--proxy-addr`           | Proxy address                                                   | `FERRETDB_PROXY_ADDR`           |                                              |
-| `--debug-addr`           | Listen address for HTTP handlers for metrics, pprof, etc        | `FERRETDB_DEBUG_ADDR`           | `127.0.0.1:8088`<br />(`:8088` for Docker)   |
+| Flag                     | Description                                                                                 | Environment Variable            | Default Value                                |
+| ------------------------ | ------------------------------------------------------------------------------------------- | ------------------------------- | -------------------------------------------- |
+| `--listen-addr`          | Listen TCP address                                                                          | `FERRETDB_LISTEN_ADDR`          | `127.0.0.1:27017`<br />(`:27017` for Docker) |
+| `--listen-unix`          | Listen Unix domain socket path                                                              | `FERRETDB_LISTEN_UNIX`          |                                              |
+| `--listen-tls`           | Listen TLS address (see [here](../security/tls-connections.md))                             | `FERRETDB_LISTEN_TLS`           |                                              |
+| `--listen-tls-cert-file` | TLS cert file path                                                                          | `FERRETDB_LISTEN_TLS_CERT_FILE` |                                              |
+| `--listen-tls-key-file`  | TLS key file path                                                                           | `FERRETDB_LISTEN_TLS_KEY_FILE`  |                                              |
+| `--listen-tls-ca-file`   | TLS CA file path                                                                            | `FERRETDB_LISTEN_TLS_CA_FILE`   |                                              |
+| `--proxy-addr`           | Proxy address                                                                               | `FERRETDB_PROXY_ADDR`           |                                              |
+| `--debug-addr`           | Listen address for HTTP handlers for metrics, pprof, etc. Set to a blank string to disable. | `FERRETDB_DEBUG_ADDR`           | `127.0.0.1:8088`<br />(`:8088` for Docker)   |
 
 ## Backend handlers
 


### PR DESCRIPTION
To resolve https://github.com/FerretDB/FerretDB/issues/3517

I am brand new to Go and just want to be helpful, so I hope that I don't end up creating more work for your team to review this.