### PR TITLE
Allow the usage of existing PostgreSQL schema

### DIFF
--- a/internal/backends/postgresql/metadata/registry.go
+++ b/internal/backends/postgresql/metadata/registry.go
@@ -311,7 +311,7 @@ func (r *Registry) databaseGetOrCreate(ctx context.Context, p *pgxpool.Pool, dbN
 	}
 
 	q := fmt.Sprintf(
-		`CREATE SCHEMA %s`,
+		`CREATE SCHEMA IF NOT EXISTS %s`,
 		pgx.Identifier{dbName}.Sanitize(),
 	)
 

--- a/internal/backends/postgresql/metadata/registry_test.go
+++ b/internal/backends/postgresql/metadata/registry_test.go
@@ -268,6 +268,25 @@ func TestCreateDropSameStress(t *testing.T) {
 	require.Less(t, int32(1), droppedTotal.Load())
 }
 
+func TestDefaultEmptySchema(t *testing.T) {
+	t.Parallel()
+
+	ctx := conninfo.Ctx(testutil.Ctx(t), conninfo.New())
+	r, _, dbName := createDatabase(t, ctx)
+
+	list, err := r.DatabaseList(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, []string{dbName}, list)
+
+	created, err := r.CollectionCreate(ctx, &CollectionCreateParams{DBName: "public", Name: testutil.CollectionName(t)})
+	require.NoError(t, err)
+	assert.True(t, created)
+
+	list, err = r.DatabaseList(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, []string{dbName, "public"}, list)
+}
+
 func TestCheckDatabaseUpdated(t *testing.T) {
 	t.Parallel()
 

--- a/internal/util/testutil/postgresql.go
+++ b/internal/util/testutil/postgresql.go
@@ -20,8 +20,10 @@ import (
 	"net/url"
 	"testing"
 
+	zapadapter "github.com/jackc/pgx-zap"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/tracelog"
 	"github.com/stretchr/testify/require"
 
 	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
@@ -57,6 +59,11 @@ func TestPostgreSQLURI(tb testtb.TB, ctx context.Context, baseURI string) string
 
 	cfg.MinConns = 0
 	cfg.MaxConns = 1
+
+	cfg.ConnConfig.Tracer = &tracelog.TraceLog{
+		Logger:   zapadapter.NewLogger(Logger(tb)),
+		LogLevel: tracelog.LogLevelTrace,
+	}
 
 	p, err := pgxpool.NewWithConfig(ctx, cfg)
 	require.NoError(tb, err)


### PR DESCRIPTION
# Description

So default schemas like `public` could be used.

## Readiness checklist

- [x] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [x] I made spot refactorings.
- [ ] I updated user documentation.
- [x] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
