### PR TITLE
Extract helper functions to `util` package

### DIFF
--- a/internal/handler/msg_aggregate.go
+++ b/internal/handler/msg_aggregate.go
@@ -36,6 +36,7 @@ import (
 	"github.com/FerretDB/FerretDB/internal/util/iterator"
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
 	"github.com/FerretDB/FerretDB/internal/util/must"
+	"github.com/FerretDB/FerretDB/internal/util/typeutil"
 	"github.com/FerretDB/FerretDB/internal/wire"
 )
 
@@ -109,10 +110,10 @@ func (h *Handler) MsgAggregate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMs
 	}
 
 	// cannot use other existing commonparams function, they return different error codes
-	maxTimeMS, err := commonparams.GetWholeNumberParam(v)
+	maxTimeMS, err := typeutil.GetWholeNumberParam(v)
 	if err != nil {
 		switch {
-		case errors.Is(err, commonparams.ErrUnexpectedType):
+		case errors.Is(err, typeutil.ErrUnexpectedType):
 			if _, ok = v.(types.NullType); ok {
 				return nil, commonerrors.NewCommandErrorMsgWithArgument(
 					commonerrors.ErrBadValue,
@@ -129,19 +130,19 @@ func (h *Handler) MsgAggregate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMs
 				),
 				document.Command(),
 			)
-		case errors.Is(err, commonparams.ErrNotWholeNumber):
+		case errors.Is(err, typeutil.ErrNotWholeNumber):
 			return nil, commonerrors.NewCommandErrorMsgWithArgument(
 				commonerrors.ErrBadValue,
 				"maxTimeMS has non-integral value",
 				document.Command(),
 			)
-		case errors.Is(err, commonparams.ErrLongExceededPositive):
+		case errors.Is(err, typeutil.ErrLongExceededPositive):
 			return nil, commonerrors.NewCommandErrorMsgWithArgument(
 				commonerrors.ErrBadValue,
 				fmt.Sprintf("%s value for maxTimeMS is out of range", types.FormatAnyValue(v)),
 				document.Command(),
 			)
-		case errors.Is(err, commonparams.ErrLongExceededNegative):
+		case errors.Is(err, typeutil.ErrLongExceededNegative):
 			return nil, commonerrors.NewCommandErrorMsgWithArgument(
 				commonerrors.ErrValueNegative,
 				fmt.Sprintf("BSON field 'maxTimeMS' value must be >= 0, actual value '%s'", types.FormatAnyValue(v)),

--- a/internal/util/typeutil/typeutil.go
+++ b/internal/util/typeutil/typeutil.go
@@ -1,0 +1,53 @@
+package typeutil
+
+import (
+	"fmt"
+	"math"
+)
+
+var (
+	// ErrNotWholeNumber is returned when a non-whole number is given.
+	ErrNotWholeNumber = fmt.Errorf("not a whole number")
+	// ErrUnexpectedLeftOpType is returned when an unexpected left operand type is given.
+	ErrUnexpectedLeftOpType = fmt.Errorf("unexpected left operand type")
+	// ErrUnexpectedRightOpType is returned when an unexpected right operand type is given.
+	ErrUnexpectedRightOpType = fmt.Errorf("unexpected right operand type")
+	// ErrLongExceededPositive is returned when a positive long value is given that exceeds the maximum value.
+	ErrLongExceededPositive = fmt.Errorf("long exceeded - positive value")
+	// ErrLongExceededNegative is returned when a negative long value is given that exceeds the minimum value.
+	ErrLongExceededNegative = fmt.Errorf("long exceeded - negative value")
+	// ErrIntExceeded is returned when an int value is given that exceeds the maximum value.
+	ErrIntExceeded = fmt.Errorf("int exceeded")
+	// ErrInfinity is returned when an infinity value is given.
+	ErrInfinity = fmt.Errorf("infinity")
+	// ErrUnexpectedType is returned when an unexpected type is given.
+	ErrUnexpectedType = fmt.Errorf("unexpected type")
+)
+
+// GetWholeNumberParam checks if the given value is int32, int64, or float64 containing a whole number,
+// such as used in the limit, $size, etc.
+func GetWholeNumberParam(value any) (int64, error) {
+	switch value := value.(type) {
+	// add string support
+	// TODO https://github.com/FerretDB/FerretDB/issues/1089
+	case float64:
+		switch {
+		case math.IsInf(value, 1):
+			return 0, ErrInfinity
+		case value > float64(math.MaxInt64):
+			return 0, ErrLongExceededPositive
+		case value < float64(math.MinInt64):
+			return 0, ErrLongExceededNegative
+		case value != math.Trunc(value):
+			return 0, ErrNotWholeNumber
+		}
+
+		return int64(value), nil
+	case int32:
+		return int64(value), nil
+	case int64:
+		return value, nil
+	default:
+		return 0, ErrUnexpectedType
+	}
+}


### PR DESCRIPTION
<!--
Please remove comments like this one, but keep and use the rest of the template.
See CONTRIBUTING.md for details.
-->

# Description

<!--
Write a short description to explain changes that are not mentioned in the initial issue.
What were the reasons for those changes?
Which decisions did you make and why?
What else should reviewers know about your changes?
-->

<!-- Replace <issue_number> with an actual issue number. -->

Closes #3754.

**It's a draft, thus it's failing. Please leave your feedback in the comments.**

As we provide `*types.Document`s to backends for things like sorting, or filtering, the backends require to handle value parsing properly. Thus functions like `GetWholeNumberParam` need to be accessible from `backend` package, if we don't want to repeat our code.

Moving them outside of `handler/commonparams` will make it cleaner, and will make it possible to avoid importing `handler/*` from `backend` package.
It'll might also make `commonparams` responsibilities more straightforward.

Current issues that block this change:
- some functions like `GetBoolOptionalParam` return CommandErrors, which shouldn't be returned at backend level
- `typeutil` "internal" errors such as `ErrLongExceededPositive`, are currently **returned** by some functions in `params` package
- `params` package might also have some functions that are more general and could be in `typeutil` (such as `AssertType`). 
  

## Readiness checklist

<!-- Please check all items in this checklist that were done. -->

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [ ] I ensured that PR title is good enough for the changelog.
- [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [ ] I marked all done items in this checklist.
