### PR TITLE
Allow `system.` prefix for collections for now

### DIFF
--- a/internal/backends/validation.go
+++ b/internal/backends/validation.go
@@ -55,7 +55,8 @@ func validateDatabaseName(name string) error {
 //
 // It follows MongoDB restrictions plus:
 //   - allows only UTF-8 characters;
-//   - disallows '.' prefix (MongoDB fails to work with such collections correctly too);
+//   - allows `system.` prefix ("system" collections are just regular collections);
+//   - disallows `.` prefix (MongoDB fails to work with such collections correctly too);
 //   - disallows `_ferretdb_` prefix.
 //
 // That validation is quite lax because
@@ -67,7 +68,7 @@ func validateCollectionName(name string) error {
 		return NewError(ErrorCodeCollectionNameIsInvalid, nil)
 	}
 
-	if strings.HasPrefix(name, ReservedPrefix) || strings.HasPrefix(name, "system.") {
+	if strings.HasPrefix(name, ReservedPrefix) {
 		return NewError(ErrorCodeCollectionNameIsInvalid, nil)
 	}
 


### PR DESCRIPTION
# Description

That will change once we have authorization.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [x] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [x] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
