### PR TITLE
Add TLS support to proxy mode

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -454,6 +454,26 @@ tasks:
         --test-records-dir=tmp/records
         --test-enable-oplog
 
+  run-proxy-secured:
+    desc: "Run FerretDB in diff-proxy mode (TLS, auth required)"
+    deps: [build-host]
+    cmds:
+      - >
+        bin/ferretdb{{exeExt}}
+        --listen-addr=''
+        --listen-tls=:27018
+        --listen-tls-cert-file=./build/certs/server-cert.pem
+        --listen-tls-key-file=./build/certs/server-key.pem
+        --listen-tls-ca-file=./build/certs/rootCA-cert.pem
+        --proxy-addr=127.0.0.1:47018
+        --proxy-tls-cert-file=./build/certs/client-cert.pem
+        --proxy-tls-key-file=./build/certs/client-key.pem
+        --proxy-tls-ca-file=./build/certs/rootCA-cert.pem
+        --mode=diff-proxy
+        --handler=pg
+        --postgresql-url='postgres://username@127.0.0.1:5433/ferretdb?search_path='
+        --test-records-dir=tmp/records
+
   lint:
     desc: "Run linters"
     cmds:

--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -64,11 +64,17 @@ var cli struct {
 		TLS         string `default:""                help:"Listen TLS address."`
 		TLSCertFile string `default:""                help:"TLS cert file path."`
 		TLSKeyFile  string `default:""                help:"TLS key file path."`
-		TLSCAFile   string `default:""                help:"TLS CA file path." name:"tls-ca-file"`
+		TLSCaFile   string `default:""                help:"TLS CA file path."`
 	} `embed:"" prefix:"listen-"`
 
-	ProxyAddr string `default:""                help:"Proxy address."`
-	DebugAddr string `default:"127.0.0.1:8088"  help:"Listen address for HTTP handlers for metrics, pprof, etc."`
+	Proxy struct {
+		Addr        string `default:"" help:"Proxy address."`
+		TLSCertFile string `default:"" help:"Proxy TLS cert file path."`
+		TLSKeyFile  string `default:"" help:"Proxy TLS key file path."`
+		TLSCaFile   string `default:"" help:"Proxy TLS CA file path."`
+	} `embed:"" prefix:"proxy-"`
+
+	DebugAddr string `default:"127.0.0.1:8088" help:"Listen address for HTTP handlers for metrics, pprof, etc."`
 
 	// see setCLIPlugins
 	kong.Plugins
@@ -400,14 +406,19 @@ func run() {
 	defer closeBackend()
 
 	l := clientconn.NewListener(&clientconn.NewListenerOpts{
-		TCP:         cli.Listen.Addr,
-		Unix:        cli.Listen.Unix,
+		TCP:  cli.Listen.Addr,
+		Unix: cli.Listen.Unix,
+
 		TLS:         cli.Listen.TLS,
 		TLSCertFile: cli.Listen.TLSCertFile,
 		TLSKeyFile:  cli.Listen.TLSKeyFile,
-		TLSCAFile:   cli.Listen.TLSCAFile,
+		TLSCAFile:   cli.Listen.TLSCaFile,
 
-		ProxyAddr:      cli.ProxyAddr,
+		ProxyAddr:        cli.Proxy.Addr,
+		ProxyTLSCertFile: cli.Proxy.TLSCertFile,
+		ProxyTLSKeyFile:  cli.Proxy.TLSKeyFile,
+		ProxyTLSCAFile:   cli.Proxy.TLSCaFile,
+
 		Mode:           clientconn.Mode(cli.Mode),
 		Metrics:        metrics,
 		Handler:        h,

--- a/ferretdb/ferretdb.go
+++ b/ferretdb/ferretdb.go
@@ -127,8 +127,9 @@ func New(config *Config) (*FerretDB, error) {
 	}
 
 	l := clientconn.NewListener(&clientconn.NewListenerOpts{
-		TCP:         config.Listener.TCP,
-		Unix:        config.Listener.Unix,
+		TCP:  config.Listener.TCP,
+		Unix: config.Listener.Unix,
+
 		TLS:         config.Listener.TLS,
 		TLSCertFile: config.Listener.TLSCertFile,
 		TLSKeyFile:  config.Listener.TLSKeyFile,

--- a/internal/clientconn/conn.go
+++ b/internal/clientconn/conn.go
@@ -84,12 +84,17 @@ type conn struct {
 
 // newConnOpts represents newConn options.
 type newConnOpts struct {
-	netConn        net.Conn
-	mode           Mode
-	l              *zap.Logger
-	handler        *handler.Handler
-	connMetrics    *connmetrics.ConnMetrics
-	proxyAddr      string
+	netConn     net.Conn
+	mode        Mode
+	l           *zap.Logger
+	handler     *handler.Handler
+	connMetrics *connmetrics.ConnMetrics
+
+	proxyAddr        string
+	proxyTLSCertFile string
+	proxyTLSKeyFile  string
+	proxyTLSCAFile   string
+
 	testRecordsDir string // if empty, no records are created
 }
 
@@ -105,7 +110,7 @@ func newConn(opts *newConnOpts) (*conn, error) {
 	var p *proxy.Router
 	if opts.mode != NormalMode {
 		var err error
-		if p, err = proxy.New(opts.proxyAddr); err != nil {
+		if p, err = proxy.New(opts.proxyAddr, opts.proxyTLSCertFile, opts.proxyTLSKeyFile, opts.proxyTLSCAFile); err != nil {
 			return nil, lazyerrors.Error(err)
 		}
 	}

--- a/internal/clientconn/listener.go
+++ b/internal/clientconn/listener.go
@@ -17,12 +17,10 @@ package clientconn
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"math/rand"
 	"net"
-	"os"
 	"runtime/pprof"
 	"sync"
 	"time"
@@ -34,6 +32,7 @@ import (
 	"github.com/FerretDB/FerretDB/internal/handler"
 	"github.com/FerretDB/FerretDB/internal/util/ctxutil"
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
+	"github.com/FerretDB/FerretDB/internal/util/tlsutil"
 	"github.com/FerretDB/FerretDB/internal/wire"
 )
 
@@ -53,14 +52,19 @@ type Listener struct {
 
 // NewListenerOpts represents listener configuration.
 type NewListenerOpts struct {
-	TCP         string
-	Unix        string
+	TCP  string
+	Unix string
+
 	TLS         string
 	TLSCertFile string
 	TLSKeyFile  string
 	TLSCAFile   string
 
-	ProxyAddr      string
+	ProxyAddr        string
+	ProxyTLSCertFile string
+	ProxyTLSKeyFile  string
+	ProxyTLSCAFile   string
+
 	Mode           Mode
 	Metrics        *connmetrics.ListenerMetrics
 	Handler        *handler.Handler
@@ -201,44 +205,12 @@ type setupTLSListenerOpts struct {
 
 // setupTLSListener returns a new TLS listener or and error.
 func setupTLSListener(opts *setupTLSListenerOpts) (net.Listener, error) {
-	if _, err := os.Stat(opts.certFile); err != nil {
-		return nil, fmt.Errorf("TLS certificate file: %w", err)
-	}
-
-	if _, err := os.Stat(opts.keyFile); err != nil {
-		return nil, fmt.Errorf("TLS key file: %w", err)
-	}
-
-	cert, err := tls.LoadX509KeyPair(opts.certFile, opts.keyFile)
+	config, err := tlsutil.Config(opts.certFile, opts.keyFile, opts.caFile)
 	if err != nil {
 		return nil, err
 	}
 
-	config := tls.Config{
-		Certificates: []tls.Certificate{cert},
-	}
-
-	if opts.caFile != "" {
-		if _, err = os.Stat(opts.caFile); err != nil {
-			return nil, fmt.Errorf("TLS CA file: %w", err)
-		}
-
-		var rootCA []byte
-
-		if rootCA, err = os.ReadFile(opts.caFile); err != nil {
-			return nil, err
-		}
-
-		roots := x509.NewCertPool()
-		if ok := roots.AppendCertsFromPEM(rootCA); !ok {
-			return nil, fmt.Errorf("failed to parse root certificate")
-		}
-
-		config.ClientAuth = tls.RequireAndVerifyClientCert
-		config.ClientCAs = roots
-	}
-
-	listener, err := tls.Listen("tcp", opts.addr, &config)
+	listener, err := tls.Listen("tcp", opts.addr, config)
 	if err != nil {
 		return nil, lazyerrors.Error(err)
 	}
@@ -302,12 +274,17 @@ func acceptLoop(ctx context.Context, listener net.Listener, wg *sync.WaitGroup, 
 			pprof.SetGoroutineLabels(runCtx)
 
 			opts := &newConnOpts{
-				netConn:        netConn,
-				mode:           l.Mode,
-				l:              l.Logger.Named("// " + connID + " "), // derive from the original unnamed logger
-				handler:        l.Handler,
-				connMetrics:    l.Metrics.ConnMetrics, // share between all conns
-				proxyAddr:      l.ProxyAddr,
+				netConn:     netConn,
+				mode:        l.Mode,
+				l:           l.Logger.Named("// " + connID + " "), // derive from the original unnamed logger
+				handler:     l.Handler,
+				connMetrics: l.Metrics.ConnMetrics, // share between all conns
+
+				proxyAddr:        l.ProxyAddr,
+				proxyTLSCertFile: l.ProxyTLSCertFile,
+				proxyTLSKeyFile:  l.ProxyTLSKeyFile,
+				proxyTLSCAFile:   l.ProxyTLSCAFile,
+
 				testRecordsDir: l.TestRecordsDir,
 			}
 

--- a/internal/util/tlsutil/tlsutil.go
+++ b/internal/util/tlsutil/tlsutil.go
@@ -1,0 +1,66 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tlsutil provides TLS utilities.
+package tlsutil
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+)
+
+// Config provides TLS configuration for the given certificate and key files.
+// If CA file is provided, full authentication is enabled.
+func Config(certFile, keyFile, caFile string) (*tls.Config, error) {
+	if _, err := os.Stat(certFile); err != nil {
+		return nil, fmt.Errorf("TLS certificate file: %w", err)
+	}
+
+	if _, err := os.Stat(keyFile); err != nil {
+		return nil, fmt.Errorf("TLS key file: %w", err)
+	}
+
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("TLS file pair: %w", err)
+	}
+
+	config := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}
+
+	if caFile != "" {
+		if _, err := os.Stat(caFile); err != nil {
+			return nil, fmt.Errorf("TLS CA file: %w", err)
+		}
+
+		b, err := os.ReadFile(caFile)
+		if err != nil {
+			return nil, err
+		}
+
+		ca := x509.NewCertPool()
+		if ok := ca.AppendCertsFromPEM(b); !ok {
+			return nil, fmt.Errorf("TLS CA file: failed to parse")
+		}
+
+		config.ClientAuth = tls.RequireAndVerifyClientCert
+		config.ClientCAs = ca
+		config.RootCAs = ca
+	}
+
+	return config, nil
+}


### PR DESCRIPTION
# Description

It allows us to see communication between TLS- and authentication-enabled client and server.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [ ] I ensured that PR title is good enough for the changelog.
- [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [ ] I marked all done items in this checklist.
