### PR TITLE
Allow building without PostgreSQL or SQLite backend

### DIFF
--- a/build/version/version.go
+++ b/build/version/version.go
@@ -31,7 +31,7 @@
 //	ferretdb_debug			- enables debug build (see below; implied by builds with race detector)
 //	ferretdb_hana			- enables Hana backend (alpha)
 //	ferretdb_no_postgresql	- disables PostgreSQL backend
-//	ferretdb_no_sqlite		- disables postgres backend
+//	ferretdb_no_sqlite		- disables SQLite backend
 //
 // # Debug builds
 //

--- a/build/version/version.go
+++ b/build/version/version.go
@@ -28,8 +28,10 @@
 // The following Go build tags (also known as build constraints) affect all builds of FerretDB,
 // including embedded usage:
 //
-//	ferretdb_debug - enables debug build (see below; implied by builds with race detector)
-//	ferretdb_hana  - enables Hana backend (alpha)
+//	ferretdb_debug			- enables debug build (see below; implied by builds with race detector)
+//	ferretdb_hana			- enables Hana backend (alpha)
+//	ferretdb_no_postgres	- disables postgres backend
+//	ferretdb_no_sqlite		- disables postgres backend
 //
 // # Debug builds
 //

--- a/build/version/version.go
+++ b/build/version/version.go
@@ -30,7 +30,7 @@
 //
 //	ferretdb_debug			- enables debug build (see below; implied by builds with race detector)
 //	ferretdb_hana			- enables Hana backend (alpha)
-//	ferretdb_no_postgres	- disables postgres backend
+//	ferretdb_no_postgresql	- disables PostgreSQL backend
 //	ferretdb_no_sqlite		- disables postgres backend
 //
 // # Debug builds

--- a/cmd/ferretdb/main_postgresql.go
+++ b/cmd/ferretdb/main_postgresql.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !ferretdb_no_postgresql
+
 package main
 
 // init adds "postgresql" backend flags.

--- a/cmd/ferretdb/main_sqlite.go
+++ b/cmd/ferretdb/main_sqlite.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !ferretdb_no_sqlite
+
 package main
 
 // init adds "sqlite" backend flags.

--- a/internal/handler/registry/postgresql.go
+++ b/internal/handler/registry/postgresql.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !ferretdb_no_postgresql
+
 package registry
 
 import (

--- a/internal/handler/registry/registry_test.go
+++ b/internal/handler/registry/registry_test.go
@@ -55,6 +55,42 @@ func tagPackages(t *testing.T, tag string) []string {
 	return maps.Keys(packages)
 }
 
+// negTagPackages returns packages that are NOT imported by FerretDB when the
+// given Go build negative tag is provided. Eg of negative tags
+// 'ferretdb_no_postgresql', 'ferretdb_no_sqlite'
+func negTagPackages(t *testing.T, negTag string) []string {
+	t.Helper()
+
+	type list struct {
+		Deps []string `json:"Deps"`
+	}
+
+	// Few packages will not be imported if a negative tag is given
+	var withNegTag list
+	b, err := exec.Command("go", "list", "-json", "-tags", negTag, "../../../cmd/ferretdb").Output()
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(b, &withNegTag))
+
+	// Packages which are removed using negative tag will be prensent in this
+	// list
+	var withoutNegTag list
+	b, err = exec.Command("go", "list", "-json", "../../../cmd/ferretdb").Output()
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(b, &withoutNegTag))
+
+	packages := make(map[string]struct{}, len(withoutNegTag.Deps))
+
+	for _, p := range withoutNegTag.Deps {
+		packages[p] = struct{}{}
+	}
+
+	for _, p := range withNegTag.Deps {
+		delete(packages, p)
+	}
+
+	return maps.Keys(packages)
+}
+
 // TestDeps ensures that some packages are imported
 // only when the corresponding backend handler is enabled via Go build tag.
 func TestDeps(t *testing.T) {
@@ -70,18 +106,16 @@ func TestDeps(t *testing.T) {
 	t.Run("NoPostgres", func(t *testing.T) {
 		t.Parallel()
 
-		diff := tagPackages(t, "ferretdb_no_postgresql")
-		// TODO: Fix the assert condition
-		// Fix it when the parent test case is rectified.
-		assert.NotContains(t, diff, "<postgres_driver_name>")
+		diff := negTagPackages(t, "ferretdb_no_postgresql")
+		assert.Contains(t, diff, "github.com/FerretDB/FerretDB/internal/backends/postgresql")
+		assert.Contains(t, diff, "github.com/jackc/pgx/v5")
 	})
 
 	t.Run("NoSqlite", func(t *testing.T) {
 		t.Parallel()
 
-		diff := tagPackages(t, "ferretdb_no_sqlite")
-		// TODO: Fix the assert condition
-		// Fix it when the parent test case is rectified.
-		assert.NotContains(t, diff, "<sqlite_driver_name>")
+		diff := negTagPackages(t, "ferretdb_no_sqlite")
+		assert.Contains(t, diff, "github.com/FerretDB/FerretDB/internal/backends/sqlite")
+		assert.Contains(t, diff, "modernc.org/sqlite")
 	})
 }

--- a/internal/handler/registry/registry_test.go
+++ b/internal/handler/registry/registry_test.go
@@ -57,7 +57,7 @@ func tagPackages(t *testing.T, tag string) []string {
 
 // negTagPackages returns packages that are NOT imported by FerretDB when the
 // given Go build negative tag is provided. Eg of negative tags
-// 'ferretdb_no_postgresql', 'ferretdb_no_sqlite'
+// 'ferretdb_no_postgresql', 'ferretdb_no_sqlite'.
 func negTagPackages(t *testing.T, negTag string) []string {
 	t.Helper()
 

--- a/internal/handler/registry/registry_test.go
+++ b/internal/handler/registry/registry_test.go
@@ -66,4 +66,22 @@ func TestDeps(t *testing.T) {
 		diff := tagPackages(t, "ferretdb_hana")
 		assert.Contains(t, diff, "github.com/SAP/go-hdb/driver")
 	})
+
+	t.Run("NoPostgres", func(t *testing.T) {
+		t.Parallel()
+
+		diff := tagPackages(t, "ferretdb_no_postgresql")
+		// TODO: Fix the assert condition
+		// Fix it when the parent test case is rectified.
+		assert.NotContains(t, diff, "<postgres_driver_name>")
+	})
+
+	t.Run("NoSqlite", func(t *testing.T) {
+		t.Parallel()
+
+		diff := tagPackages(t, "ferretdb_no_sqlite")
+		// TODO: Fix the assert condition
+		// Fix it when the parent test case is rectified.
+		assert.NotContains(t, diff, "<sqlite_driver_name>")
+	})
 }

--- a/internal/handler/registry/sqlite.go
+++ b/internal/handler/registry/sqlite.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !ferretdb_no_sqlite
+
 package registry
 
 import (


### PR DESCRIPTION
# Description

**Requirement**:  We should allow building FerretDB without PostgreSQL and/or SQLite backend with `ferretdb_no_postgresql` and `ferretdb_no_sqlite` build tags. Both should be absent in official builds.

I have added the relevant build tags in postgres & sqlite handler and registry files. The corresponding test `TestDeps` is skipped in the `main` branch. I have added placeholders for testing the above build tag changes. We can fix these once the `TestDeps` is fixed.

## Testing Strategy

1. Add required build tags in `BUILD_TAGS` in `Taskfile.yml`.
2. Build using `task build-host`.
3. Check the compiled handlers using `bin/ferretdb -h`.

### Test Results 

1. Build without Postgresql

Build tags given
<img width="1221" alt="image" src="https://github.com/FerretDB/FerretDB/assets/3938758/f391b351-f57a-48da-9a13-72df33dccbbd">

Postgres handler is absent.
<img width="1343" alt="image" src="https://github.com/FerretDB/FerretDB/assets/3938758/4c090023-6f03-4633-b942-1554f3034ff0">

2. Build without Sqlite

Build tags given
<img width="1161" alt="image" src="https://github.com/FerretDB/FerretDB/assets/3938758/adc09af1-b05a-47d6-bd66-e174d30810cb">

Sqlite handler is absent.
<img width="1365" alt="image" src="https://github.com/FerretDB/FerretDB/assets/3938758/525a9f2a-ec07-4ee4-bb0e-f088a72cbe34">


Closes #3629 

## Readiness checklist

<!-- Please check all items in this checklist that were done. -->

- [x] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
