### PR TITLE
Ignore `$clusterTime`

### DIFF
--- a/internal/handler/common/count.go
+++ b/internal/handler/common/count.go
@@ -38,6 +38,7 @@ type CountParams struct {
 	ReadConcern *types.Document `ferretdb:"readConcern,ignored"`
 	Comment     string          `ferretdb:"comment,ignored"`
 	LSID        any             `ferretdb:"lsid,ignored"`
+	ClusterTime any             `ferretdb:"$clusterTime,ignored"`
 }
 
 // GetCountParams returns the parameters for the count command.

--- a/internal/handler/common/delete_params.go
+++ b/internal/handler/common/delete_params.go
@@ -36,6 +36,7 @@ type DeleteParams struct {
 
 	WriteConcern *types.Document `ferretdb:"writeConcern,ignored"`
 	LSID         any             `ferretdb:"lsid,ignored"`
+	ClusterTime  any             `ferretdb:"$clusterTime,ignored"`
 }
 
 // Delete represents single delete operation parameters.

--- a/internal/handler/common/distinct.go
+++ b/internal/handler/common/distinct.go
@@ -44,6 +44,7 @@ type DistinctParams struct {
 
 	ReadConcern *types.Document `ferretdb:"readConcern,ignored"`
 	LSID        any             `ferretdb:"lsid,ignored"`
+	ClusterTime any             `ferretdb:"$clusterTime,ignored"`
 }
 
 // GetDistinctParams returns `distinct` command parameters.

--- a/internal/handler/common/find.go
+++ b/internal/handler/common/find.go
@@ -51,6 +51,7 @@ type FindParams struct {
 	Min          *types.Document `ferretdb:"min,ignored"`
 	Hint         any             `ferretdb:"hint,ignored"`
 	LSID         any             `ferretdb:"lsid,ignored"`
+	ClusterTime  any             `ferretdb:"$clusterTime,ignored"`
 
 	ReturnKey           bool `ferretdb:"returnKey,unimplemented-non-default"`
 	ShowRecordId        bool `ferretdb:"showRecordId,opt"`

--- a/internal/handler/common/findandmodify.go
+++ b/internal/handler/common/findandmodify.go
@@ -68,6 +68,7 @@ type FindAndModifyParams struct {
 	WriteConcern             *types.Document `ferretdb:"writeConcern,ignored"`
 	BypassDocumentValidation bool            `ferretdb:"bypassDocumentValidation,ignored"`
 	LSID                     any             `ferretdb:"lsid,ignored"`
+	ClusterTime              any             `ferretdb:"$clusterTime,ignored"`
 }
 
 // UpsertParams represents parameters for upsert, if the document exists UpdateParams is set.

--- a/internal/handler/common/insert.go
+++ b/internal/handler/common/insert.go
@@ -36,6 +36,7 @@ type InsertParams struct {
 	BypassDocumentValidation bool   `ferretdb:"bypassDocumentValidation,ignored"`
 	Comment                  string `ferretdb:"comment,ignored"`
 	LSID                     any    `ferretdb:"lsid,ignored"`
+	ClusterTime              any    `ferretdb:"$clusterTime,ignored"`
 }
 
 // GetInsertParams returns the parameters for an insert command.

--- a/internal/handler/common/update_params.go
+++ b/internal/handler/common/update_params.go
@@ -38,6 +38,7 @@ type UpdateParams struct {
 	BypassDocumentValidation bool            `ferretdb:"bypassDocumentValidation,ignored"`
 	WriteConcern             *types.Document `ferretdb:"writeConcern,ignored"`
 	LSID                     any             `ferretdb:"lsid,ignored"`
+	ClusterTime              any             `ferretdb:"$clusterTime,ignored"`
 }
 
 // Update represents a single update operation parameters.


### PR DESCRIPTION
# Description

To make proxy-diff mode usable again.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
