### PR TITLE
Enable OpLog and tailable cursors

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -381,7 +381,6 @@ tasks:
         --handler=sqlite
         --sqlite-url=file:tmp/sqlite/
         --test-records-dir=tmp/records
-        --test-enable-oplog
 
   run-mysql:
     desc: "Run FerretDB with `mysql` backend"
@@ -452,7 +451,6 @@ tasks:
         --handler=sqlite
         --sqlite-url=file:tmp/sqlite/
         --test-records-dir=tmp/records
-        --test-enable-oplog
 
   run-proxy-secured:
     desc: "Run FerretDB in diff-proxy mode (TLS, auth required)"

--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -94,7 +94,6 @@ var cli struct {
 		RecordsDir string `default:"" help:"Testing: directory for record files."`
 
 		DisablePushdown bool `default:"false" help:"Experimental: disable pushdown."`
-		EnableOplog     bool `default:"false" help:"Experimental: enable capped collections, tailable cursors and OpLog." hidden:""`
 		CappedCleanup   struct {
 			Interval   time.Duration `default:"1m" help:"Experimental: capped collections cleanup interval." hidden:""`
 			Percentage uint8         `default:"10" help:"Experimental: percentage of documents to cleanup."  hidden:""`
@@ -402,7 +401,6 @@ func run() {
 
 		TestOpts: registry.TestOpts{
 			DisablePushdown:         cli.Test.DisablePushdown,
-			EnableOplog:             cli.Test.EnableOplog,
 			CappedCleanupInterval:   cli.Test.CappedCleanup.Interval,
 			CappedCleanupPercentage: cli.Test.CappedCleanup.Percentage,
 			EnableNewAuth:           cli.Test.EnableNewAuth,

--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -51,8 +51,6 @@ import (
 // It's used for parsing the user input.
 //
 // Keep order in sync with documentation.
-//
-//nolint:lll // some tags are long
 var cli struct {
 	Version  bool   `default:"false"           help:"Print version to stdout and exit." env:"-"`
 	Handler  string `default:"postgresql"      help:"${help_handler}"`
@@ -94,13 +92,14 @@ var cli struct {
 		RecordsDir string `default:"" help:"Testing: directory for record files."`
 
 		DisablePushdown bool `default:"false" help:"Experimental: disable pushdown."`
-		CappedCleanup   struct {
+
+		CappedCleanup struct {
 			Interval   time.Duration `default:"1m" help:"Experimental: capped collections cleanup interval." hidden:""`
 			Percentage uint8         `default:"10" help:"Experimental: percentage of documents to cleanup."  hidden:""`
 		} `embed:"" prefix:"capped-cleanup-"`
+
 		EnableNewAuth bool `default:"false" help:"Experimental: enable new authentication." hidden:""`
 
-		//nolint:lll // for readability
 		Telemetry struct {
 			URL            string        `default:"https://beacon.ferretdb.io/" help:"Telemetry: reporting URL."`
 			UndecidedDelay time.Duration `default:"1h"                          help:"Telemetry: delay for undecided state."`

--- a/integration/setup/listener.go
+++ b/integration/setup/listener.go
@@ -180,7 +180,6 @@ func setupListener(tb testtb.TB, ctx context.Context, logger *zap.Logger) string
 
 		TestOpts: registry.TestOpts{
 			DisablePushdown:         *disablePushdownF,
-			EnableOplog:             true,
 			CappedCleanupPercentage: 20,
 			CappedCleanupInterval:   0,
 			EnableNewAuth:           true,

--- a/internal/backends/decorators/oplog/backend.go
+++ b/internal/backends/decorators/oplog/backend.go
@@ -54,7 +54,7 @@ func (b *backend) Database(name string) (backends.Database, error) {
 		return nil, err
 	}
 
-	return newDatabase(origDB, name, b, b.l), nil
+	return newDatabase(origDB, name, b.origB, b.l), nil
 }
 
 // ListDatabases implements backends.Backend interface.

--- a/internal/backends/decorators/oplog/collection.go
+++ b/internal/backends/decorators/oplog/collection.go
@@ -215,6 +215,8 @@ func (c *collection) DropIndexes(ctx context.Context, params *backends.DropIndex
 }
 
 // oplogCollection returns the OpLog collection if it exist.
+//
+// The returned collection is not wrapped with OpLog functionality to prevent recursive calls.
 func (c *collection) oplogCollection(ctx context.Context) backends.Collection {
 	db := must.NotFail(c.origB.Database(oplogDatabase))
 

--- a/internal/backends/postgresql/collection.go
+++ b/internal/backends/postgresql/collection.go
@@ -249,6 +249,8 @@ func (c *collection) DeleteAll(ctx context.Context, params *backends.DeleteAllPa
 		return &backends.DeleteAllResult{Deleted: 0}, nil
 	}
 
+	// TODO https://github.com/FerretDB/FerretDB/issues/3888
+
 	var column string
 	var placeholders []string
 	var args []any

--- a/internal/backends/sqlite/collection.go
+++ b/internal/backends/sqlite/collection.go
@@ -204,6 +204,8 @@ func (c *collection) DeleteAll(ctx context.Context, params *backends.DeleteAllPa
 		return &backends.DeleteAllResult{Deleted: 0}, nil
 	}
 
+	// TODO https://github.com/FerretDB/FerretDB/issues/3888
+
 	var column string
 	var placeholders []string
 	var args []any

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -74,7 +74,6 @@ type NewOpts struct {
 
 	// test options
 	DisablePushdown         bool
-	EnableOplog             bool
 	CappedCleanupInterval   time.Duration
 	CappedCleanupPercentage uint8
 	EnableNewAuth           bool
@@ -82,11 +81,7 @@ type NewOpts struct {
 
 // New returns a new handler.
 func New(opts *NewOpts) (*Handler, error) {
-	b := opts.Backend
-
-	if opts.EnableOplog {
-		b = oplog.NewBackend(b, opts.L.Named("oplog"))
-	}
+	b := oplog.NewBackend(opts.Backend, opts.L.Named("oplog"))
 
 	if opts.CappedCleanupPercentage >= 100 || opts.CappedCleanupPercentage <= 0 {
 		return nil, fmt.Errorf(
@@ -136,11 +131,6 @@ func New(opts *NewOpts) (*Handler, error) {
 
 // runCapppedCleanup calls capped collections cleanup function according to the given interval.
 func (h *Handler) runCappedCleanup() {
-	if !h.EnableOplog {
-		h.L.Info("The routine to cleanup capped collections is disabled because oplog is disabled")
-		return
-	}
-
 	if h.CappedCleanupInterval <= 0 {
 		h.L.Info("The routine to cleanup capped collections is disabled", zap.Duration("interval", h.CappedCleanupInterval))
 		return

--- a/internal/handler/msg_create.go
+++ b/internal/handler/msg_create.go
@@ -83,10 +83,6 @@ func (h *Handler) MsgCreate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 	}
 
 	if capped {
-		if !h.EnableOplog {
-			return nil, common.Unimplemented(document, "capped")
-		}
-
 		size, _ := document.Get("size")
 		if _, ok := size.(types.NullType); size == nil || ok {
 			msg := "the 'size' field is required when 'capped' is true"

--- a/internal/handler/registry/hana.go
+++ b/internal/handler/registry/hana.go
@@ -43,7 +43,6 @@ func init() {
 			StateProvider: opts.StateProvider,
 
 			DisablePushdown:         opts.DisablePushdown,
-			EnableOplog:             opts.EnableOplog,
 			CappedCleanupPercentage: opts.CappedCleanupPercentage,
 			CappedCleanupInterval:   opts.CappedCleanupInterval,
 			EnableNewAuth:           opts.EnableNewAuth,

--- a/internal/handler/registry/mysql.go
+++ b/internal/handler/registry/mysql.go
@@ -39,7 +39,6 @@ func init() {
 			StateProvider: opts.StateProvider,
 
 			DisablePushdown:         opts.DisablePushdown,
-			EnableOplog:             opts.EnableOplog,
 			CappedCleanupPercentage: opts.CappedCleanupPercentage,
 			CappedCleanupInterval:   opts.CappedCleanupInterval,
 			EnableNewAuth:           opts.EnableNewAuth,

--- a/internal/handler/registry/postgresql.go
+++ b/internal/handler/registry/postgresql.go
@@ -41,7 +41,6 @@ func init() {
 			StateProvider: opts.StateProvider,
 
 			DisablePushdown:         opts.DisablePushdown,
-			EnableOplog:             opts.EnableOplog,
 			CappedCleanupPercentage: opts.CappedCleanupPercentage,
 			CappedCleanupInterval:   opts.CappedCleanupInterval,
 			EnableNewAuth:           opts.EnableNewAuth,

--- a/internal/handler/registry/registry.go
+++ b/internal/handler/registry/registry.go
@@ -65,7 +65,6 @@ type NewHandlerOpts struct {
 // TestOpts represents experimental configuration options.
 type TestOpts struct {
 	DisablePushdown         bool
-	EnableOplog             bool
 	CappedCleanupInterval   time.Duration
 	CappedCleanupPercentage uint8
 	EnableNewAuth           bool

--- a/internal/handler/registry/sqlite.go
+++ b/internal/handler/registry/sqlite.go
@@ -41,7 +41,6 @@ func init() {
 			StateProvider: opts.StateProvider,
 
 			DisablePushdown:         opts.DisablePushdown,
-			EnableOplog:             opts.EnableOplog,
 			CappedCleanupPercentage: opts.CappedCleanupPercentage,
 			CappedCleanupInterval:   opts.CappedCleanupInterval,
 			EnableNewAuth:           opts.EnableNewAuth,


### PR DESCRIPTION
# Description

OpLog functionality does nothing if `local.oplog.rs` collection is not created. The user is expected to create it manually.

Closes #76.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [x] I added/updated comments and checked rendering.
- [x] I made spot refactorings.
- [ ] I updated user documentation.
- [x] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
