### PR TITLE
Fix clean-up on `aggregate` errors

### DIFF
--- a/internal/handler/msg_aggregate.go
+++ b/internal/handler/msg_aggregate.go
@@ -288,6 +288,7 @@ func (h *Handler) MsgAggregate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMs
 		var cList *backends.ListCollectionsResult
 
 		if cList, err = db.ListCollections(ctx, nil); err != nil {
+			closer.Close()
 			return nil, err
 		}
 
@@ -312,6 +313,7 @@ func (h *Handler) MsgAggregate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMs
 			}
 
 			if !cInfo.Capped() {
+				closer.Close()
 				return nil, handlererrors.NewCommandErrorMsgWithArgument(
 					handlererrors.ErrNotImplemented,
 					"$natural sort for non-capped collection is not supported.",


### PR DESCRIPTION
# Description

Close closers.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [x] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
