### PR TITLE
Forbid `bson.E/D/M/A`, except integration tests

### DIFF
--- a/.golangci-new.yml
+++ b/.golangci-new.yml
@@ -66,6 +66,7 @@ linters:
     - asciicheck
     - depguard
     - exhaustive
+    - forbidigo
     - gci
     - gochecksumtype
     - goconst
@@ -100,7 +101,6 @@ linters:
     - exhaustivestruct
     - exhaustruct
     - exportloopref
-    - forbidigo
     - forcetypeassert
     - funlen
     - gochecknoglobals

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,6 +71,35 @@ linters-settings:
           - pkg: github.com/FerretDB/FerretDB/internal/backends
   exhaustive:
     default-signifies-exhaustive: false
+  forbidigo:
+    forbid:
+      # integration tests use a different configuration file
+      - p: ^\Qbson.E\E$
+        pkg: ^\Qgo.mongodb.org/mongo-driver/bson\E$
+        msg: Use *types.Document or *types.Array instead.
+      - p: ^\Qprimitive.E\E$
+        pkg: ^\Qgo.mongodb.org/mongo-driver/bson/primitive\E$
+        msg: Use *types.Document or *types.Array instead.
+      - p: ^\Qbson.D\E$
+        pkg: ^\Qgo.mongodb.org/mongo-driver/bson\E$
+        msg: Use *types.Document instead.
+      - p: ^\Qprimitive.D\E$
+        pkg: ^\Qgo.mongodb.org/mongo-driver/bson/primitive\E$
+        msg: Use *types.Document instead.
+      - p: ^\Qbson.M\E$
+        pkg: ^\Qgo.mongodb.org/mongo-driver/bson\E$
+        msg: Use *types.Document instead.
+      - p: ^\Qprimitive.M\E$
+        pkg: ^\Qgo.mongodb.org/mongo-driver/bson/primitive\E$
+        msg: Use *types.Document instead.
+      - p: ^\Qbson.A\E$
+        pkg: ^\Qgo.mongodb.org/mongo-driver/bson\E$
+        msg: Use *types.Array instead.
+      - p: ^\Qprimitive.A\E$
+        pkg: ^\Qgo.mongodb.org/mongo-driver/bson/primitive\E$
+        msg: Use *types.Array instead.
+    exclude-godoc-examples: true
+    analyze-types: true
   gci:
     sections:
       - standard
@@ -178,6 +207,7 @@ linters:
     - asciicheck
     - depguard
     - exhaustive
+    - forbidigo
     - gci
     - gochecksumtype
     - goconst


### PR DESCRIPTION
# Description

To avoid confusion.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [x] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
