### PR TITLE
Disallow native passwords for MySQL

### DIFF
--- a/internal/backends/mysql/metadata/pool/uri.go
+++ b/internal/backends/mysql/metadata/pool/uri.go
@@ -46,12 +46,13 @@ func parseURI(uri string) (string, error) {
 	// mysql url requires a specified format to work
 	// For example: username:password@tcp(127.0.0.1:3306)/ferretdb
 	cfg := mysql.Config{
-		User:   username,
-		Passwd: password,
-		Net:    "tcp",
-		Addr:   u.Host,
-		DBName: strings.TrimPrefix(u.Path, "/"),
-		Params: params,
+		User:                 username,
+		Passwd:               password,
+		Net:                  "tcp",
+		Addr:                 u.Host,
+		DBName:               strings.TrimPrefix(u.Path, "/"),
+		AllowNativePasswords: false,
+		Params:               params,
 	}
 	mysqlURL := cfg.FormatDSN()
 

--- a/internal/backends/mysql/metadata/registry_test.go
+++ b/internal/backends/mysql/metadata/registry_test.go
@@ -83,8 +83,6 @@ func TestCheckAuth(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(r.Close)
 
-		t.Skip("https://github.com/FerretDB/FerretDB/issues/3413")
-
 		_, err = r.getPool(ctx)
 
 		expected := `Error 1045 \(28000\): Access denied for user 'wrong-user*'@'[\d\.]+' \(using password: YES\)`


### PR DESCRIPTION
# Description
Resolves the issue causing MySQL backend's registry_test to fail; alternate MySQL errors

Closes #3413.

## Readiness checklist
- [x] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [x] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [x] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
