### PR TITLE
Add test to show `maxTimeMS` should not propagate to `getMore` for tailable cursors

### DIFF
--- a/build/legacy-mongo-shell/test.js
+++ b/build/legacy-mongo-shell/test.js
@@ -32,18 +32,15 @@
 
   // verify that the maxTimeMS value is not propagated to getMore
   const now = new Date();
-  cmdRes = assert.commandWorked(
+  assert.commandWorked(
       db.runCommand({
         getMore: cmdRes.cursor.id,
         collection: t.getName(),
         batchSize: 1,
       }),
   );
-
-  assert.eq(0, cmdRes.cursor.nextBatch.length);
-
   // allow the delta some margin of error
-  assert.gte((new Date()) - now, defaultMaxTimeMS-100);
+  assert.lte((new Date()) - now, defaultMaxTimeMS+100);
 
   print('test.js passed!');
 })();

--- a/build/legacy-mongo-shell/test.js
+++ b/build/legacy-mongo-shell/test.js
@@ -3,5 +3,47 @@
 (function() {
   'use strict';
 
+  const t = db.foo;
+  t.drop();
+
+  db.createCollection('foo', {capped: true, size: 10 * 1024 * 1024});
+
+  t.insert({_id: 1});
+  t.insert({_id: 2});
+
+  const oneMinute = 1 * 60 * 1000;
+
+  // defaults to 1000ms
+  const defaultMaxTimeMS = 1 * 1000;
+
+  let cmdRes = db.runCommand({
+    find: 'foo',
+    batchSize: 1,
+    tailable: true,
+    awaitData: true,
+    maxTimeMS: oneMinute,
+  });
+
+  cmdRes = db.runCommand({
+    getMore: cmdRes.cursor.id,
+    collection: t.getName(),
+    batchSize: 1,
+  });
+
+  // verify that the maxTimeMS value is not propagated to getMore
+  const now = new Date();
+  cmdRes = assert.commandWorked(
+      db.runCommand({
+        getMore: cmdRes.cursor.id,
+        collection: t.getName(),
+        batchSize: 1,
+      }),
+  );
+
+  assert.eq(0, cmdRes.cursor.nextBatch.length);
+
+  // allow the delta some margin of error
+  assert.gte((new Date()) - now, defaultMaxTimeMS-100);
+
   print('test.js passed!');
 })();


### PR DESCRIPTION
<!--
Please remove comments like this one, but keep and use the rest of the template.
See CONTRIBUTING.md for details.
-->

# Description

<!--
Write a short description to explain changes that are not mentioned in the initial issue.
What were the reasons for those changes?
Which decisions did you make and why?
What else should reviewers know about your changes?
-->

<!-- Replace <issue_number> with an actual issue number. -->

Closes #2983.

It either uses the user defined value or it defaults to 1000ms. #2983 is related to non-tailable cursors over non-capped collections.

## Readiness checklist

<!-- Please check all items in this checklist that were done. -->

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [ ] I ensured that PR title is good enough for the changelog.
- [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [ ] I marked all done items in this checklist.
