### PR TITLE
Ignore `$readPreference` field

### DIFF
--- a/internal/handler/common/count.go
+++ b/internal/handler/common/count.go
@@ -34,11 +34,12 @@ type CountParams struct {
 
 	Fields any `ferretdb:"fields,ignored"` // legacy MongoDB shell adds it, but it is never actually used
 
-	Hint        any             `ferretdb:"hint,ignored"`
-	ReadConcern *types.Document `ferretdb:"readConcern,ignored"`
-	Comment     string          `ferretdb:"comment,ignored"`
-	LSID        any             `ferretdb:"lsid,ignored"`
-	ClusterTime any             `ferretdb:"$clusterTime,ignored"`
+	Hint           any             `ferretdb:"hint,ignored"`
+	ReadConcern    *types.Document `ferretdb:"readConcern,ignored"`
+	Comment        string          `ferretdb:"comment,ignored"`
+	LSID           any             `ferretdb:"lsid,ignored"`
+	ClusterTime    any             `ferretdb:"$clusterTime,ignored"`
+	ReadPreference *types.Document `ferretdb:"$readPreference,ignored"`
 }
 
 // GetCountParams returns the parameters for the count command.

--- a/internal/handler/common/delete_params.go
+++ b/internal/handler/common/delete_params.go
@@ -34,9 +34,10 @@ type DeleteParams struct {
 
 	Let *types.Document `ferretdb:"let,unimplemented"`
 
-	WriteConcern *types.Document `ferretdb:"writeConcern,ignored"`
-	LSID         any             `ferretdb:"lsid,ignored"`
-	ClusterTime  any             `ferretdb:"$clusterTime,ignored"`
+	WriteConcern   *types.Document `ferretdb:"writeConcern,ignored"`
+	LSID           any             `ferretdb:"lsid,ignored"`
+	ClusterTime    any             `ferretdb:"$clusterTime,ignored"`
+	ReadPreference *types.Document `ferretdb:"$readPreference,ignored"`
 }
 
 // Delete represents single delete operation parameters.

--- a/internal/handler/common/distinct.go
+++ b/internal/handler/common/distinct.go
@@ -42,9 +42,10 @@ type DistinctParams struct {
 
 	Collation *types.Document `ferretdb:"collation,unimplemented"`
 
-	ReadConcern *types.Document `ferretdb:"readConcern,ignored"`
-	LSID        any             `ferretdb:"lsid,ignored"`
-	ClusterTime any             `ferretdb:"$clusterTime,ignored"`
+	ReadConcern    *types.Document `ferretdb:"readConcern,ignored"`
+	LSID           any             `ferretdb:"lsid,ignored"`
+	ClusterTime    any             `ferretdb:"$clusterTime,ignored"`
+	ReadPreference *types.Document `ferretdb:"$readPreference,ignored"`
 }
 
 // GetDistinctParams returns `distinct` command parameters.

--- a/internal/handler/common/find.go
+++ b/internal/handler/common/find.go
@@ -46,13 +46,14 @@ type FindParams struct {
 	Collation *types.Document `ferretdb:"collation,unimplemented"`
 	Let       *types.Document `ferretdb:"let,unimplemented"`
 
-	AllowDiskUse bool            `ferretdb:"allowDiskUse,ignored"`
-	ReadConcern  *types.Document `ferretdb:"readConcern,ignored"`
-	Max          *types.Document `ferretdb:"max,ignored"`
-	Min          *types.Document `ferretdb:"min,ignored"`
-	Hint         any             `ferretdb:"hint,ignored"`
-	LSID         any             `ferretdb:"lsid,ignored"`
-	ClusterTime  any             `ferretdb:"$clusterTime,ignored"`
+	AllowDiskUse   bool            `ferretdb:"allowDiskUse,ignored"`
+	ReadConcern    *types.Document `ferretdb:"readConcern,ignored"`
+	Max            *types.Document `ferretdb:"max,ignored"`
+	Min            *types.Document `ferretdb:"min,ignored"`
+	Hint           any             `ferretdb:"hint,ignored"`
+	LSID           any             `ferretdb:"lsid,ignored"`
+	ClusterTime    any             `ferretdb:"$clusterTime,ignored"`
+	ReadPreference *types.Document `ferretdb:"$readPreference,ignored"`
 
 	ReturnKey           bool `ferretdb:"returnKey,unimplemented-non-default"`
 	OplogReplay         bool `ferretdb:"oplogReplay,ignored"`

--- a/internal/handler/common/findandmodify.go
+++ b/internal/handler/common/findandmodify.go
@@ -52,6 +52,7 @@ type FindAndModifyParams struct {
 	BypassDocumentValidation bool            `ferretdb:"bypassDocumentValidation,ignored"`
 	LSID                     any             `ferretdb:"lsid,ignored"`
 	ClusterTime              any             `ferretdb:"$clusterTime,ignored"`
+	ReadPreference           *types.Document `ferretdb:"$readPreference,ignored"`
 }
 
 // GetFindAndModifyParams returns `findAndModifyParams` command parameters.

--- a/internal/handler/common/update_params.go
+++ b/internal/handler/common/update_params.go
@@ -39,6 +39,7 @@ type UpdateParams struct {
 	WriteConcern             *types.Document `ferretdb:"writeConcern,ignored"`
 	LSID                     any             `ferretdb:"lsid,ignored"`
 	ClusterTime              any             `ferretdb:"$clusterTime,ignored"`
+	ReadPreference           *types.Document `ferretdb:"$readPreference,ignored"`
 }
 
 // Update represents a single update operation parameters.

--- a/tools/checkcomments/testdata/testdata.go
+++ b/tools/checkcomments/testdata/testdata.go
@@ -16,7 +16,7 @@
 package testdata
 
 func testCorrect() {
-	// TODO https://github.com/FerretDB/FerretDB/issues/3615
+	// TODO https://github.com/FerretDB/FerretDB/issues/3413
 }
 
 func testIncorrectNoURL() {
@@ -24,7 +24,7 @@ func testIncorrectNoURL() {
 }
 
 func testIncorrectFormat() {
-	// TODO: https://github.com/FerretDB/FerretDB/issues/3615 // want "invalid TODO: incorrect format"
+	// TODO: https://github.com/FerretDB/FerretDB/issues/3413 // want "invalid TODO: incorrect format"
 }
 
 func testCorrectFormatClosed() {

--- a/tools/checkcomments/testdata/testdata.go
+++ b/tools/checkcomments/testdata/testdata.go
@@ -16,7 +16,7 @@
 package testdata
 
 func testCorrect() {
-	// TODO https://github.com/FerretDB/FerretDB/issues/3413
+	// TODO https://github.com/FerretDB/FerretDB/issues/3615
 }
 
 func testIncorrectNoURL() {
@@ -24,7 +24,7 @@ func testIncorrectNoURL() {
 }
 
 func testIncorrectFormat() {
-	// TODO: https://github.com/FerretDB/FerretDB/issues/3413 // want "invalid TODO: incorrect format"
+	// TODO: https://github.com/FerretDB/FerretDB/issues/3615 // want "invalid TODO: incorrect format"
 }
 
 func testCorrectFormatClosed() {


### PR DESCRIPTION
<!--
Please remove comments like this one, but keep and use the rest of the template.
See CONTRIBUTING.md for details.
-->

# Description

<!--
Write a short description to explain changes that are not mentioned in the initial issue.
What were the reasons for those changes?
Which decisions did you make and why?
What else should reviewers know about your changes?
-->

<!-- Replace <issue_number> with an actual issue number. -->

Some drivers will attach a `$readPreference` document when connecting to a replica set, see [here](https://github.com/FerretDB/dance/actions/runs/7609512189/job/20720911668?pr=738#step:8:2466) and [here](https://github.com/FerretDB/dance/actions/runs/7615410166/job/20740339032?pr=738#step:8:200) for failures. We should ignore this field altogether.

## Readiness checklist

<!-- Please check all items in this checklist that were done. -->

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
