### PR TITLE
Hide `*types.Document` from `wire` struct fields

### DIFF
--- a/internal/clientconn/conn.go
+++ b/internal/clientconn/conn.go
@@ -258,9 +258,9 @@ func (c *conn) run(ctx context.Context) (err error) {
 			protoErr := handlererrors.ProtocolError(validationErr)
 
 			var res wire.OpMsg
-			must.NoError(res.SetSections(wire.OpMsgSection{
-				Documents: []*types.Document{protoErr.Document()},
-			}))
+			must.NoError(res.SetSections(wire.MakeOpMsgSection(
+				protoErr.Document(),
+			)))
 
 			b := must.NotFail(res.MarshalBinary())
 
@@ -479,9 +479,9 @@ func (c *conn) route(ctx context.Context, reqHeader *wire.MsgHeader, reqBody wir
 			protoErr := handlererrors.ProtocolError(err)
 
 			var res wire.OpMsg
-			must.NoError(res.SetSections(wire.OpMsgSection{
-				Documents: []*types.Document{protoErr.Document()},
-			}))
+			must.NoError(res.SetSections(wire.MakeOpMsgSection(
+				protoErr.Document(),
+			)))
 			resBody = &res
 
 			switch protoErr := protoErr.(type) {

--- a/internal/handler/cmd_query.go
+++ b/internal/handler/cmd_query.go
@@ -42,15 +42,17 @@ func (h *Handler) CmdQuery(ctx context.Context, query *wire.OpQuery) (*wire.OpRe
 
 	if cmd == "saslStart" && strings.HasSuffix(collection, ".$cmd") {
 		var emptyPayload types.Binary
-		return &wire.OpReply{
+		reply := wire.OpReply{
 			NumberReturned: 1,
-			Documents: []*types.Document{must.NotFail(types.NewDocument(
-				"conversationId", int32(1),
-				"done", true,
-				"payload", emptyPayload,
-				"ok", float64(1),
-			))},
-		}, nil
+		}
+		reply.SetDocuments([]*types.Document{must.NotFail(types.NewDocument(
+			"conversationId", int32(1),
+			"done", true,
+			"payload", emptyPayload,
+			"ok", float64(1),
+		))})
+
+		return &reply, nil
 	}
 
 	return nil, handlererrors.NewCommandErrorMsgWithArgument(

--- a/internal/handler/cmd_query.go
+++ b/internal/handler/cmd_query.go
@@ -28,12 +28,12 @@ import (
 
 // CmdQuery implements deprecated OP_QUERY message handling.
 func (h *Handler) CmdQuery(ctx context.Context, query *wire.OpQuery) (*wire.OpReply, error) {
-	cmd := query.Query.Command()
+	cmd := query.Query().Command()
 	collection := query.FullCollectionName
 
 	// both are valid and are allowed to be run against any database as we don't support authorization yet
 	if (cmd == "ismaster" || cmd == "isMaster") && strings.HasSuffix(collection, ".$cmd") {
-		return common.IsMaster(ctx, query.Query, h.TCPHost, h.ReplSetName)
+		return common.IsMaster(ctx, query.Query(), h.TCPHost, h.ReplSetName)
 	}
 
 	// TODO https://github.com/FerretDB/FerretDB/issues/3008

--- a/internal/handler/cmd_query.go
+++ b/internal/handler/cmd_query.go
@@ -45,12 +45,12 @@ func (h *Handler) CmdQuery(ctx context.Context, query *wire.OpQuery) (*wire.OpRe
 		reply := wire.OpReply{
 			NumberReturned: 1,
 		}
-		reply.SetDocuments([]*types.Document{must.NotFail(types.NewDocument(
+		reply.SetDocument(must.NotFail(types.NewDocument(
 			"conversationId", int32(1),
 			"done", true,
 			"payload", emptyPayload,
 			"ok", float64(1),
-		))})
+		)))
 
 		return &reply, nil
 	}

--- a/internal/handler/common/ismaster.go
+++ b/internal/handler/common/ismaster.go
@@ -31,10 +31,12 @@ func IsMaster(ctx context.Context, query *types.Document, tcpHost, name string) 
 		return nil, lazyerrors.Error(err)
 	}
 
-	return &wire.OpReply{
+	reply := wire.OpReply{
 		NumberReturned: 1,
-		Documents:      IsMasterDocuments(tcpHost, name),
-	}, nil
+	}
+	reply.SetDocuments(IsMasterDocuments(tcpHost, name))
+
+	return &reply, nil
 }
 
 // IsMasterDocuments returns isMaster's Documents field (identical for both OP_MSG and OP_QUERY).

--- a/internal/handler/common/ismaster.go
+++ b/internal/handler/common/ismaster.go
@@ -34,13 +34,13 @@ func IsMaster(ctx context.Context, query *types.Document, tcpHost, name string) 
 	reply := wire.OpReply{
 		NumberReturned: 1,
 	}
-	reply.SetDocuments(IsMasterDocuments(tcpHost, name))
+	reply.SetDocuments([]*types.Document{IsMasterDocument(tcpHost, name)})
 
 	return &reply, nil
 }
 
 // IsMasterDocuments returns isMaster's Documents field (identical for both OP_MSG and OP_QUERY).
-func IsMasterDocuments(tcpHost, name string) []*types.Document {
+func IsMasterDocument(tcpHost, name string) *types.Document {
 	doc := must.NotFail(types.NewDocument(
 		"ismaster", true, // only lowercase
 		// topologyVersion
@@ -68,5 +68,5 @@ func IsMasterDocuments(tcpHost, name string) []*types.Document {
 		doc.Set("hosts", must.NotFail(types.NewArray(tcpHost)))
 	}
 
-	return []*types.Document{doc}
+	return doc
 }

--- a/internal/handler/common/ismaster.go
+++ b/internal/handler/common/ismaster.go
@@ -34,7 +34,7 @@ func IsMaster(ctx context.Context, query *types.Document, tcpHost, name string) 
 	reply := wire.OpReply{
 		NumberReturned: 1,
 	}
-	reply.SetDocuments([]*types.Document{IsMasterDocument(tcpHost, name)})
+	reply.SetDocument(IsMasterDocument(tcpHost, name))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_aggregate.go
+++ b/internal/handler/msg_aggregate.go
@@ -382,16 +382,16 @@ func (h *Handler) MsgAggregate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMs
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"cursor", must.NotFail(types.NewDocument(
 				"firstBatch", firstBatch,
 				"id", cursorID,
 				"ns", dbName+"."+cName,
 			)),
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_buildinfo.go
+++ b/internal/handler/msg_buildinfo.go
@@ -33,8 +33,8 @@ func (h *Handler) MsgBuildInfo(ctx context.Context, msg *wire.OpMsg) (*wire.OpMs
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"version", version.Get().MongoDBVersion,
 			"gitVersion", version.Get().Commit,
 			"modules", must.NotFail(types.NewArray()),
@@ -52,8 +52,8 @@ func (h *Handler) MsgBuildInfo(ctx context.Context, msg *wire.OpMsg) (*wire.OpMs
 			)),
 
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_collstats.go
+++ b/internal/handler/msg_collstats.go
@@ -159,9 +159,9 @@ func (h *Handler) MsgCollStats(ctx context.Context, msg *wire.OpMsg) (*wire.OpMs
 	)
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(pairs...))},
-	}))
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(pairs...)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_compact.go
+++ b/internal/handler/msg_compact.go
@@ -136,12 +136,12 @@ func (h *Handler) MsgCompact(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg,
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"bytesFreed", float64(bytesFreed),
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_connectionstatus.go
+++ b/internal/handler/msg_connectionstatus.go
@@ -34,16 +34,16 @@ func (h *Handler) MsgConnectionStatus(ctx context.Context, msg *wire.OpMsg) (*wi
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"authInfo", must.NotFail(types.NewDocument(
 				"authenticatedUsers", users,
 				"authenticatedUserRoles", must.NotFail(types.NewArray()),
 				"authenticatedUserPrivileges", must.NotFail(types.NewArray()),
 			)),
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_count.go
+++ b/internal/handler/msg_count.go
@@ -97,12 +97,12 @@ func (h *Handler) MsgCount(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, e
 	n, _ := count.(int32)
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"n", n,
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_create.go
+++ b/internal/handler/msg_create.go
@@ -117,11 +117,11 @@ func (h *Handler) MsgCreate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 	switch {
 	case err == nil:
 		var reply wire.OpMsg
-		must.NoError(reply.SetSections(wire.OpMsgSection{
-			Documents: []*types.Document{must.NotFail(types.NewDocument(
+		must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+			must.NotFail(types.NewDocument(
 				"ok", float64(1),
-			))},
-		}))
+			)),
+		)))
 
 		return &reply, nil
 

--- a/internal/handler/msg_createindexes.go
+++ b/internal/handler/msg_createindexes.go
@@ -166,9 +166,9 @@ func (h *Handler) MsgCreateIndexes(ctx context.Context, msg *wire.OpMsg) (*wire.
 	resp.Set("ok", float64(1))
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{resp},
-	}))
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		resp,
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_createuser.go
+++ b/internal/handler/msg_createuser.go
@@ -210,11 +210,11 @@ func (h *Handler) MsgCreateUser(ctx context.Context, msg *wire.OpMsg) (*wire.OpM
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_currentop.go
+++ b/internal/handler/msg_currentop.go
@@ -25,12 +25,12 @@ import (
 // MsgCurrentOp implements `currentOp` command.
 func (h *Handler) MsgCurrentOp(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error) {
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"inprog", must.NotFail(types.NewArray()),
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_datasize.go
+++ b/internal/handler/msg_datasize.go
@@ -95,15 +95,15 @@ func (h *Handler) MsgDataSize(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"estimate", false,
 			"size", stats.SizeTotal,
 			"numObjects", stats.CountDocuments,
 			"millis", int32(time.Since(started).Milliseconds()),
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_dbstats.go
+++ b/internal/handler/msg_dbstats.go
@@ -158,9 +158,9 @@ func (h *Handler) MsgDBStats(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg,
 	)
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(pairs...))},
-	}))
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(pairs...)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_debugerror.go
+++ b/internal/handler/msg_debugerror.go
@@ -54,9 +54,9 @@ func (h *Handler) MsgDebugError(ctx context.Context, msg *wire.OpMsg) (*wire.OpM
 			"ok", float64(1),
 		))
 
-		must.NoError(reply.SetSections(wire.OpMsgSection{
-			Documents: []*types.Document{replyDoc},
-		}))
+		must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+			replyDoc,
+		)))
 
 		return &reply, nil
 

--- a/internal/handler/msg_delete.go
+++ b/internal/handler/msg_delete.go
@@ -104,9 +104,9 @@ func (h *Handler) MsgDelete(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 	res.Set("ok", float64(1))
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{res},
-	}))
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		res,
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_distinct.go
+++ b/internal/handler/msg_distinct.go
@@ -84,12 +84,12 @@ func (h *Handler) MsgDistinct(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"values", distinct,
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_drop.go
+++ b/internal/handler/msg_drop.go
@@ -76,13 +76,13 @@ func (h *Handler) MsgDrop(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, er
 	switch {
 	case err == nil, backends.ErrorCodeIs(err, backends.ErrorCodeCollectionDoesNotExist):
 		var reply wire.OpMsg
-		must.NoError(reply.SetSections(wire.OpMsgSection{
-			Documents: []*types.Document{must.NotFail(types.NewDocument(
+		must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+			must.NotFail(types.NewDocument(
 				"nIndexesWas", int32(1), // TODO https://github.com/FerretDB/FerretDB/issues/2337
 				"ns", dbName+"."+collectionName,
 				"ok", float64(1),
-			))},
-		}))
+			)),
+		)))
 
 		return &reply, nil
 

--- a/internal/handler/msg_dropallusersfromdatabase.go
+++ b/internal/handler/msg_dropallusersfromdatabase.go
@@ -92,12 +92,12 @@ func (h *Handler) MsgDropAllUsersFromDatabase(ctx context.Context, msg *wire.OpM
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"n", deleted,
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_dropdatabase.go
+++ b/internal/handler/msg_dropdatabase.go
@@ -70,9 +70,9 @@ func (h *Handler) MsgDropDatabase(ctx context.Context, msg *wire.OpMsg) (*wire.O
 	res.Set("ok", float64(1))
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{res},
-	}))
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		res,
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_dropindexes.go
+++ b/internal/handler/msg_dropindexes.go
@@ -114,9 +114,9 @@ func (h *Handler) MsgDropIndexes(ctx context.Context, msg *wire.OpMsg) (*wire.Op
 	)
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{replyDoc},
-	}))
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		replyDoc,
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_dropuser.go
+++ b/internal/handler/msg_dropuser.go
@@ -73,11 +73,11 @@ func (h *Handler) MsgDropUser(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_explain.go
+++ b/internal/handler/msg_explain.go
@@ -153,8 +153,8 @@ func (h *Handler) MsgExplain(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg,
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"queryPlanner", res.QueryPlanner,
 			"explainVersion", "1",
 			"command", cmd,
@@ -167,8 +167,8 @@ func (h *Handler) MsgExplain(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg,
 			"limitPushdown", res.LimitPushdown,
 
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_find.go
+++ b/internal/handler/msg_find.go
@@ -184,16 +184,16 @@ func (h *Handler) MsgFind(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, er
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"cursor", must.NotFail(types.NewDocument(
 				"firstBatch", firstBatch,
 				"id", cursorID,
 				"ns", params.DB+"."+params.Collection,
 			)),
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_findandmodify.go
+++ b/internal/handler/msg_findandmodify.go
@@ -88,9 +88,9 @@ func (h *Handler) MsgFindAndModify(ctx context.Context, msg *wire.OpMsg) (*wire.
 	resDoc.Set("ok", float64(1))
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{resDoc},
-	}))
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		resDoc,
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_getcmdlineopts.go
+++ b/internal/handler/msg_getcmdlineopts.go
@@ -25,13 +25,13 @@ import (
 // MsgGetCmdLineOpts implements `getCmdLineOpts` command.
 func (h *Handler) MsgGetCmdLineOpts(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error) {
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"argv", must.NotFail(types.NewArray("ferretdb")),
 			"parsed", must.NotFail(types.NewDocument()),
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_getfreemonitoringstatus.go
+++ b/internal/handler/msg_getfreemonitoringstatus.go
@@ -28,13 +28,13 @@ func (h *Handler) MsgGetFreeMonitoringStatus(ctx context.Context, msg *wire.OpMs
 	message := "monitoring is " + state
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"state", state,
 			"message", message,
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_getlog.go
+++ b/internal/handler/msg_getlog.go
@@ -157,9 +157,9 @@ func (h *Handler) MsgGetLog(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{resDoc},
-	}))
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		resDoc,
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_getmore.go
+++ b/internal/handler/msg_getmore.go
@@ -259,16 +259,16 @@ func (h *Handler) MsgGetMore(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg,
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"cursor", must.NotFail(types.NewDocument(
 				"nextBatch", nextBatch,
 				"id", cursorID,
 				"ns", db+"."+collection,
 			)),
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_getparameter.go
+++ b/internal/handler/msg_getparameter.go
@@ -90,9 +90,9 @@ func (h *Handler) MsgGetParameter(ctx context.Context, msg *wire.OpMsg) (*wire.O
 	resDoc.Set("ok", float64(1))
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{resDoc},
-	}))
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		resDoc,
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_hello.go
+++ b/internal/handler/msg_hello.go
@@ -37,8 +37,8 @@ func (h *Handler) MsgHello(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, e
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"isWritablePrimary", true,
 			"maxBsonObjectSize", int32(types.MaxDocumentLen),
 			"maxMessageSizeBytes", int32(wire.MaxMsgLen),
@@ -49,8 +49,8 @@ func (h *Handler) MsgHello(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, e
 			"maxWireVersion", common.MaxWireVersion,
 			"readOnly", false,
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_hostinfo.go
+++ b/internal/handler/msg_hostinfo.go
@@ -66,8 +66,8 @@ func (h *Handler) MsgHostInfo(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"system", must.NotFail(types.NewDocument(
 				"currentTime", now,
 				"hostname", hostname,
@@ -82,8 +82,8 @@ func (h *Handler) MsgHostInfo(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg
 			)),
 			"extra", must.NotFail(types.NewDocument()),
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_insert.go
+++ b/internal/handler/msg_insert.go
@@ -201,9 +201,9 @@ func (h *Handler) MsgInsert(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 	res.Set("ok", float64(1))
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{res},
-	}))
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		res,
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_ismaster.go
+++ b/internal/handler/msg_ismaster.go
@@ -35,9 +35,9 @@ func (h *Handler) MsgIsMaster(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: common.IsMasterDocuments(h.TCPHost, h.ReplSetName),
-	}))
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		common.IsMasterDocument(h.TCPHost, h.ReplSetName),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_killcursors.go
+++ b/internal/handler/msg_killcursors.go
@@ -103,15 +103,15 @@ func (h *Handler) MsgKillCursors(ctx context.Context, msg *wire.OpMsg) (*wire.Op
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"cursorsKilled", cursorsKilled,
 			"cursorsNotFound", cursorsNotFound,
 			"cursorsAlive", cursorsAlive,
 			"cursorsUnknown", cursorsUnknown,
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_listcollections.go
+++ b/internal/handler/msg_listcollections.go
@@ -140,16 +140,16 @@ func (h *Handler) MsgListCollections(ctx context.Context, msg *wire.OpMsg) (*wir
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"cursor", must.NotFail(types.NewDocument(
 				"id", int64(0),
 				"ns", dbName+".$cmd.listCollections",
 				"firstBatch", collections,
 			)),
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_listcommands.go
+++ b/internal/handler/msg_listcommands.go
@@ -43,12 +43,12 @@ func (h *Handler) MsgListCommands(ctx context.Context, msg *wire.OpMsg) (*wire.O
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"commands", cmdList,
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_listdatabases.go
+++ b/internal/handler/msg_listdatabases.go
@@ -102,21 +102,21 @@ func (h *Handler) MsgListDatabases(ctx context.Context, msg *wire.OpMsg) (*wire.
 
 	switch {
 	case nameOnly:
-		must.NoError(reply.SetSections(wire.OpMsgSection{
-			Documents: []*types.Document{must.NotFail(types.NewDocument(
+		must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+			must.NotFail(types.NewDocument(
 				"databases", databases,
 				"ok", float64(1),
-			))},
-		}))
+			)),
+		)))
 	default:
-		must.NoError(reply.SetSections(wire.OpMsgSection{
-			Documents: []*types.Document{must.NotFail(types.NewDocument(
+		must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+			must.NotFail(types.NewDocument(
 				"databases", databases,
 				"totalSize", totalSize,
 				"totalSizeMb", totalSize/1024/1024,
 				"ok", float64(1),
-			))},
-		}))
+			)),
+		)))
 	}
 
 	return &reply, nil

--- a/internal/handler/msg_listindexes.go
+++ b/internal/handler/msg_listindexes.go
@@ -105,16 +105,16 @@ func (h *Handler) MsgListIndexes(ctx context.Context, msg *wire.OpMsg) (*wire.Op
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"cursor", must.NotFail(types.NewDocument(
 				"id", int64(0),
 				"ns", fmt.Sprintf("%s.%s", dbName, collection),
 				"firstBatch", firstBatch,
 			)),
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_logout.go
+++ b/internal/handler/msg_logout.go
@@ -28,11 +28,11 @@ func (h *Handler) MsgLogout(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 	conninfo.Get(ctx).SetAuth("", "")
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_ping.go
+++ b/internal/handler/msg_ping.go
@@ -53,11 +53,11 @@ func (h *Handler) MsgPing(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, er
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_renamecollection.go
+++ b/internal/handler/msg_renamecollection.go
@@ -162,11 +162,11 @@ func (h *Handler) MsgRenameCollection(ctx context.Context, msg *wire.OpMsg) (*wi
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_saslstart.go
+++ b/internal/handler/msg_saslstart.go
@@ -71,14 +71,14 @@ func (h *Handler) MsgSASLStart(ctx context.Context, msg *wire.OpMsg) (*wire.OpMs
 
 	var emptyPayload types.Binary
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"conversationId", int32(1),
 			"done", true,
 			"payload", emptyPayload,
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_serverstatus.go
+++ b/internal/handler/msg_serverstatus.go
@@ -99,9 +99,9 @@ func (h *Handler) MsgServerStatus(ctx context.Context, msg *wire.OpMsg) (*wire.O
 	)))
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{res},
-	}))
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		res,
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_setfreemonitoring.go
+++ b/internal/handler/msg_setfreemonitoring.go
@@ -77,11 +77,11 @@ func (h *Handler) MsgSetFreeMonitoring(ctx context.Context, msg *wire.OpMsg) (*w
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_update.go
+++ b/internal/handler/msg_update.go
@@ -82,9 +82,9 @@ func (h *Handler) MsgUpdate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 	res.Set("ok", float64(1))
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{res},
-	}))
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		res,
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_updateuser.go
+++ b/internal/handler/msg_updateuser.go
@@ -230,11 +230,11 @@ func (h *Handler) MsgUpdateUser(ctx context.Context, msg *wire.OpMsg) (*wire.OpM
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_usersinfo.go
+++ b/internal/handler/msg_usersinfo.go
@@ -183,12 +183,12 @@ func (h *Handler) MsgUsersInfo(ctx context.Context, msg *wire.OpMsg) (*wire.OpMs
 	}
 
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"users", res,
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_validate.go
+++ b/internal/handler/msg_validate.go
@@ -70,8 +70,8 @@ func (h *Handler) MsgValidate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg
 
 	// TODO https://github.com/FerretDB/FerretDB/issues/3841
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"ns", dbName+"."+collection,
 			"nInvalidDocuments", int32(0),
 			"nNonCompliantDocuments", int32(0),
@@ -85,8 +85,8 @@ func (h *Handler) MsgValidate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg
 			"missingIndexEntries", types.MakeArray(0),
 			"corruptRecords", types.MakeArray(0),
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/msg_whatsmyuri.go
+++ b/internal/handler/msg_whatsmyuri.go
@@ -26,12 +26,12 @@ import (
 // MsgWhatsMyURI implements `whatsMyURI` command.
 func (h *Handler) MsgWhatsMyURI(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, error) {
 	var reply wire.OpMsg
-	must.NoError(reply.SetSections(wire.OpMsgSection{
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+	must.NoError(reply.SetSections(wire.MakeOpMsgSection(
+		must.NotFail(types.NewDocument(
 			"you", conninfo.Get(ctx).PeerAddr,
 			"ok", float64(1),
-		))},
-	}))
+		)),
+	)))
 
 	return &reply, nil
 }

--- a/internal/handler/sjson/sjson_test.go
+++ b/internal/handler/sjson/sjson_test.go
@@ -216,7 +216,7 @@ func addRecordedFuzzDocs(f *testing.F, needDocument, needSchema bool) int {
 			}
 
 		case *wire.OpReply:
-			docs = append(docs, b.Documents...)
+			docs = append(docs, b.Documents()...)
 		}
 
 		for _, doc := range docs {

--- a/internal/handler/sjson/sjson_test.go
+++ b/internal/handler/sjson/sjson_test.go
@@ -207,11 +207,11 @@ func addRecordedFuzzDocs(f *testing.F, needDocument, needSchema bool) int {
 			docs = append(docs, doc)
 
 		case *wire.OpQuery:
-			if doc := b.Query; doc != nil {
+			if doc := b.Query(); doc != nil {
 				docs = append(docs, doc)
 			}
 
-			if doc := b.ReturnFieldsSelector; doc != nil {
+			if doc := b.ReturnFieldsSelector(); doc != nil {
 				docs = append(docs, doc)
 			}
 

--- a/internal/wire/op_msg_test.go
+++ b/internal/wire/op_msg_test.go
@@ -34,7 +34,7 @@ var msgTestCases = []testCase{{
 	},
 	msgBody: &OpMsg{
 		sections: []OpMsgSection{{
-			Documents: []*types.Document{must.NotFail(types.NewDocument(
+			documents: []*types.Document{must.NotFail(types.NewDocument(
 				"buildInfo", int32(1),
 				"lsid", must.NotFail(types.NewDocument(
 					"id", types.Binary{
@@ -62,7 +62,7 @@ var msgTestCases = []testCase{{
 	},
 	msgBody: &OpMsg{
 		sections: []OpMsgSection{{
-			Documents: []*types.Document{must.NotFail(types.NewDocument(
+			documents: []*types.Document{must.NotFail(types.NewDocument(
 				"version", "5.0.0",
 				"gitVersion", "1184f004a99660de6f5e745573419bda8a28c0e9",
 				"modules", must.NotFail(types.NewArray()),
@@ -117,7 +117,7 @@ var msgTestCases = []testCase{{
 	},
 	msgBody: &OpMsg{
 		sections: []OpMsgSection{{
-			Documents: []*types.Document{must.NotFail(types.NewDocument(
+			documents: []*types.Document{must.NotFail(types.NewDocument(
 				"insert", "actor",
 				"ordered", true,
 				"writeConcern", must.NotFail(types.NewDocument(
@@ -128,7 +128,7 @@ var msgTestCases = []testCase{{
 		}, {
 			Kind:       1,
 			Identifier: "documents",
-			Documents: []*types.Document{
+			documents: []*types.Document{
 				must.NotFail(types.NewDocument(
 					"_id", types.ObjectID{0x61, 0x2e, 0xc2, 0x80, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01},
 					"actor_id", int32(1),
@@ -187,7 +187,7 @@ var msgTestCases = []testCase{{
 	},
 	msgBody: &OpMsg{
 		sections: []OpMsgSection{{
-			Documents: []*types.Document{must.NotFail(types.NewDocument(
+			documents: []*types.Document{must.NotFail(types.NewDocument(
 				"insert", "values",
 				"documents", must.NotFail(types.NewArray(
 					must.NotFail(types.NewDocument(
@@ -237,7 +237,7 @@ var msgTestCases = []testCase{{
 	},
 	msgBody: &OpMsg{
 		sections: []OpMsgSection{{
-			Documents: []*types.Document{must.NotFail(types.NewDocument(
+			documents: []*types.Document{must.NotFail(types.NewDocument(
 				"insert", "TestInsertSimple",
 				"ordered", true,
 				"$db", "testinsertsimple",
@@ -245,7 +245,7 @@ var msgTestCases = []testCase{{
 		}, {
 			Kind:       1,
 			Identifier: "documents",
-			Documents: []*types.Document{must.NotFail(types.NewDocument(
+			documents: []*types.Document{must.NotFail(types.NewDocument(
 				"_id", types.ObjectID{0x63, 0x7c, 0xfa, 0xd8, 0x8d, 0xc3, 0xce, 0xcd, 0xe3, 0x8e, 0x1e, 0x6b},
 				"v", math.Copysign(0, -1),
 			))},
@@ -295,12 +295,12 @@ var msgTestCases = []testCase{{
 		sections: []OpMsgSection{{
 			Kind:       1,
 			Identifier: "documents",
-			Documents: []*types.Document{must.NotFail(types.NewDocument(
+			documents: []*types.Document{must.NotFail(types.NewDocument(
 				"_id", types.ObjectID{0x63, 0x8c, 0xec, 0x46, 0xaa, 0x77, 0x8b, 0xf3, 0x70, 0x10, 0x54, 0x29},
 				"a", float64(3),
 			))},
 		}, {
-			Documents: []*types.Document{must.NotFail(types.NewDocument(
+			documents: []*types.Document{must.NotFail(types.NewDocument(
 				"insert", "foo",
 				"ordered", true,
 				"$db", "test",
@@ -367,7 +367,7 @@ var msgTestCases = []testCase{{
 		sections: []OpMsgSection{{
 			Kind:       1,
 			Identifier: "updates",
-			Documents: []*types.Document{must.NotFail(types.NewDocument(
+			documents: []*types.Document{must.NotFail(types.NewDocument(
 				"q", must.NotFail(types.NewDocument(
 					"a", float64(20),
 				)),
@@ -380,7 +380,7 @@ var msgTestCases = []testCase{{
 				"upsert", false,
 			))},
 		}, {
-			Documents: []*types.Document{must.NotFail(types.NewDocument(
+			documents: []*types.Document{must.NotFail(types.NewDocument(
 				"update", "foo",
 				"ordered", true,
 				"$db", "test",
@@ -432,12 +432,12 @@ var msgTestCases = []testCase{{
 		sections: []OpMsgSection{{
 			Kind:       1,
 			Identifier: "documents",
-			Documents: []*types.Document{must.NotFail(types.NewDocument(
+			documents: []*types.Document{must.NotFail(types.NewDocument(
 				"_id", types.ObjectID{0x63, 0x8c, 0xec, 0x46, 0xaa, 0x77, 0x8b, 0xf3, 0x70, 0x10, 0x54, 0x29},
 				"a", float64(3),
 			))},
 		}, {
-			Documents: []*types.Document{must.NotFail(types.NewDocument(
+			documents: []*types.Document{must.NotFail(types.NewDocument(
 				"insert", "fooo",
 				"ordered", true,
 				"$db", "test",

--- a/internal/wire/op_query_test.go
+++ b/internal/wire/op_query_test.go
@@ -37,7 +37,7 @@ var queryTestCases = []testCase{{
 		FullCollectionName: "admin.$cmd",
 		NumberToSkip:       0,
 		NumberToReturn:     -1,
-		Query: must.NotFail(types.NewDocument(
+		query: must.NotFail(types.NewDocument(
 			"ismaster", true,
 			"client", must.NotFail(types.NewDocument(
 				"driver", must.NotFail(types.NewDocument(
@@ -58,7 +58,7 @@ var queryTestCases = []testCase{{
 			"compression", must.NotFail(types.NewArray("none")),
 			"loadBalanced", false,
 		)),
-		ReturnFieldsSelector: nil,
+		returnFieldsSelector: nil,
 	},
 }, {
 	name:    "handshake3",
@@ -75,7 +75,7 @@ var queryTestCases = []testCase{{
 		FullCollectionName: "admin.$cmd",
 		NumberToSkip:       0,
 		NumberToReturn:     -1,
-		Query: must.NotFail(types.NewDocument(
+		query: must.NotFail(types.NewDocument(
 			"ismaster", true,
 			"client", must.NotFail(types.NewDocument(
 				"driver", must.NotFail(types.NewDocument(
@@ -96,7 +96,7 @@ var queryTestCases = []testCase{{
 			"compression", must.NotFail(types.NewArray("none")),
 			"loadBalanced", false,
 		)),
-		ReturnFieldsSelector: nil,
+		returnFieldsSelector: nil,
 	},
 }}
 

--- a/internal/wire/op_reply.go
+++ b/internal/wire/op_reply.go
@@ -127,9 +127,9 @@ func (reply *OpReply) Documents() []*types.Document {
 	return reply.documents
 }
 
-// SetDocuments sets reply documents.
-func (reply *OpReply) SetDocuments(docs []*types.Document) {
-	reply.documents = docs
+// SetDocuments sets reply document.
+func (reply *OpReply) SetDocument(doc *types.Document) {
+	reply.documents = []*types.Document{doc}
 }
 
 // String returns a string representation for logging.

--- a/internal/wire/op_reply.go
+++ b/internal/wire/op_reply.go
@@ -127,7 +127,7 @@ func (reply *OpReply) Documents() []*types.Document {
 	return reply.documents
 }
 
-// SetDocuments sets reply document.
+// SetDocument sets reply document.
 func (reply *OpReply) SetDocument(doc *types.Document) {
 	reply.documents = []*types.Document{doc}
 }

--- a/internal/wire/op_reply.go
+++ b/internal/wire/op_reply.go
@@ -36,7 +36,7 @@ type OpReply struct {
 	CursorID       int64
 	StartingFrom   int32
 	NumberReturned int32
-	Documents      []*types.Document
+	documents      []*types.Document
 }
 
 func (reply *OpReply) msgbody() {}
@@ -59,13 +59,13 @@ func (reply *OpReply) readFrom(bufr *bufio.Reader) error {
 		return lazyerrors.Errorf("wire.OpReply.ReadFrom: invalid NumberReturned %d", n)
 	}
 
-	reply.Documents = make([]*types.Document, reply.NumberReturned)
+	reply.documents = make([]*types.Document, reply.NumberReturned)
 	for i := int32(0); i < reply.NumberReturned; i++ {
 		var doc bson.Document
 		if err := doc.ReadFrom(bufr); err != nil {
 			return lazyerrors.Errorf("wire.OpReply.ReadFrom: %w", err)
 		}
-		reply.Documents[i] = must.NotFail(types.ConvertDocument(&doc))
+		reply.documents[i] = must.NotFail(types.ConvertDocument(&doc))
 	}
 
 	return nil
@@ -89,7 +89,7 @@ func (reply *OpReply) UnmarshalBinary(b []byte) error {
 
 // MarshalBinary writes an OpReply to a byte array.
 func (reply *OpReply) MarshalBinary() ([]byte, error) {
-	if l := len(reply.Documents); int32(l) != reply.NumberReturned {
+	if l := len(reply.documents); int32(l) != reply.NumberReturned {
 		return nil, lazyerrors.Errorf("wire.OpReply.MarshalBinary: len(Documents)=%d, NumberReturned=%d", l, reply.NumberReturned)
 	}
 
@@ -109,7 +109,7 @@ func (reply *OpReply) MarshalBinary() ([]byte, error) {
 		return nil, lazyerrors.Errorf("wire.OpReply.UnmarshalBinary (binary.Write): %w", err)
 	}
 
-	for _, doc := range reply.Documents {
+	for _, doc := range reply.documents {
 		if err := must.NotFail(bson.ConvertDocument(doc)).WriteTo(bufw); err != nil {
 			return nil, lazyerrors.Errorf("wire.OpReply.MarshalBinary: %w", err)
 		}
@@ -120,6 +120,16 @@ func (reply *OpReply) MarshalBinary() ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
+}
+
+// Documents returns reply documents.
+func (reply *OpReply) Documents() []*types.Document {
+	return reply.documents
+}
+
+// SetDocuments sets reply documents.
+func (reply *OpReply) SetDocuments(docs []*types.Document) {
+	reply.documents = docs
 }
 
 // String returns a string representation for logging.
@@ -135,8 +145,8 @@ func (reply *OpReply) String() string {
 		"NumberReturned": reply.NumberReturned,
 	}
 
-	docs := make([]json.RawMessage, len(reply.Documents))
-	for i, d := range reply.Documents {
+	docs := make([]json.RawMessage, len(reply.documents))
+	for i, d := range reply.documents {
 		docs[i] = json.RawMessage(must.NotFail(fjson.Marshal(d)))
 	}
 

--- a/internal/wire/op_reply_test.go
+++ b/internal/wire/op_reply_test.go
@@ -38,7 +38,7 @@ var replyTestCases = []testCase{{
 		CursorID:       0,
 		StartingFrom:   0,
 		NumberReturned: 1,
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+		documents: []*types.Document{must.NotFail(types.NewDocument(
 			"ismaster", true,
 			"topologyVersion", must.NotFail(types.NewDocument(
 				"processId", types.ObjectID{0x60, 0xfb, 0xed, 0x53, 0x71, 0xfe, 0x1b, 0xae, 0x70, 0x33, 0x95, 0x05},
@@ -71,7 +71,7 @@ var replyTestCases = []testCase{{
 		CursorID:       0,
 		StartingFrom:   0,
 		NumberReturned: 1,
-		Documents: []*types.Document{must.NotFail(types.NewDocument(
+		documents: []*types.Document{must.NotFail(types.NewDocument(
 			"ismaster", true,
 			"topologyVersion", must.NotFail(types.NewDocument(
 				"processId", types.ObjectID{0x60, 0xfb, 0xed, 0x53, 0x71, 0xfe, 0x1b, 0xae, 0x70, 0x33, 0x95, 0x05},


### PR DESCRIPTION
# Description

That would allow us to replace them with `bson2.RawDocument`s later.

## Readiness checklist

- [x] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [x] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [x] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
