### PR TITLE
Add `bson2` helpers for conversions and logging

### DIFF
--- a/internal/bson2/raw_array.go
+++ b/internal/bson2/raw_array.go
@@ -18,6 +18,7 @@ import (
 	"log/slog"
 	"strconv"
 
+	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
 )
 
@@ -27,7 +28,7 @@ import (
 type RawArray []byte
 
 // LogValue implements slog.LogValuer interface.
-func (arr *RawArray) LogValue() slog.Value {
+func (arr RawArray) LogValue() slog.Value {
 	return slogValue(arr)
 }
 
@@ -50,6 +51,21 @@ func (raw RawArray) Decode() (*Array, error) {
 // All nested documents and arrays are decoded recursively.
 func (raw RawArray) DecodeDeep() (*Array, error) {
 	res, err := raw.decode(true)
+	if err != nil {
+		return nil, lazyerrors.Error(err)
+	}
+
+	return res, nil
+}
+
+// Convert converts a single BSON array that takes the whole raw slice into [*types.Array].
+func (raw RawArray) Convert() (*types.Array, error) {
+	arr, err := raw.decode(false)
+	if err != nil {
+		return nil, lazyerrors.Error(err)
+	}
+
+	res, err := arr.Convert()
 	if err != nil {
 		return nil, lazyerrors.Error(err)
 	}

--- a/internal/bson2/raw_document.go
+++ b/internal/bson2/raw_document.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cristalhq/bson/bsonproto"
 
+	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
 	"github.com/FerretDB/FerretDB/internal/util/must"
 )
@@ -30,7 +31,7 @@ import (
 type RawDocument []byte
 
 // LogValue implements slog.LogValuer interface.
-func (doc *RawDocument) LogValue() slog.Value {
+func (doc RawDocument) LogValue() slog.Value {
 	return slogValue(doc)
 }
 
@@ -53,6 +54,21 @@ func (raw RawDocument) Decode() (*Document, error) {
 // All nested documents and arrays are decoded recursively.
 func (raw RawDocument) DecodeDeep() (*Document, error) {
 	res, err := raw.decode(true)
+	if err != nil {
+		return nil, lazyerrors.Error(err)
+	}
+
+	return res, nil
+}
+
+// Convert converts a single BSON document that takes the whole raw slice into [*types.Document].
+func (raw RawDocument) Convert() (*types.Document, error) {
+	doc, err := raw.decode(false)
+	if err != nil {
+		return nil, lazyerrors.Error(err)
+	}
+
+	res, err := doc.Convert()
 	if err != nil {
 		return nil, lazyerrors.Error(err)
 	}

--- a/internal/bson2/slog.go
+++ b/internal/bson2/slog.go
@@ -38,6 +38,9 @@ func slogValue(v any) slog.Value {
 		return slog.GroupValue(attrs...)
 
 	case RawDocument:
+		if v == nil {
+			return slog.StringValue("RawDocument(nil)")
+		}
 		return slog.StringValue("RawDocument(" + strconv.Itoa(len(v)) + " bytes)")
 
 	case *Array:
@@ -50,6 +53,9 @@ func slogValue(v any) slog.Value {
 		return slog.GroupValue(attrs...)
 
 	case RawArray:
+		if v == nil {
+			return slog.StringValue("RawArray(nil)")
+		}
 		return slog.StringValue("RawArray(" + strconv.Itoa(len(v)) + " bytes)")
 
 	default:


### PR DESCRIPTION
# Description

To simplify the transition from `bson`+`types` to `bson2`.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [x] I added/updated comments and checked rendering.
- [x] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
