### PR TITLE
Add helper for decoding document sequences

### DIFF
--- a/internal/bson2/raw_array.go
+++ b/internal/bson2/raw_array.go
@@ -22,7 +22,7 @@ import (
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
 )
 
-// RawArray represents a BSON array in the binary encoded form.
+// RawArray represents a single BSON array in the binary encoded form.
 //
 // It generally references a part of a larger slice, not a copy.
 type RawArray []byte
@@ -37,8 +37,6 @@ func (arr RawArray) LogValue() slog.Value {
 // Only top-level elements are decoded;
 // nested documents and arrays are converted to RawDocument and RawArray respectively,
 // using raw's subslices without copying.
-//
-// In debug builds, it also recursively checks that slice.
 func (raw RawArray) Decode() (*Array, error) {
 	res, err := raw.decode(decodeShallow)
 	if err != nil {
@@ -48,7 +46,7 @@ func (raw RawArray) Decode() (*Array, error) {
 	return res, nil
 }
 
-// DecodeDeep decodes a single BSON array that takes the whole byte slice.
+// DecodeDeep decodes a single valid BSON array that takes the whole byte slice.
 //
 // All nested documents and arrays are decoded recursively.
 func (raw RawArray) DecodeDeep() (*Array, error) {
@@ -70,7 +68,7 @@ func (raw RawArray) Check() error {
 	return nil
 }
 
-// Convert converts a single BSON array that takes the whole byte slice into [*types.Array].
+// Convert converts a single valid BSON array that takes the whole byte slice into [*types.Array].
 func (raw RawArray) Convert() (*types.Array, error) {
 	arr, err := raw.decode(decodeShallow)
 	if err != nil {

--- a/internal/bson2/slog.go
+++ b/internal/bson2/slog.go
@@ -89,6 +89,6 @@ func slogScalarValue(v any) slog.Value {
 	case int64:
 		return slog.StringValue(fmt.Sprintf("%[1]T(%[1]v)", v))
 	default:
-		panic(fmt.Sprintf("invalid type %T", v))
+		panic(fmt.Sprintf("invalid BSON type %T", v))
 	}
 }


### PR DESCRIPTION
# Description

It will be used during the decoding of OP_MSG sections of kind 1.

## Readiness checklist

- [x] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [x] I added/updated comments and checked rendering.
- [x] I made spot refactorings.
- [ ] I updated user documentation.
- [x] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
