### PR TITLE
Fix SCRAM for legacy shell

### DIFF
--- a/internal/util/password/scramsha256.go
+++ b/internal/util/password/scramsha256.go
@@ -28,7 +28,7 @@ import (
 
 // SCRAMSHA256Hash computes SCRAM-SHA-256 credentials and returns the document that should be stored.
 func SCRAMSHA256Hash(password string) (*types.Document, error) {
-	salt := make([]byte, fixedScramSHA256Params.saltLen-4) // minus 4 to base64 length to 40 bytes.
+	salt := make([]byte, fixedScramSHA256Params.saltLen-4) // minus 4 is needed here to encode to 40 bytes.
 	if _, err := rand.Read(salt); err != nil {
 		return nil, lazyerrors.Error(err)
 	}

--- a/internal/util/password/scramsha256.go
+++ b/internal/util/password/scramsha256.go
@@ -71,7 +71,5 @@ func scramSHA256HashParams(password string, salt []byte, params *scramParams) (*
 
 	saltedPassword := pbkdf2.Key([]byte(prepPassword), salt, params.iterationCount, sha256.Size, sha256.New)
 
-	fmt.Println(len(saltedPassword))
-
 	return scramDoc(sha256.New, saltedPassword, salt, params)
 }


### PR DESCRIPTION
<!--
Please remove comments like this one, but keep and use the rest of the template.
See CONTRIBUTING.md for details.
-->

# Description

Changes the `saltLen` and uses a suffix for the legacy shell see an error [here](https://github.com/FerretDB/dance/actions/runs/7992993540/job/21827846032?pr=784#step:9:1507).

<!--
Write a short description to explain changes that are not mentioned in the initial issue.
What were the reasons for those changes?
Which decisions did you make and why?
What else should reviewers know about your changes?
-->

<!-- Replace <issue_number> with an actual issue number. -->

## Readiness checklist

<!-- Please check all items in this checklist that were done. -->

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
