### PR TITLE
Return authentication error upon saslStart for `PLAIN` mechanism

### DIFF
--- a/internal/handler/msg_saslstart.go
+++ b/internal/handler/msg_saslstart.go
@@ -80,6 +80,10 @@ func (h *Handler) saslStart(ctx context.Context, dbName string, document *types.
 
 		conninfo.Get(ctx).SetAuth(username, password, mechanism)
 
+		if err = h.authenticate(ctx); err != nil {
+			return nil, err
+		}
+
 		var emptyPayload types.Binary
 
 		return must.NotFail(types.NewDocument(


### PR DESCRIPTION
<!--
Please remove comments like this one, but keep and use the rest of the template.
See CONTRIBUTING.md for details.
-->

# Description

<!--
Write a short description to explain changes that are not mentioned in the initial issue.
What were the reasons for those changes?
Which decisions did you make and why?
What else should reviewers know about your changes?
-->

If `SCRAM` mechanism fails during the exchange, it returns topology error from `salsContinue`. Where `PLAIN` does not call `salsContinue` so it fails after only after calling handler that requires authentication. Resulting such as below. This PR makes `PLAIN` mechanism authentication failure more similar to `SCRAM`.
 

SCRAM
```
$ docker compose exec mongodb mongosh --verbose --shell 'mongodb://wrong:wrong@host.docker.internal:27018/?authMechanism=SCRAM-SHA-1&tls=true&tlsCertificateKeyFile=/etc/certs/client.pem&tlsCaFile=/etc/certs/rootCA-cert.pem'
Current Mongosh Log ID: 65f25b089f989c4f0db9b975
Connecting to:          mongodb://<credentials>@host.docker.internal:27018/?authMechanism=SCRAM-SHA-1&tls=true&tlsCertificateKeyFile=%2Fetc%2Fcerts%2Fclient.pem&tlsCaFile=%2Fetc%2Fcerts%2FrootCA-cert.pem&
directConnection=true&appName=mongosh+2.1.4        
MongoServerError: Authentication failed.           
```

PLAIN
```
$ docker compose exec mongodb mongosh --verbose --shell 'mongodb://wrong:wrong@host.docker.internal:27018/?authMechanism=PLAIN&tls=true&tlsCertificateKeyFile=/etc/certs/client.pem&tlsCaFile=/etc/certs/rootCA-cert.pem'
Current Mongosh Log ID: 65f25b411390b079795a0017
Connecting to:          mongodb://<credentials>@host.docker.internal:27018/?authMechanism=PLAIN&tls=true&tlsCertificateKeyFile=%2Fetc%2Fcerts%2Fclient.pem&tlsCaFile=%2Fetc%2Fcerts%2FrootCA-cert.pem&directConnection=true&appName=mongosh+2.1.4
Using MongoDB:          7.0.42
Using Mongosh:          2.1.4

For mongosh info see: https://docs.mongodb.com/mongodb-shell/

Telemetry is now disabled.
test> db.runCommand({connectionStatus:1})
{
  authInfo: {
    authenticatedUsers: [ { user: 'wrong' } ],
    authenticatedUserRoles: [],
    authenticatedUserPrivileges: []
  },
  ok: 1
}
test> db.test.find()
MongoServerError[AuthenticationFailed]: Authentication failed
```

<!-- Replace <issue_number> with an actual issue number. -->

Closes #4100.

## Readiness checklist

<!-- Please check all items in this checklist that were done. -->

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [ ] I ensured that PR title is good enough for the changelog.
- [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [ ] I marked all done items in this checklist.
