### PR TITLE
Use non-privileged `scratch` for production Docker images

### DIFF
--- a/build/ferretdb/production.Dockerfile
+++ b/build/ferretdb/production.Dockerfile
@@ -86,9 +86,9 @@ go build -v -o=bin/ferretdb ./cmd/ferretdb
 
 go version -m bin/ferretdb
 bin/ferretdb --version
-EOF
 
-RUN mkdir /state
+mkdir /state
+EOF
 
 # stage for binary only
 
@@ -101,13 +101,12 @@ COPY --from=production-build /src/bin/ferretdb /ferretdb
 
 FROM scratch AS production
 
-COPY --from=production-build /src/bin/ferretdb /ferretdb
-
 COPY build/ferretdb/passwd /etc/passwd
 COPY build/ferretdb/group  /etc/group
 USER ferretdb:ferretdb
 
-COPY --chown=ferretdb:ferretdb --from=production-build /state /state
+COPY --from=production-build /src/bin/ferretdb /ferretdb
+COPY --from=production-build  --chown=ferretdb:ferretdb /state /state
 
 ENTRYPOINT [ "/ferretdb" ]
 

--- a/build/ferretdb/production.Dockerfile
+++ b/build/ferretdb/production.Dockerfile
@@ -106,7 +106,7 @@ COPY build/ferretdb/group  /etc/group
 USER ferretdb:ferretdb
 
 COPY --from=production-build /src/bin/ferretdb /ferretdb
-COPY --from=production-build  --chown=ferretdb:ferretdb /state /state
+COPY --from=production-build --chown=ferretdb:ferretdb /state /state
 
 ENTRYPOINT [ "/ferretdb" ]
 

--- a/build/ferretdb/production.Dockerfile
+++ b/build/ferretdb/production.Dockerfile
@@ -88,11 +88,7 @@ go version -m bin/ferretdb
 bin/ferretdb --version
 EOF
 
-RUN groupadd -g 1000 ferretdb
-RUN useradd -u 1000 -g 1000 ferretdb
-
 RUN mkdir /state
-RUN chown -R ferretdb:ferretdb /state
 
 # stage for binary only
 

--- a/build/ferretdb/production.Dockerfile
+++ b/build/ferretdb/production.Dockerfile
@@ -88,6 +88,11 @@ go version -m bin/ferretdb
 bin/ferretdb --version
 EOF
 
+RUN groupadd -g 1000 ferretdb
+RUN useradd -u 1000 -g 1000 ferretdb
+
+RUN mkdir /state
+RUN chown -R ferretdb:ferretdb /state
 
 # stage for binary only
 
@@ -102,10 +107,11 @@ FROM scratch AS production
 
 COPY --from=production-build /src/bin/ferretdb /ferretdb
 
-# TODO https://github.com/FerretDB/FerretDB/issues/3992
-# COPY build/ferretdb/passwd /etc/passwd
-# COPY build/ferretdb/group  /etc/group
-# USER ferretdb:ferretdb
+COPY build/ferretdb/passwd /etc/passwd
+COPY build/ferretdb/group  /etc/group
+USER ferretdb:ferretdb
+
+COPY --chown=ferretdb:ferretdb --from=production-build /state /state
 
 ENTRYPOINT [ "/ferretdb" ]
 


### PR DESCRIPTION
<!--
Please remove comments like this one, but keep and use the rest of the template.
See CONTRIBUTING.md for details.
-->

Fun fact: surprisingly, I found the answer in the only book about Docker I own 😄 

# Description

In this change, in the Dockerfile `state` dir is created explicitly, and in the final stage, its ownership is assigned to the necessary user through `--chown` flag. This explicitly sets ownership, and even if a docker container would be run with an anonymous volume (e.g. through `docker run` without setting `-v` or `--mount`), the `ferretdb` user will have the necessary permission.

In case, volume is specified when starting the container, the specified volume will be used. 
E.g. something like `docker run -v ./state:/state my-ferretdb-image` would work without having those `mkdir` and `COPY`.

<!--
Write a short description to explain changes that are not mentioned in the initial issue.
What were the reasons for those changes?
Which decisions did you make and why?
What else should reviewers know about your changes?
-->

<!-- Replace <issue_number> with an actual issue number. -->

Closes #3992.

## Readiness checklist

<!-- Please check all items in this checklist that were done. -->

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
