### PR TITLE
Populate `env-data` for running `FerretDB`

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -231,8 +231,14 @@ jobs:
       - name: Run init
         run: bin/task init
 
+      - name: Build bin/ferretdb
+        run: bin/task build-host
+
       - name: Wait for and setup environment
         run: bin/task env-setup
+
+      - name: Start FerretDB in the background
+        run: bin/task run &
 
       - name: Run env-data
         run: bin/task env-data

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,27 +124,12 @@ Please create a pull request and include the link of the pull request in the bug
 With `task` installed (see above), you may do the following:
 
 1. Start the development environment with `task env-up`.
-2. Run all tests in another terminal window with `task test` (see [below](#running-tests)).
-3. Start FerretDB with `task run`.
-   This will start it in a development mode where all requests are handled by FerretDB, but also routed to MongoDB.
-   The differences in response are then logged and the FerretDB response is sent back to the client.
-4. Fill collections in `test` database with data for experiments with `task env-data`.
+2. Run all tests with `task test` (see [below](#running-tests)).
+3. Start FerretDB with `task run`, `task run-sqlite` or `task run-proxy`.
+   (See [Operation modes](https://docs.ferretdb.io/configuration/operation-modes/) page in our documentation.)
+4. Fill collections in the `test` database with data for experiments with `task env-data`.
 5. Run `mongosh` with `task mongosh`.
-   This allows you to run commands against FerretDB.
-   For example, you can see what data was inserted by the previous command with `db.values.find()`.
-
-### Operation modes
-
-FerretDB can run in multiple operation modes.
-Operation mode specify how FerretDB handles incoming requests.
-FerretDB supports four operation modes: `normal`, `proxy`, `diff-normal`, `diff-proxy`,
-see [Operation modes documentation page](https://docs.ferretdb.io/configuration/operation-modes/) for more details.
-
-By running `task run` FerretDB starts on `diff-normal` mode, which routes all of
-the sent requests both to the FerretDB and MongoDB.
-While running, it logs a difference between both returned responses,
-but sends the one from FerretDB to the client.
-If you want to get the MongoDB response, you can run `task run-proxy` to start FerretDB in `diff-proxy` mode.
+   See what collections were created by the previous command with `show collections`.
 
 ### Code overview
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -423,7 +423,7 @@ tasks:
         --test-records-dir=tmp/records
 
   run-proxy:
-    desc: "Run FerretDB in diff-proxy mode"
+    desc: "Run FerretDB in the diff-proxy mode"
     deps: [build-host]
     cmds:
       - >
@@ -436,7 +436,7 @@ tasks:
         --test-records-dir=tmp/records
 
   run-sqlite-proxy:
-    desc: "Run FerretDB with `sqlite` handler in diff-proxy mode"
+    desc: "Run FerretDB with `sqlite` handler in the diff-proxy mode"
     deps: [build-host]
     cmds:
       - bin/envtool{{exeExt}} shell mkdir tmp/sqlite
@@ -450,7 +450,7 @@ tasks:
         --test-records-dir=tmp/records
 
   run-proxy-secured:
-    desc: "Run FerretDB in diff-proxy mode (TLS, auth required)"
+    desc: "Run FerretDB in the diff-proxy mode (TLS, auth required)"
     deps: [build-host]
     cmds:
       - >

--- a/integration/Taskfile.yml
+++ b/integration/Taskfile.yml
@@ -23,12 +23,11 @@ tasks:
         -tags=ferretdb_testenvdata .
         -target-backend=ferretdb-postgresql
         -postgresql-url=postgres://username:password@127.0.0.1:5433/ferretdb
-      - ../bin/envtool{{exeExt}} shell mkdir ../tmp/sqlite
       - >
         go test -count=1 {{.RACE_FLAG}} -run=TestEnvData
         -tags=ferretdb_testenvdata .
         -target-backend=ferretdb-sqlite
-        -sqlite-url=file:../tmp/sqlite/
+        -sqlite-url=file:../tmp/sqlite-tests/
       # no hana yet
       - >
         go test -count=1 {{.RACE_FLAG}} -run=TestEnvData

--- a/integration/Taskfile.yml
+++ b/integration/Taskfile.yml
@@ -17,18 +17,7 @@ tasks:
         go test -count=1 {{.RACE_FLAG}} -run=TestEnvData
         -tags=ferretdb_testenvdata .
         -target-backend=ferretdb-postgresql
-        -postgresql-url=postgres://username@127.0.0.1:5432/ferretdb
-      - >
-        go test -count=1 {{.RACE_FLAG}} -run=TestEnvData
-        -tags=ferretdb_testenvdata .
-        -target-backend=ferretdb-postgresql
-        -postgresql-url=postgres://username:password@127.0.0.1:5433/ferretdb
-      - >
-        go test -count=1 {{.RACE_FLAG}} -run=TestEnvData
-        -tags=ferretdb_testenvdata .
-        -target-backend=ferretdb-sqlite
-        -sqlite-url=file:../tmp/sqlite-tests/
-      # no hana yet
+        -target-url='mongodb://127.0.0.1:27017/'
       - >
         go test -count=1 {{.RACE_FLAG}} -run=TestEnvData
         -tags=ferretdb_testenvdata .

--- a/integration/setup/listener.go
+++ b/integration/setup/listener.go
@@ -95,7 +95,7 @@ func listenerMongoDBURI(tb testtb.TB, hostPort, unixSocketPath string, tlsAndAut
 
 // setupListener starts in-process FerretDB server that runs until ctx is canceled.
 // It returns basic MongoDB URI for that listener.
-func setupListener(tb testtb.TB, ctx context.Context, logger *zap.Logger, opts *BackendOpts, persistData bool) string {
+func setupListener(tb testtb.TB, ctx context.Context, logger *zap.Logger, opts *BackendOpts) string {
 	tb.Helper()
 
 	_, span := otel.Tracer("").Start(ctx, "setupListener")
@@ -147,14 +147,14 @@ func setupListener(tb testtb.TB, ctx context.Context, logger *zap.Logger, opts *
 	// use per-test PostgreSQL database to prevent handler's/backend's metadata registry
 	// read schemas owned by concurrent tests
 	postgreSQLURLF := *postgreSQLURLF
-	if postgreSQLURLF != "" && !persistData {
+	if postgreSQLURLF != "" {
 		postgreSQLURLF = testutil.TestPostgreSQLURI(tb, ctx, postgreSQLURLF)
 	}
 
 	// use per-test directory to prevent handler's/backend's metadata registry
 	// read databases owned by concurrent tests
 	sqliteURL := *sqliteURLF
-	if sqliteURL != "" && !persistData {
+	if sqliteURL != "" {
 		sqliteURL = testutil.TestSQLiteURI(tb, sqliteURL)
 	}
 

--- a/integration/setup/listener.go
+++ b/integration/setup/listener.go
@@ -144,8 +144,7 @@ func setupListener(tb testtb.TB, ctx context.Context, logger *zap.Logger, opts *
 		panic("not reached")
 	}
 
-	// use per-test PostgreSQL database to prevent handler's/backend's metadata registry
-	// read schemas owned by concurrent tests
+	// use per-test PostgreSQL database to prevent problems with parallel tests
 	postgreSQLURLF := *postgreSQLURLF
 	if postgreSQLURLF != "" {
 		postgreSQLURLF = testutil.TestPostgreSQLURI(tb, ctx, postgreSQLURLF)

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -100,10 +100,6 @@ type SetupOpts struct {
 
 	// Options to override default backend configuration.
 	BackendOptions *BackendOpts
-
-	// PersistData modifies the database given by backend url directly
-	// instead of creating a backend database that is deleted after this test.
-	PersistData bool
 }
 
 // BackendOpts represents backend configuration used for test setup.
@@ -180,7 +176,7 @@ func SetupWithOpts(tb testtb.TB, opts *SetupOpts) *SetupResult {
 			opts.BackendOptions.CappedCleanupPercentage = NewBackendOpts().CappedCleanupPercentage
 		}
 
-		uri = setupListener(tb, setupCtx, logger, opts.BackendOptions, opts.PersistData)
+		uri = setupListener(tb, setupCtx, logger, opts.BackendOptions)
 	} else {
 		uri = toAbsolutePathURI(tb, *targetURLF)
 	}

--- a/integration/setup/setup_compat.go
+++ b/integration/setup/setup_compat.go
@@ -103,7 +103,7 @@ func SetupCompatWithOpts(tb testtb.TB, opts *SetupCompatOpts) *SetupCompatResult
 
 	var targetClient *mongo.Client
 	if *targetURLF == "" {
-		uri := setupListener(tb, setupCtx, logger, NewBackendOpts(), false)
+		uri := setupListener(tb, setupCtx, logger, NewBackendOpts())
 		targetClient = setupClient(tb, setupCtx, uri)
 	} else {
 		targetClient = setupClient(tb, setupCtx, *targetURLF)

--- a/integration/shareddata_test.go
+++ b/integration/shareddata_test.go
@@ -25,9 +25,6 @@ package integration
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-	"go.mongodb.org/mongo-driver/bson"
-
 	"github.com/FerretDB/FerretDB/integration/setup"
 	"github.com/FerretDB/FerretDB/integration/shareddata"
 )
@@ -35,34 +32,16 @@ import (
 func TestEnvData(t *testing.T) {
 	t.Parallel()
 
-	var previousName string
-
 	for _, p := range shareddata.AllProviders() {
+		p := p
 		name := p.Name()
 
 		t.Run(name, func(t *testing.T) {
-			s := setup.SetupWithOpts(t, &setup.SetupOpts{
+			setup.SetupWithOpts(t, &setup.SetupOpts{
 				DatabaseName:   "test",
-				CollectionName: name,
+				CollectionName: p.Name(),
 				Providers:      []shareddata.Provider{p},
-				PersistData:    true,
 			})
-
-			// envData must persist, other integration tests do not
-			// persist data once the current t.Run() ends, hence check
-			// the collection created by the previous t.Run() persists
-			if previousName != "" {
-				ctx, database := s.Ctx, s.Collection.Database()
-				cursor, err := database.Collection(previousName).Find(ctx, bson.D{})
-				require.NoError(t, err)
-
-				var res []bson.D
-				err = cursor.All(ctx, &res)
-				require.NoError(t, err)
-				require.NotEmpty(t, res)
-			}
-
-			previousName = name
 		})
 	}
 }

--- a/integration/users/connection_test.go
+++ b/integration/users/connection_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/FerretDB/FerretDB/integration/setup"
 	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/util/must"
-	"github.com/FerretDB/FerretDB/internal/util/testutil"
 	"github.com/FerretDB/FerretDB/internal/util/testutil/testtb"
 )
 
@@ -336,7 +335,7 @@ func TestAuthenticationLocalhostException(tt *testing.T) {
 
 	t := setup.FailsForMongoDB(tt, "MongoDB is not connected via localhost")
 
-	s := setup.SetupWithOpts(t, &setup.SetupOpts{CollectionName: testutil.CollectionName(t)})
+	s := setup.SetupWithOpts(t, nil)
 	ctx := s.Ctx
 	collection := s.Collection
 	db := collection.Database()
@@ -368,8 +367,9 @@ func TestAuthenticationLocalhostException(tt *testing.T) {
 	err = db.RunCommand(ctx, firstUser).Err()
 	require.NoError(t, err, "cannot create user")
 
+	anotherUsername := "anotheruser"
 	secondUser := bson.D{
-		{"createUser", "anotheruser"},
+		{"createUser", anotherUsername},
 		{"roles", roles},
 		{"pwd", "anotherpass"},
 		{"mechanisms", bson.A{mechanism}},
@@ -404,6 +404,12 @@ func TestAuthenticationLocalhostException(tt *testing.T) {
 	db = client.Database(db.Name())
 	err = db.RunCommand(ctx, secondUser).Err()
 	require.NoError(t, err, "cannot create user")
+
+	t.Cleanup(func() {
+		// delete all users so collection cleanup does not return an authentication error
+		err = db.RunCommand(ctx, bson.D{{"dropAllUsersFromDatabase", int32(1)}}).Err()
+		require.NoError(t, err)
+	})
 }
 
 func TestAuthenticationEnableNewAuthPLAIN(tt *testing.T) {


### PR DESCRIPTION
# Description

Simplifies `task env-data` logic.

## Readiness checklist

<!-- Please check all items in this checklist that were done. -->

- [ ] I added/updated unit tests (and they pass).
- [x] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
