### PR TITLE
Add stub for the Docker healthcheck

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -655,8 +655,7 @@ tasks:
         vars:
           DOCKER_IMAGES: ferretdb-local
           OUTPUT: type=docker
-              #FILE: "{{.FILE}}"
-          TARGET: development
+          TARGET: "{{.FILE}}"
     requires:
       vars: [FILE]
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -655,7 +655,8 @@ tasks:
         vars:
           DOCKER_IMAGES: ferretdb-local
           OUTPUT: type=docker
-          TARGET: "{{.FILE}}"
+              #FILE: "{{.FILE}}"
+          TARGET: development
     requires:
       vars: [FILE]
 

--- a/build/ferretdb/all-in-one.Dockerfile
+++ b/build/ferretdb/all-in-one.Dockerfile
@@ -135,9 +135,10 @@ ENV POSTGRES_DB=ferretdb
 STOPSIGNAL SIGHUP
 ENTRYPOINT [ "/entrypoint.sh" ]
 
-HEALTHCHECK CMD /ferretdb ping
-
 # all-in-one hacks stop there
+
+HEALTHCHECK --interval=30s --timeout=30s --start-period=0s --start-interval=5s --retries=3 \ 
+  CMD /ferretdb ping 
 
 WORKDIR /
 VOLUME /state

--- a/build/ferretdb/all-in-one.Dockerfile
+++ b/build/ferretdb/all-in-one.Dockerfile
@@ -135,6 +135,8 @@ ENV POSTGRES_DB=ferretdb
 STOPSIGNAL SIGHUP
 ENTRYPOINT [ "/entrypoint.sh" ]
 
+HEALTHCHECK CMD /ferretdb ping
+
 # all-in-one hacks stop there
 
 WORKDIR /

--- a/build/ferretdb/development.Dockerfile
+++ b/build/ferretdb/development.Dockerfile
@@ -118,7 +118,8 @@ COPY --from=development-build /src/bin/ferretdb /ferretdb
 
 ENTRYPOINT [ "/ferretdb" ]
 
-HEALTHCHECK CMD /ferretdb ping
+HEALTHCHECK --interval=30s --timeout=30s --start-period=0s --start-interval=5s --retries=3 \ 
+  CMD /ferretdb ping 
 
 WORKDIR /
 VOLUME /state

--- a/build/ferretdb/development.Dockerfile
+++ b/build/ferretdb/development.Dockerfile
@@ -118,8 +118,7 @@ COPY --from=development-build /src/bin/ferretdb /ferretdb
 
 ENTRYPOINT [ "/ferretdb" ]
 
-HEALTHCHECK \
-  CMD /ferretdb ping
+HEALTHCHECK CMD /ferretdb ping
 
 WORKDIR /
 VOLUME /state

--- a/build/ferretdb/development.Dockerfile
+++ b/build/ferretdb/development.Dockerfile
@@ -118,6 +118,9 @@ COPY --from=development-build /src/bin/ferretdb /ferretdb
 
 ENTRYPOINT [ "/ferretdb" ]
 
+HEALTHCHECK \
+  CMD /ferretdb ping
+
 WORKDIR /
 VOLUME /state
 EXPOSE 27017 27018 8088

--- a/build/ferretdb/production.Dockerfile
+++ b/build/ferretdb/production.Dockerfile
@@ -110,7 +110,8 @@ COPY --from=production-build --chown=ferretdb:ferretdb /state /state
 
 ENTRYPOINT [ "/ferretdb" ]
 
-HEALTHCHECK CMD /ferretdb ping
+HEALTHCHECK --interval=30s --timeout=30s --start-period=0s --start-interval=5s --retries=3 \ 
+  CMD /ferretdb ping 
 
 WORKDIR /
 VOLUME /state

--- a/build/ferretdb/production.Dockerfile
+++ b/build/ferretdb/production.Dockerfile
@@ -110,6 +110,8 @@ COPY --from=production-build --chown=ferretdb:ferretdb /state /state
 
 ENTRYPOINT [ "/ferretdb" ]
 
+HEALTHCHECK CMD /ferretdb ping
+
 WORKDIR /
 VOLUME /state
 EXPOSE 27017 27018 8088

--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -57,6 +57,7 @@ import (
 //
 // Keep order in sync with documentation.
 var cli struct {
+	// We hide `run` command to show only `ping` in the help message.
 	Run  struct{} `cmd:"" default:"1"                             hidden:""`
 	Ping struct{} `cmd:"" help:"Ping existing FerretDB instance."`
 

--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -267,17 +267,12 @@ func ping() {
 	}
 
 	if cli.Listen.Unix != "" {
-		u := &url.URL{
-			Scheme: "mongodb",
-			Host:   cli.Listen.Unix,
-			Path:   cli.Setup.Database,
-			User:   url.UserPassword(cli.Setup.Username, cli.Setup.Password),
-		}
-
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 
-		client, err := mongo.Connect(ctx, options.Client().ApplyURI(u.String()))
+		u := strings.ReplaceAll(cli.Listen.Addr, "/", "%2F")
+
+		client, err := mongo.Connect(ctx, options.Client().ApplyURI("mongodb://"+u))
 		if err != nil {
 			l.Fatal(err)
 		}

--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -246,22 +246,17 @@ func ping() {
 		host = "127.0.0.1"
 	}
 
-	// is it possible?
-	if port == "" {
-		port = "27017"
+	u := &url.URL{
+		Scheme: "mongodb",
+		Host:   fmt.Sprintf("%s:%s", host, port),
+		Path:   cli.Setup.Database,
+		User:   url.UserPassword(cli.Setup.Username, cli.Setup.Password),
 	}
-
-	addr, err := url.Parse(fmt.Sprintf("mongodb://%s:%s", host, port))
-	if err != nil {
-		l.Fatal(err)
-	}
-
-	addr.User = url.UserPassword(cli.Setup.Username, cli.Setup.Password)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	client, err := mongo.Connect(ctx, options.Client().ApplyURI(addr.String()))
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(u.String()))
 	if err != nil {
 		l.Fatal(err)
 	}

--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -229,7 +229,6 @@ func ping() {
 	}
 
 	// TODO TLS, Socket
-	// TODO timeout
 
 	host, port, err := net.SplitHostPort(cli.Listen.Addr)
 	if err != nil {
@@ -250,7 +249,9 @@ func ping() {
 		log.Fatal(err)
 	}
 
-	ctx := context.TODO()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
 	client, err := mongo.Connect(ctx, options.Client().ApplyURI(addr.String()))
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -229,6 +229,7 @@ func ping() {
 	}
 
 	// TODO TLS, Socket
+	// TODO timeout
 
 	host, port, err := net.SplitHostPort(cli.Listen.Addr)
 	if err != nil {

--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -57,8 +57,8 @@ import (
 //
 // Keep order in sync with documentation.
 var cli struct {
-	Run  struct{} `cmd:"" default:"1"`
-	Ping struct{} `cmd:""`
+	Run  struct{} `cmd:"Start FerretDB." default:"1"`
+	Ping struct{} `cmd:"Ping existing FerretDB instance."`
 
 	Version     bool   `default:"false"           help:"Print version to stdout and exit." env:"-"`
 	Handler     string `default:"postgresql"      help:"${help_handler}"`
@@ -223,7 +223,14 @@ func main() {
 	}
 }
 
+// ping creates connection to FerretDB instance specified by the flags, and runs `ping` command against it.
+// If
 func ping() {
+	logger := setupLogger(setupState(), cli.Log.Format)
+	l := logger.Sugar()
+
+	checkFlags(logger)
+
 	if cli.Listen.Addr == "" {
 		return
 	}
@@ -238,7 +245,7 @@ func ping() {
 
 	host, port, err := net.SplitHostPort(cli.Listen.Addr)
 	if err != nil {
-		log.Fatal(err)
+		l.Fatal(err)
 	}
 
 	if host == "" {
@@ -252,7 +259,7 @@ func ping() {
 
 	addr, err := url.Parse(fmt.Sprintf("mongodb://%s:%s", host, port))
 	if err != nil {
-		log.Fatal(err)
+		l.Fatal(err)
 	}
 
 	addr.User = url.UserPassword(cli.Setup.Username, cli.Setup.Password)
@@ -262,12 +269,12 @@ func ping() {
 
 	client, err := mongo.Connect(ctx, options.Client().ApplyURI(addr.String()))
 	if err != nil {
-		log.Fatal(err)
+		l.Fatal(err)
 	}
 
 	defer client.Disconnect(ctx)
 	if err = client.Ping(ctx, nil); err != nil {
-		log.Fatal(err)
+		l.Fatal(err)
 	}
 }
 

--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -53,6 +53,9 @@ import (
 //
 // Keep order in sync with documentation.
 var cli struct {
+	Run  struct{} `cmd:"" default:"1"`
+	Ping struct{} `cmd:""`
+
 	Version     bool   `default:"false"           help:"Print version to stdout and exit." env:"-"`
 	Handler     string `default:"postgresql"      help:"${help_handler}"`
 	Mode        string `default:"${default_mode}" help:"${help_mode}"                      enum:"${enum_mode}"`
@@ -204,9 +207,16 @@ var (
 
 func main() {
 	setCLIPlugins()
-	kong.Parse(&cli, kongOptions...)
+	ctx := kong.Parse(&cli, kongOptions...)
 
-	run()
+	switch ctx.Command() {
+	case "run":
+		run()
+	case "ping":
+		log.Print("TODO ping")
+	default:
+		panic("not reachable")
+	}
 }
 
 // defaultLogLevel returns the default log level.

--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -231,13 +231,7 @@ func ping() {
 
 	checkFlags(logger)
 
-	if cli.Listen.Addr == "" {
-		return
-	}
-
-	if cli.Setup.Database == "" ||
-		cli.Setup.Username == "" ||
-		cli.Setup.Password == "" {
+	if cli.Listen.Addr == "" || cli.Setup.Database == "" {
 		return
 	}
 
@@ -273,6 +267,7 @@ func ping() {
 	}
 
 	defer client.Disconnect(ctx)
+
 	if err = client.Ping(ctx, nil); err != nil {
 		l.Fatal(err)
 	}

--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -288,8 +288,6 @@ func ping() {
 			l.Fatal(err)
 		}
 	}
-
-	// TODO TLS, Socket
 }
 
 // defaultLogLevel returns the default log level.

--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -274,7 +274,7 @@ func ping() {
 		ctx, cancel := context.WithTimeout(context.Background(), cli.Setup.Timeout)
 		defer cancel()
 
-		u := strings.ReplaceAll(cli.Listen.Addr, "/", "%2F")
+		u := strings.ReplaceAll(cli.Listen.Unix, "/", "%2F")
 
 		client, err := mongo.Connect(ctx, options.Client().ApplyURI("mongodb://"+u))
 		if err != nil {

--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -240,6 +240,7 @@ func ping() {
 		host = "127.0.0.1"
 	}
 
+	// is it possible?
 	if port == "" {
 		port = "27017"
 	}

--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -57,8 +57,8 @@ import (
 //
 // Keep order in sync with documentation.
 var cli struct {
-	Run  struct{} `cmd:"Start FerretDB."                  default:"1"`
-	Ping struct{} `cmd:"Ping existing FerretDB instance."`
+	Run  struct{} `cmd:"" default:"1"                             hidden:""`
+	Ping struct{} `cmd:"" help:"Ping existing FerretDB instance."`
 
 	Version     bool   `default:"false"           help:"Print version to stdout and exit." env:"-"`
 	Handler     string `default:"postgresql"      help:"${help_handler}"`
@@ -193,6 +193,9 @@ var (
 	logFormats = []string{"console", "json"}
 
 	kongOptions = []kong.Option{
+		kong.HelpOptions{
+			Compact: true,
+		},
 		kong.Vars{
 			"default_log_level": defaultLogLevel().String(),
 			"default_mode":      clientconn.AllModes[0],

--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -57,7 +57,7 @@ import (
 //
 // Keep order in sync with documentation.
 var cli struct {
-	Run  struct{} `cmd:"Start FerretDB." default:"1"`
+	Run  struct{} `cmd:"Start FerretDB."                  default:"1"`
 	Ping struct{} `cmd:"Ping existing FerretDB instance."`
 
 	Version     bool   `default:"false"           help:"Print version to stdout and exit." env:"-"`
@@ -251,7 +251,7 @@ func ping() {
 			User:   url.UserPassword(cli.Setup.Username, cli.Setup.Password),
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), cli.Setup.Timeout)
 		defer cancel()
 
 		client, err := mongo.Connect(ctx, options.Client().ApplyURI(u.String()))
@@ -259,7 +259,11 @@ func ping() {
 			l.Fatal(err)
 		}
 
-		defer client.Disconnect(ctx)
+		defer func() {
+			if err = client.Disconnect(ctx); err != nil {
+				l.Fatal(err)
+			}
+		}()
 
 		if err = client.Ping(ctx, nil); err != nil {
 			l.Fatal(err)
@@ -267,7 +271,7 @@ func ping() {
 	}
 
 	if cli.Listen.Unix != "" {
-		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), cli.Setup.Timeout)
 		defer cancel()
 
 		u := strings.ReplaceAll(cli.Listen.Addr, "/", "%2F")
@@ -277,7 +281,11 @@ func ping() {
 			l.Fatal(err)
 		}
 
-		defer client.Disconnect(ctx)
+		defer func() {
+			if err = client.Disconnect(ctx); err != nil {
+				l.Fatal(err)
+			}
+		}()
 
 		if err = client.Ping(ctx, nil); err != nil {
 			l.Fatal(err)

--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -219,12 +219,11 @@ func main() {
 	case "ping":
 		ping()
 	default:
-		panic("not reachable")
+		panic("unknown sub-command")
 	}
 }
 
 // ping creates connection to FerretDB instance specified by the flags, and runs `ping` command against it.
-// If
 func ping() {
 	logger := setupLogger(setupState(), cli.Log.Format)
 	l := logger.Sugar()

--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -228,6 +228,12 @@ func ping() {
 		return
 	}
 
+	if cli.Setup.Database == "" ||
+		cli.Setup.Username == "" ||
+		cli.Setup.Password == "" {
+		return
+	}
+
 	// TODO TLS, Socket
 
 	host, port, err := net.SplitHostPort(cli.Listen.Addr)
@@ -248,6 +254,8 @@ func ping() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	addr.User = url.UserPassword(cli.Setup.Username, cli.Setup.Password)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()


### PR DESCRIPTION
Closes #4246.

Ping implementation will be done in #4364.

```
./bin/ferretdb --help
warning: GOCOVERDIR not set, no coverage data emitted
Usage: ferretdb <command> [flags]

Flags:
  -h, --help                                                   Show context-sensitive help.
      --version                                                Print version to stdout and exit.
      --handler="postgresql"                                   Backend handler: 'postgresql', 'sqlite', 'hana', 'mysql' ($FERRETDB_HANDLER).
      --mode="normal"                                          Operation mode: 'normal', 'proxy', 'diff-normal', 'diff-proxy' ($FERRETDB_MODE).
      --state-dir="."                                          Process state directory ($FERRETDB_STATE_DIR).
      --repl-set-name=""                                       Replica set name ($FERRETDB_REPL_SET_NAME).
      --listen-addr="127.0.0.1:27017"                          Listen TCP address ($FERRETDB_LISTEN_ADDR).
      --listen-unix=""                                         Listen Unix domain socket path ($FERRETDB_LISTEN_UNIX).
      --listen-tls=""                                          Listen TLS address ($FERRETDB_LISTEN_TLS).
      --listen-tls-cert-file=""                                TLS cert file path ($FERRETDB_LISTEN_TLS_CERT_FILE).
      --listen-tls-key-file=""                                 TLS key file path ($FERRETDB_LISTEN_TLS_KEY_FILE).
      --listen-tls-ca-file=""                                  TLS CA file path ($FERRETDB_LISTEN_TLS_CA_FILE).
      --proxy-addr=""                                          Proxy address ($FERRETDB_PROXY_ADDR).
      --proxy-tls-cert-file=""                                 Proxy TLS cert file path ($FERRETDB_PROXY_TLS_CERT_FILE).
      --proxy-tls-key-file=""                                  Proxy TLS key file path ($FERRETDB_PROXY_TLS_KEY_FILE).
      --proxy-tls-ca-file=""                                   Proxy TLS CA file path ($FERRETDB_PROXY_TLS_CA_FILE).
      --debug-addr="127.0.0.1:8088"                            Listen address for HTTP handlers for metrics, pprof, etc ($FERRETDB_DEBUG_ADDR).
      --postgresql-url="postgres://127.0.0.1:5432/ferretdb"    PostgreSQL URL for 'postgresql' handler ($FERRETDB_POSTGRESQL_URL).
      --sqlite-url="file:data/"                                SQLite URI (directory) for 'sqlite' handler ($FERRETDB_SQLITE_URL).
      --hana-url=STRING                                        SAP HANA URL for 'hana' handler ($FERRETDB_HANA_URL)
      --setup-database=""                                      Setup database during backend initialization ($FERRETDB_SETUP_DATABASE).
      --setup-username=""                                      Setup user during backend initialization ($FERRETDB_SETUP_USERNAME).
      --setup-password=""                                      Setup user's password ($FERRETDB_SETUP_PASSWORD).
      --setup-timeout=30s                                      Setup timeout ($FERRETDB_SETUP_TIMEOUT).
      --log-level="debug"                                      Log level: 'debug', 'info', 'warn', 'error' ($FERRETDB_LOG_LEVEL).
      --log-format="console"                                   Log format: 'console', 'json' ($FERRETDB_LOG_FORMAT).
      --[no-]log-uuid                                          Add instance UUID to all log messages ($FERRETDB_LOG_UUID).
      --[no-]metrics-uuid                                      Add instance UUID to all metrics ($FERRETDB_METRICS_UUID).
      --telemetry=undecided                                    Enable or disable basic telemetry. See https://beacon.ferretdb.com ($FERRETDB_TELEMETRY).
      --test-records-dir=""                                    Testing: directory for record files ($FERRETDB_TEST_RECORDS_DIR).
      --test-disable-pushdown                                  Experimental: disable pushdown ($FERRETDB_TEST_DISABLE_PUSHDOWN).
      --test-enable-nested-pushdown                            Experimental: enable pushdown for dot notation ($FERRETDB_TEST_ENABLE_NESTED_PUSHDOWN).
      --test-capped-cleanup-interval=1m                        Experimental: capped collections cleanup interval ($FERRETDB_TEST_CAPPED_CLEANUP_INTERVAL).
      --test-capped-cleanup-percentage=10                      Experimental: percentage of documents to cleanup ($FERRETDB_TEST_CAPPED_CLEANUP_PERCENTAGE).
      --test-enable-new-auth                                   Experimental: enable new authentication ($FERRETDB_TEST_ENABLE_NEW_AUTH).
      --test-batch-size=100                                    Experimental: maximum insertion batch size ($FERRETDB_TEST_BATCH_SIZE).
      --test-max-bson-object-size-mi-b=16                      Experimental: maximum BSON object size in MiB ($FERRETDB_TEST_MAX_BSON_OBJECT_SIZE_MI_B).
      --test-telemetry-url="https://beacon.ferretdb.com/"      Telemetry: reporting URL ($FERRETDB_TEST_TELEMETRY_URL).
      --test-telemetry-undecided-delay=1h                      Telemetry: delay for undecided state ($FERRETDB_TEST_TELEMETRY_UNDECIDED_DELAY).
      --test-telemetry-report-interval=24h                     Telemetry: report interval ($FERRETDB_TEST_TELEMETRY_REPORT_INTERVAL).
      --test-telemetry-report-timeout=5s                       Telemetry: report timeout ($FERRETDB_TEST_TELEMETRY_REPORT_TIMEOUT).
      --test-telemetry-package=""                              Telemetry: custom package type ($FERRETDB_TEST_TELEMETRY_PACKAGE).

Commands:
  run [flags]

  ping [flags]

Run "ferretdb <command> --help" for more information on a command.
```


## Readiness checklist

<!-- Please check all items in this checklist that were done. -->

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [x] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
