### PR TITLE
Check database name for authentication

### DIFF
--- a/integration/setup/listener.go
+++ b/integration/setup/listener.go
@@ -53,7 +53,7 @@ func unixSocketPath(tb testtb.TB) string {
 }
 
 // listenerMongoDBURI builds MongoDB URI for in-process FerretDB.
-func listenerMongoDBURI(tb testtb.TB, hostPort, unixSocketPath string, tlsAndAuth, enableNewAuth bool) string {
+func listenerMongoDBURI(tb testtb.TB, hostPort, unixSocketPath, newAuthDB string, tlsAndAuth bool) string {
 	tb.Helper()
 
 	var host string
@@ -81,15 +81,18 @@ func listenerMongoDBURI(tb testtb.TB, hostPort, unixSocketPath string, tlsAndAut
 		user = url.UserPassword("username", "password")
 	}
 
-	if enableNewAuth {
+	path := "/"
+
+	if newAuthDB != "" {
 		q.Set("authMechanism", "SCRAM-SHA-256")
+		path += newAuthDB
 	}
 
 	// TODO https://github.com/FerretDB/FerretDB/issues/1507
 	u := &url.URL{
 		Scheme:   "mongodb",
 		Host:     host,
-		Path:     "/",
+		Path:     path,
 		User:     user,
 		RawQuery: q.Encode(),
 	}
@@ -196,7 +199,7 @@ func setupListener(tb testtb.TB, ctx context.Context, logger *zap.Logger, opts *
 	}
 
 	if !opts.DisableNewAuth {
-		handlerOpts.SetupDatabase = "admin"
+		handlerOpts.SetupDatabase = "test"
 		handlerOpts.SetupUsername = "username"
 		handlerOpts.SetupPassword = password.WrapPassword("password")
 		handlerOpts.SetupTimeout = 1 * time.Second
@@ -272,7 +275,7 @@ func setupListener(tb testtb.TB, ctx context.Context, logger *zap.Logger, opts *
 		hostPort = l.TCPAddr().String()
 	}
 
-	uri := listenerMongoDBURI(tb, hostPort, unixSocketPath, tlsAndAuth, !opts.DisableNewAuth)
+	uri := listenerMongoDBURI(tb, hostPort, unixSocketPath, handlerOpts.SetupDatabase, tlsAndAuth)
 
 	logger.Info("Listener started", zap.String("handler", handler), zap.String("uri", uri))
 

--- a/integration/setup/listener.go
+++ b/integration/setup/listener.go
@@ -196,7 +196,7 @@ func setupListener(tb testtb.TB, ctx context.Context, logger *zap.Logger, opts *
 	}
 
 	if !opts.DisableNewAuth {
-		handlerOpts.SetupDatabase = "test"
+		handlerOpts.SetupDatabase = "admin"
 		handlerOpts.SetupUsername = "username"
 		handlerOpts.SetupPassword = password.WrapPassword("password")
 		handlerOpts.SetupTimeout = 1 * time.Second

--- a/internal/handler/cmd_query.go
+++ b/internal/handler/cmd_query.go
@@ -80,10 +80,7 @@ func (h *Handler) CmdQuery(ctx context.Context, query *wire.OpQuery) (*wire.OpRe
 			return &opReply, nil
 		}
 
-		// TODO https://github.com/FerretDB/FerretDB/issues/4392
-		_ = dbName
-
-		speculativeAuthenticate, err := h.saslStart(ctx, authDoc)
+		speculativeAuthenticate, err := h.saslStart(ctx, dbName, authDoc)
 		if err != nil {
 			h.L.Debug("Speculative authentication failed", zap.Error(err))
 


### PR DESCRIPTION
<!--
Please remove comments like this one, but keep and use the rest of the template.
See CONTRIBUTING.md for details.
-->

# Description

<!--
Write a short description to explain changes that are not mentioned in the initial issue.
What were the reasons for those changes?
Which decisions did you make and why?
What else should reviewers know about your changes?
-->

We should use the database name as part of authentication. For example, `db1.user` and `db2.user` are two different users despite the same name. If `db1.user` user should have an access right to `db2` or other databases, it is assigned via authorization roles. https://www.mongodb.com/docs/manual/core/security-users/#authentication-database

<!-- Replace <issue_number> with an actual issue number. -->

Closes #4392.

## Readiness checklist

<!-- Please check all items in this checklist that were done. -->

- [ ] I added/updated unit tests (and they pass).
- [x] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
