### PR TITLE
Add an ability to exclude particular spans from being recorded in traces

### DIFF
--- a/cmd/envtool/tests.go
+++ b/cmd/envtool/tests.go
@@ -169,6 +169,7 @@ func runGoTest(ctx context.Context, args []string, total int, times bool, logger
 			must.NotBeZero(parentCtx)
 			must.NotBeZero(spanName)
 
+			/// ???? Unfinished span ???
 			res.ctx, _ = otel.Tracer("").Start(parentCtx, spanName, oteltrace.WithAttributes(attributes...))
 			res.outputs = make([]string, 0, 2)
 		}

--- a/cmd/envtool/tests.go
+++ b/cmd/envtool/tests.go
@@ -169,7 +169,6 @@ func runGoTest(ctx context.Context, args []string, total int, times bool, logger
 			must.NotBeZero(parentCtx)
 			must.NotBeZero(spanName)
 
-			/// ???? Unfinished span ???
 			res.ctx, _ = otel.Tracer("").Start(parentCtx, spanName, oteltrace.WithAttributes(attributes...))
 			res.outputs = make([]string, 0, 2)
 		}

--- a/cmd/envtool/tests.go
+++ b/cmd/envtool/tests.go
@@ -379,9 +379,10 @@ func testsRun(ctx context.Context, index, total uint, run, skip string, args []s
 	}
 
 	ot, err := observability.NewOtelTracer(&observability.OtelTracerOpts{
-		Logger:   logger.Desugar(),
-		Service:  "envtool-tests",
-		Endpoint: "127.0.0.1:4318",
+		Logger:     logger.Desugar(),
+		Service:    "envtool-tests",
+		Endpoint:   "127.0.0.1:4318",
+		WithFilter: true,
 	})
 	if err != nil {
 		return lazyerrors.Error(err)

--- a/integration/diff_08_names_test.go
+++ b/integration/diff_08_names_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"go.opentelemetry.io/otel"
+
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/FerretDB/FerretDB/internal/util/observability"
@@ -84,7 +85,7 @@ func TestDiffCollectionName(t *testing.T) {
 				ctx, collection := setup.Setup(t)
 
 				var span trace.Span
-				ctx, span = otel.Tracer("").Start(ctx, "FOO", trace.WithAttributes(observability.ExclusionAttribute))
+				ctx, span = otel.Tracer("").Start(ctx, "FOO")
 				span.SetAttributes(observability.ExclusionAttribute)
 				defer span.End()
 

--- a/integration/diff_08_names_test.go
+++ b/integration/diff_08_names_test.go
@@ -72,7 +72,7 @@ func TestDiffCollectionName(t *testing.T) {
 
 	testcases := map[string]string{
 		"ReservedPrefix": "_ferretdb_xxx",
-		"NonUTF-8":       string([]byte{0xff, 0xfe, 0xfd}),
+		//"NonUTF-8":       string([]byte{0xff, 0xfe, 0xfd}),
 	}
 
 	t.Run("CreateCollection", func(t *testing.T) {
@@ -84,7 +84,7 @@ func TestDiffCollectionName(t *testing.T) {
 				ctx, collection := setup.Setup(t)
 
 				var span trace.Span
-				ctx, span = otel.Tracer("").Start(ctx, "CreateCollection"+name)
+				ctx, span = otel.Tracer("").Start(ctx, "FOO", trace.WithAttributes(observability.ExclusionAttribute))
 				span.SetAttributes(observability.ExclusionAttribute)
 				defer span.End()
 

--- a/integration/diff_08_names_test.go
+++ b/integration/diff_08_names_test.go
@@ -18,16 +18,13 @@ import (
 	"fmt"
 	"testing"
 
-	"go.opentelemetry.io/otel"
-
-	"go.opentelemetry.io/otel/trace"
-
-	"github.com/FerretDB/FerretDB/internal/util/observability"
-
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 
+	"github.com/FerretDB/FerretDB/internal/util/observability"
 	"github.com/FerretDB/FerretDB/internal/util/testutil"
 
 	"github.com/FerretDB/FerretDB/integration/setup"
@@ -91,6 +88,7 @@ func TestDiffCollectionName(t *testing.T) {
 					var span trace.Span
 					ctx, span = otel.Tracer("").Start(ctx, name+"ToExclude")
 					span.SetAttributes(observability.ExclusionAttribute)
+
 					defer span.End()
 				}
 
@@ -122,6 +120,7 @@ func TestDiffCollectionName(t *testing.T) {
 					var span trace.Span
 					ctx, span = otel.Tracer("").Start(ctx, name+"ToExclude")
 					span.SetAttributes(observability.ExclusionAttribute)
+
 					defer span.End()
 				}
 

--- a/integration/diff_08_names_test.go
+++ b/integration/diff_08_names_test.go
@@ -85,9 +85,8 @@ func TestDiffCollectionName(t *testing.T) {
 
 				var span trace.Span
 				ctx, span = otel.Tracer("").Start(ctx, "CreateCollection"+name)
-				defer span.End()
-
 				span.SetAttributes(observability.ExclusionAttribute)
+				defer span.End()
 
 				err := collection.Database().CreateCollection(ctx, cName)
 

--- a/integration/diff_08_names_test.go
+++ b/integration/diff_08_names_test.go
@@ -18,9 +18,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/FerretDB/FerretDB/internal/util/observability"
-
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/FerretDB/FerretDB/internal/util/observability"
 
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -82,8 +83,11 @@ func TestDiffCollectionName(t *testing.T) {
 
 				ctx, collection := setup.Setup(t)
 
-				currentSpan := trace.SpanFromContext(ctx)
-				currentSpan.SetAttributes(observability.ExclusionAttribute)
+				var span trace.Span
+				ctx, span = otel.Tracer("").Start(ctx, "CreateCollection"+name)
+				defer span.End()
+
+				span.SetAttributes(observability.ExclusionAttribute)
 
 				err := collection.Database().CreateCollection(ctx, cName)
 

--- a/integration/diff_08_names_test.go
+++ b/integration/diff_08_names_test.go
@@ -73,7 +73,7 @@ func TestDiffCollectionName(t *testing.T) {
 
 	testcases := map[string]string{
 		"ReservedPrefix": "_ferretdb_xxx",
-		//"NonUTF-8":       string([]byte{0xff, 0xfe, 0xfd}),
+		"NonUTF-8":       string([]byte{0xff, 0xfe, 0xfd}),
 	}
 
 	t.Run("CreateCollection", func(t *testing.T) {

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -14,6 +14,7 @@ require (
 	go.mongodb.org/mongo-driver v1.16.0
 	go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo v0.52.0
 	go.opentelemetry.io/otel v1.28.0
+	go.opentelemetry.io/otel/trace v1.28.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8
 )
@@ -61,7 +62,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.28.0 // indirect
 	go.opentelemetry.io/otel/metric v1.28.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.28.0 // indirect
-	go.opentelemetry.io/otel/trace v1.28.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/crypto v0.24.0 // indirect

--- a/integration/setup/startup.go
+++ b/integration/setup/startup.go
@@ -71,9 +71,10 @@ func Startup() {
 	}
 
 	ot, err := observability.NewOtelTracer(&observability.OtelTracerOpts{
-		Logger:   zap.L().Named("otel"),
-		Service:  "integration-tests",
-		Endpoint: "127.0.0.1:4318",
+		Logger:     zap.L().Named("otel"),
+		Service:    "integration-tests",
+		Endpoint:   "127.0.0.1:4318",
+		WithFilter: true,
 	})
 	if err != nil {
 		zap.S().Fatalf("Failed to create Otel tracer: %s.", err)

--- a/internal/util/observability/observability.go
+++ b/internal/util/observability/observability.go
@@ -142,7 +142,6 @@ func (e *ExporterWithFilter) ExportSpans(ctx context.Context, spans []otelsdktra
 		}
 	}
 
-	// If there are no spans to exclude, just export all spans.
 	if len(parents) == 0 {
 		return e.exporter.ExportSpans(ctx, spans)
 	}

--- a/internal/util/observability/observability.go
+++ b/internal/util/observability/observability.go
@@ -52,7 +52,7 @@ type OtelTracerOpts struct {
 	Service    string
 	Version    string
 	Endpoint   string
-	WithFilter bool // If true, the tracer will filter out spans with ExclusionAttribute.
+	WithFilter bool // If true, the exporter will filter out spans with ExclusionAttribute.
 }
 
 // NewOtelTracer sets up OTLP tracer.

--- a/internal/util/observability/observability.go
+++ b/internal/util/observability/observability.go
@@ -20,7 +20,6 @@ package observability
 import (
 	"context"
 	"errors"
-	"slices"
 	"sync/atomic"
 	"time"
 
@@ -31,7 +30,6 @@ import (
 	otelsdkresource "go.opentelemetry.io/otel/sdk/resource"
 	otelsdktrace "go.opentelemetry.io/otel/sdk/trace"
 	otelsemconv "go.opentelemetry.io/otel/semconv/v1.21.0"
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/FerretDB/FerretDB/internal/util/ctxutil"
@@ -125,9 +123,9 @@ type ExporterWithFilter struct {
 var ExclusionAttribute = attribute.KeyValue{Key: "excluded"}
 
 func (e *ExporterWithFilter) ExportSpans(ctx context.Context, spans []otelsdktrace.ReadOnlySpan) error {
-	excluded := make(map[trace.SpanID]struct{})
+	/*excluded := make(map[trace.SpanID]struct{})
 
-	for i, span := range spans {
+		for i, span := range spans {
 		if slices.Contains(span.Attributes(), ExclusionAttribute) {
 			excluded[span.SpanContext().SpanID()] = struct{}{}
 		}
@@ -138,12 +136,12 @@ func (e *ExporterWithFilter) ExportSpans(ctx context.Context, spans []otelsdktra
 			}
 		}
 	}
-
+	*/
 	var filteredSpans []otelsdktrace.ReadOnlySpan
 	for _, span := range spans {
-		if _, ok := excluded[span.SpanContext().SpanID()]; !ok {
-			filteredSpans = append(filteredSpans, span)
-		}
+		//	if _, ok := excluded[span.SpanContext().SpanID()]; !ok {
+		filteredSpans = append(filteredSpans, span)
+		//	}
 	}
 
 	return e.exporter.ExportSpans(ctx, filteredSpans)

--- a/internal/util/observability/observability_test.go
+++ b/internal/util/observability/observability_test.go
@@ -1,0 +1,64 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package observability
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestExporterWithFilter(t *testing.T) {
+	t.Parallel()
+
+	inMemExporter := tracetest.NewInMemoryExporter()
+
+	exporter := ExporterWithFilter{exporter: inMemExporter}
+	require.NotNil(t, exporter)
+
+	root := tracetest.SpanStub{
+		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{SpanID: trace.SpanID{1}}),
+	}
+	span := tracetest.SpanStub{
+		Parent:      root.Parent,
+		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{SpanID: trace.SpanID{11}}),
+	}
+	subspan := tracetest.SpanStub{
+		Parent:      span.SpanContext,
+		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{SpanID: trace.SpanID{111}}),
+	}
+	excludedSpan := tracetest.SpanStub{
+		Parent:      root.Parent,
+		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{SpanID: trace.SpanID{12}}),
+		Attributes:  []attribute.KeyValue{ExclusionAttribute},
+	}
+	exludedSubspan := tracetest.SpanStub{
+		Parent:      excludedSpan.SpanContext,
+		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{SpanID: trace.SpanID{121}}),
+	}
+
+	spans := []tracetest.SpanStub{root, span, subspan, excludedSpan, exludedSubspan}
+
+	require.NoError(t, exporter.ExportSpans(context.Background(), tracetest.SpanStubs(spans).Snapshots()))
+
+	filteredSpans := inMemExporter.GetSpans()
+
+	require.Len(t, filteredSpans, 3)
+}

--- a/internal/util/observability/observability_test.go
+++ b/internal/util/observability/observability_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package observability
 
 import (


### PR DESCRIPTION
<!--
Please remove comments like this one, but keep and use the rest of the template.
See CONTRIBUTING.md for details.
-->

# Description

<!--
Write a short description to explain changes that are not mentioned in the initial issue.
What were the reasons for those changes?
Which decisions did you make and why?
What else should reviewers know about your changes?
-->

<!-- Replace <issue_number> with an actual issue number. -->

Closes #4345.

The implementation is based on this discussion: https://github.com/open-telemetry/opentelemetry-go/issues/4718.

Also, if it were possible to propagate parent's attributes to all the children's spans automatically, the algorithm of span exclusion would be much easier. But there isn't an option for it, so we need to find all the children while exporting spans.

Please leave your feedback if you see that something can be simplified.

## Readiness checklist

<!-- Please check all items in this checklist that were done. -->

- [x] I added/updated unit tests (and they pass).
- [x] I added/updated integration/compatibility tests (and they pass).
- [x] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
