### PR TITLE
Stop Otel exporter gracefully in `envtool`

### DIFF
--- a/integration/aggregate_documents_compat_test.go
+++ b/integration/aggregate_documents_compat_test.go
@@ -62,15 +62,12 @@ func testAggregateStagesCompatWithProviders(t *testing.T, providers shareddata.P
 	ctx, targetCollections, compatCollections := s.Ctx, s.TargetCollections, s.CompatCollections
 
 	for name, tc := range testCases {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Helper()
 
 			if tc.skip != "" {
 				t.Skip(tc.skip)
 			}
-
-			t.Parallel()
 
 			pipeline := tc.pipeline
 			require.NotNil(t, pipeline, "pipeline should be set")
@@ -192,15 +189,12 @@ func testAggregateCommandCompat(t *testing.T, testCases map[string]aggregateComm
 	compatCollection := s.CompatCollections[0]
 
 	for name, tc := range testCases {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Helper()
 
 			if tc.skip != "" {
 				t.Skip(tc.skip)
 			}
-
-			t.Parallel()
 
 			command := tc.command
 			require.NotNil(t, command, "command should be set")

--- a/integration/aggregate_documents_test.go
+++ b/integration/aggregate_documents_test.go
@@ -62,13 +62,10 @@ func TestAggregateAddFieldsErrors(t *testing.T) {
 			},
 		},
 	} {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			if tc.skip != "" {
 				t.Skip(tc.skip)
 			}
-
-			t.Parallel()
 
 			require.NotNil(t, tc.pipeline, "pipeline must not be nil")
 			require.NotNil(t, tc.err, "err must not be nil")
@@ -273,13 +270,10 @@ func TestAggregateGroupErrors(t *testing.T) {
 			skip: "https://github.com/FerretDB/FerretDB/issues/2275",
 		},
 	} {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			if tc.skip != "" {
 				t.Skip(tc.skip)
 			}
-
-			t.Parallel()
 
 			require.NotNil(t, tc.pipeline, "pipeline must not be nil")
 			require.NotNil(t, tc.err, "err must not be nil")
@@ -594,13 +588,10 @@ func TestAggregateProjectErrors(t *testing.T) {
 			},
 		},
 	} {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			if tc.skip != "" {
 				t.Skip(tc.skip)
 			}
-
-			t.Parallel()
 
 			require.NotNil(t, tc.pipeline, "pipeline must not be nil")
 			require.NotNil(t, tc.err, "err must not be nil")
@@ -637,13 +628,10 @@ func TestAggregateProject(t *testing.T) {
 			res: []bson.D{{{"v", int32(42)}}},
 		},
 	} {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			if tc.skip != "" {
 				t.Skip(tc.skip)
 			}
-
-			t.Parallel()
 
 			require.NotNil(t, tc.pipeline, "pipeline must not be nil")
 			require.NotNil(t, tc.res, "res must not be nil")
@@ -694,13 +682,10 @@ func TestAggregateSetErrors(t *testing.T) {
 			},
 		},
 	} {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			if tc.skip != "" {
 				t.Skip(tc.skip)
 			}
-
-			t.Parallel()
 
 			require.NotNil(t, tc.pipeline, "pipeline must not be nil")
 			require.NotNil(t, tc.err, "err must not be nil")
@@ -895,13 +880,10 @@ func TestAggregateUnsetErrors(t *testing.T) {
 			},
 		},
 	} {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			if tc.skip != "" {
 				t.Skip(tc.skip)
 			}
-
-			t.Parallel()
 
 			require.NotNil(t, tc.pipeline, "pipeline must not be nil")
 			require.NotNil(t, tc.err, "err must not be nil")
@@ -935,13 +917,10 @@ func TestAggregateSortErrors(t *testing.T) {
 			},
 		},
 	} {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			if tc.skip != "" {
 				t.Skip(tc.skip)
 			}
-
-			t.Parallel()
 
 			require.NotNil(t, tc.pipeline, "pipeline must not be nil")
 			require.NotNil(t, tc.err, "err must not be nil")
@@ -954,6 +933,7 @@ func TestAggregateSortErrors(t *testing.T) {
 
 func TestAggregateCommandMaxTimeMSErrors(t *testing.T) {
 	t.Parallel()
+
 	ctx, collection := setup.Setup(t)
 
 	for name, tc := range map[string]struct { //nolint:vet // used for testing only
@@ -1128,13 +1108,10 @@ func TestAggregateCommandMaxTimeMSErrors(t *testing.T) {
 			altMessage: "BSON field 'aggregate.maxTimeMS' is the wrong type 'object', expected types '[long, int, decimal, double]'",
 		},
 	} {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			if tc.skip != "" {
 				t.Skip(tc.skip)
 			}
-
-			t.Parallel()
 
 			require.NotNil(t, tc.err, "err must not be nil")
 
@@ -1148,6 +1125,7 @@ func TestAggregateCommandMaxTimeMSErrors(t *testing.T) {
 
 func TestAggregateCommandCursor(t *testing.T) {
 	t.Parallel()
+
 	ctx, collection := setup.Setup(t)
 
 	// the number of documents is set above the default batchSize of 101
@@ -1247,13 +1225,10 @@ func TestAggregateCommandCursor(t *testing.T) {
 			firstBatch: arr[:6],
 		},
 	} {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			if tc.skip != "" {
 				t.Skip(tc.skip)
 			}
-
-			t.Parallel()
 
 			var pipeline any = bson.A{}
 			if tc.pipeline != nil {

--- a/integration/aggregate_stats_compat_test.go
+++ b/integration/aggregate_stats_compat_test.go
@@ -67,13 +67,10 @@ func TestAggregateCompatCollStats(t *testing.T) {
 			},
 		},
 	} {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			if tc.skip != "" {
 				t.Skip(tc.skip)
 			}
-
-			t.Parallel()
 
 			require.NotNil(t, tc.pipeline, "pipeline must be set")
 

--- a/integration/aggregate_stats_test.go
+++ b/integration/aggregate_stats_test.go
@@ -187,13 +187,10 @@ func TestAggregateCollStatsCommandErrors(t *testing.T) {
 			},
 		},
 	} {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			if tc.skip != "" {
 				t.Skip(tc.skip)
 			}
-
-			t.Parallel()
 
 			require.NotNil(t, tc.err, "err must not be nil")
 

--- a/integration/diff_08_names_test.go
+++ b/integration/diff_08_names_test.go
@@ -76,7 +76,7 @@ func TestDiffCollectionName(t *testing.T) {
 		},
 		"NonUTF-8": {
 			collection:  string([]byte{0xff, 0xfe, 0xfd}),
-			disableOtel: true, // otel exporter can't export non-UTF-8 collection name
+			disableOtel: true, // otlptracehttp can't convert non-UTF-8 collection name as protobuf string
 		},
 	}
 

--- a/integration/setup/client.go
+++ b/integration/setup/client.go
@@ -67,7 +67,7 @@ func makeClient(ctx context.Context, uri string, disableOtel bool) (*mongo.Clien
 	clientOpts := options.Client().ApplyURI(uri)
 
 	if !disableOtel {
-		clientOpts.SetMonitor(otelmongo.NewMonitor())
+		clientOpts.SetMonitor(otelmongo.NewMonitor(otelmongo.WithCommandAttributeDisabled(false)))
 	}
 
 	client, err := mongo.Connect(ctx, clientOpts)

--- a/integration/setup/startup.go
+++ b/integration/setup/startup.go
@@ -127,7 +127,7 @@ func Startup() {
 			zap.S().Fatal(err)
 		}
 
-		client, err := makeClient(clientCtx, *targetURLF, true)
+		client, err := makeClient(clientCtx, *targetURLF, false)
 		if err != nil {
 			zap.S().Fatalf("Failed to connect to target system %s: %s", *targetURLF, err)
 		}
@@ -147,7 +147,7 @@ func Startup() {
 			zap.S().Fatal(err)
 		}
 
-		client, err := makeClient(clientCtx, *compatURLF, true)
+		client, err := makeClient(clientCtx, *compatURLF, false)
 		if err != nil {
 			zap.S().Fatalf("Failed to connect to compat system %s: %s", *compatURLF, err)
 		}


### PR DESCRIPTION
# Description

Plus, don't run some subtests in parallel (based on Otel traces analyses).

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [x] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [x] I made spot refactorings.
- [ ] I updated user documentation.
- [x] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
