### PR TITLE
Quick fixes for some failing tests

### DIFF
--- a/integration/commands_administration_test.go
+++ b/integration/commands_administration_test.go
@@ -1829,8 +1829,6 @@ func TestCommandsAdministrationCompactCapped(t *testing.T) {
 }
 
 func TestCommandsAdministrationCompactErrors(t *testing.T) {
-	t.Parallel()
-
 	for name, tc := range map[string]struct {
 		dbName string
 
@@ -1869,8 +1867,6 @@ func TestCommandsAdministrationCompactErrors(t *testing.T) {
 			if tc.skipForMongoDB != "" {
 				setup.SkipForMongoDB(t, tc.skipForMongoDB)
 			}
-
-			t.Parallel()
 
 			require.NotNil(t, tc.err, "err must not be nil")
 

--- a/integration/cursors/awaitdata_test.go
+++ b/integration/cursors/awaitdata_test.go
@@ -490,6 +490,8 @@ func TestCursorsTailableAwaitDataStress(t *testing.T) {
 }
 
 func TestCursorsAwaitDataFirstBatchMaxTimeMS(t *testing.T) {
+	t.Skip("https://github.com/FerretDB/FerretDB/issues/3945")
+
 	t.Parallel()
 
 	s := setup.SetupWithOpts(t, nil)

--- a/integration/cursors/batch_test.go
+++ b/integration/cursors/batch_test.go
@@ -30,7 +30,6 @@ import (
 )
 
 func TestCursorsBatchSize(t *testing.T) {
-	t.Parallel()
 	ctx, collection := setup.Setup(t)
 
 	// the number of documents is set above the default batchSize of 101

--- a/integration/cursors/tailable_test.go
+++ b/integration/cursors/tailable_test.go
@@ -33,8 +33,6 @@ import (
 )
 
 func TestCursorsTailableErrors(t *testing.T) {
-	t.Parallel()
-
 	t.Run("NonCapped", func(t *testing.T) {
 		t.Parallel()
 

--- a/integration/cursors/tailable_test.go
+++ b/integration/cursors/tailable_test.go
@@ -322,6 +322,8 @@ func TestCursorsTailableTwoCursorsSameCollection(t *testing.T) {
 }
 
 func TestCursorsTailableFirstBatchMaxTimeMS(t *testing.T) {
+	t.Skip("https://github.com/FerretDB/FerretDB/issues/3945")
+
 	t.Parallel()
 
 	s := setup.SetupWithOpts(t, nil)
@@ -385,6 +387,8 @@ func TestCursorsTailableFirstBatchMaxTimeMS(t *testing.T) {
 	})
 
 	t.Run("GetMoreEmpty", func(t *testing.T) {
+		t.Skip("https://github.com/FerretDB/FerretDB/issues/3945")
+
 		time.Sleep(100 * time.Millisecond)
 		var res bson.D
 		err = collection.Database().RunCommand(ctx, getMoreCmd).Decode(&res)

--- a/integration/indexes_command_test.go
+++ b/integration/indexes_command_test.go
@@ -212,8 +212,6 @@ func TestDropIndexesCommandErrors(t *testing.T) {
 }
 
 func TestCreateIndexesCommandInvalidSpec(t *testing.T) {
-	t.Parallel()
-
 	for name, tc := range map[string]struct {
 		indexes        any  // optional
 		missingIndexes bool // optional, if set indexes must be nil

--- a/integration/update_field_compat_test.go
+++ b/integration/update_field_compat_test.go
@@ -374,8 +374,6 @@ func TestUpdateFieldCompatMax(t *testing.T) {
 }
 
 func TestUpdateFieldCompatMin(t *testing.T) {
-	t.Parallel()
-
 	testCases := map[string]updateCompatTestCase{
 		"Int32Lower": {
 			update: bson.D{{"$min", bson.D{{"v", int32(30)}}}},

--- a/integration/update_field_compat_test.go
+++ b/integration/update_field_compat_test.go
@@ -1087,8 +1087,6 @@ func TestUpdateFieldCompatMixed(t *testing.T) {
 }
 
 func TestUpdateFieldCompatMul(t *testing.T) {
-	t.Parallel()
-
 	providers := shareddata.AllProviders().
 		// OverflowVergeDoubles and Scalars contain numbers that produces +INF on compat,
 		// validation error on target upon $mul operation.

--- a/integration/update_field_compat_test.go
+++ b/integration/update_field_compat_test.go
@@ -971,8 +971,6 @@ func TestUpdateFieldCompatSetOnInsert(t *testing.T) {
 }
 
 func TestUpdateFieldCompatSetOnInsertComplex(t *testing.T) {
-	t.Parallel()
-
 	testCases := map[string]testUpdateManyCompatTestCase{
 		"IDExists": {
 			filter:     bson.D{{"_id", "int32"}},


### PR DESCRIPTION
# Description

Fixes in this PR:
- Remove `t.Parrallel()` from tests that fail with exceeded context (so we have fewer parallel tests where goroutines have to wait).
- Skip flaky tests about cursors, to be fixed in #3945.

Example of a pipeline where these tests fail: https://github.com/FerretDB/FerretDB/actions/runs/9886847696/job/27307378186?pr=4450

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [x] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
