### PR TITLE
Implement `slog.LogValuer` interface for `types` package

### DIFF
--- a/internal/types/array.go
+++ b/internal/types/array.go
@@ -16,6 +16,7 @@ package types
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/FerretDB/FerretDB/internal/util/iterator"
 	"github.com/FerretDB/FerretDB/internal/util/must"
@@ -260,3 +261,13 @@ func (a *Array) Remove(index int) {
 
 	a.s = append(a.s[:index], a.s[index+1:]...)
 }
+
+// LogValue implements [slog.LogValuer].
+func (arr *Array) LogValue() slog.Value {
+	return slogValue(arr, 1)
+}
+
+// check interfaces
+var (
+	_ slog.LogValuer = (*Array)(nil)
+)

--- a/internal/types/binary.go
+++ b/internal/types/binary.go
@@ -14,6 +14,8 @@
 
 package types
 
+import "log/slog"
+
 //go:generate ../../bin/stringer -linecomment -type BinarySubtype
 
 // BinarySubtype represents BSON Binary's subtype.
@@ -50,3 +52,13 @@ type Binary struct {
 	B       []byte
 	Subtype BinarySubtype
 }
+
+// LogValue implements [slog.LogValuer].
+func (b Binary) LogValue() slog.Value {
+	return slogValue(b, 1)
+}
+
+// check interfaces
+var (
+	_ slog.LogValuer = Binary{}
+)

--- a/internal/types/document.go
+++ b/internal/types/document.go
@@ -17,6 +17,7 @@ package types
 import (
 	"cmp"
 	"fmt"
+	"log/slog"
 	"slices"
 	"strconv"
 
@@ -492,4 +493,14 @@ func (d *Document) moveIDToTheFirstIndex() {
 // check interfaces
 var (
 	_ document = (*Document)(nil)
+)
+
+// LogValue implements [slog.LogValuer].
+func (doc *Document) LogValue() slog.Value {
+	return slogValue(doc, 1)
+}
+
+// check interfaces
+var (
+	_ slog.LogValuer = (*Document)(nil)
 )

--- a/internal/types/logging.go
+++ b/internal/types/logging.go
@@ -26,8 +26,7 @@ import (
 // logMaxDepth is the maximum depth of a recursive representation of a BSON value.
 const logMaxDepth = 20
 
-// slogValue returns a compact representation of any Go types matching BSON types as [slog.Value].
-// The implementation is a copy of [bson.slogValue].
+// slogValue is a copy of [bson.slogValue] implementation modified to fit `types` value types.
 func slogValue(v any, depth int) slog.Value {
 	switch v := v.(type) {
 	case *Document:

--- a/internal/types/logging.go
+++ b/internal/types/logging.go
@@ -1,0 +1,113 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"math"
+	"strconv"
+	"time"
+)
+
+// logMaxDepth is the maximum depth of a recursive representation of a BSON value.
+const logMaxDepth = 20
+
+// slogValue returns a compact representation of any Go types matching BSON types as [slog.Value].
+// The implementation is a copy of [bson.slogValue].
+func slogValue(v any, depth int) slog.Value {
+	switch v := v.(type) {
+	case *Document:
+		if v == nil {
+			return slog.StringValue("Document<nil>")
+		}
+
+		if depth > logMaxDepth {
+			return slog.StringValue("Document<...>")
+		}
+
+		var attrs []slog.Attr
+
+		for _, f := range v.fields {
+			attrs = append(attrs, slog.Attr{Key: f.key, Value: slogValue(f.value, depth+1)})
+		}
+
+		return slog.GroupValue(attrs...)
+
+	case *Array:
+		if v == nil {
+			return slog.StringValue("Array<nil>")
+		}
+
+		if depth > logMaxDepth {
+			return slog.StringValue("Array<...>")
+		}
+
+		var attrs []slog.Attr
+
+		for i, v := range v.s {
+			attrs = append(attrs, slog.Attr{Key: strconv.Itoa(i), Value: slogValue(v, depth+1)})
+		}
+
+		return slog.GroupValue(attrs...)
+
+	case float64:
+		// for JSON handler to work
+		switch {
+		case math.IsNaN(v):
+			return slog.StringValue("NaN")
+		case math.IsInf(v, 1):
+			return slog.StringValue("+Inf")
+		case math.IsInf(v, -1):
+			return slog.StringValue("-Inf")
+		}
+
+		return slog.Float64Value(v)
+
+	case string:
+		return slog.StringValue(v)
+
+	case Binary:
+		return slog.StringValue(fmt.Sprintf("%#v", v))
+
+	case ObjectID:
+		return slog.StringValue("ObjectID(" + hex.EncodeToString(v[:]) + ")")
+
+	case bool:
+		return slog.BoolValue(v)
+
+	case time.Time:
+		return slog.TimeValue(v.Truncate(time.Millisecond).UTC())
+
+	case NullType:
+		return slog.Value{}
+
+	case Regex:
+		return slog.StringValue(fmt.Sprintf("%#v", v))
+
+	case int32:
+		return slog.Int64Value(int64(v))
+
+	case Timestamp:
+		return slog.StringValue(fmt.Sprintf("%#v", v))
+
+	case int64:
+		return slog.Int64Value(v)
+
+	default:
+		panic(fmt.Sprintf("invalid BSON type %T", v))
+	}
+}

--- a/internal/types/logging_test.go
+++ b/internal/types/logging_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/FerretDB/FerretDB/internal/util/must"
 )
 
+// TestLogging is a copy of [bson_test.TestLoggingNil] modified to fit `types` value types.
 func TestLoggingNil(t *testing.T) {
 	var doc *types.Document
 	assert.Equal(t, doc.LogValue().String(), "Document<nil>")
@@ -37,6 +38,7 @@ func TestLoggingNil(t *testing.T) {
 	assert.Equal(t, arr.LogValue().String(), "Array<nil>")
 }
 
+// TestLogging is a copy of [bson_test.TestLogging] modified to fit `types` value types.
 func TestLogging(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/types/logging_test.go
+++ b/internal/types/logging_test.go
@@ -1,0 +1,276 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types_test
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/FerretDB/FerretDB/internal/types"
+	"github.com/FerretDB/FerretDB/internal/util/logging"
+	"github.com/FerretDB/FerretDB/internal/util/must"
+)
+
+func TestLoggingNil(t *testing.T) {
+	var doc *types.Document
+	assert.Equal(t, doc.LogValue().String(), "Document<nil>")
+
+	var arr *types.Array
+	assert.Equal(t, arr.LogValue().String(), "Array<nil>")
+}
+
+func TestLogging(t *testing.T) {
+	ctx := context.Background()
+
+	var cbuf, tbuf, jbuf bytes.Buffer
+	clog := slog.New(logging.NewHandler(&cbuf, &logging.NewHandlerOpts{
+		Base:         "console",
+		RemoveTime:   true,
+		RemoveLevel:  true,
+		RemoveSource: true,
+	}))
+	tlog := slog.New(logging.NewHandler(&tbuf, &logging.NewHandlerOpts{
+		Base:         "text",
+		RemoveTime:   true,
+		RemoveLevel:  true,
+		RemoveSource: true,
+	}))
+	jlog := slog.New(logging.NewHandler(&jbuf, &logging.NewHandlerOpts{
+		Base:         "json",
+		RemoveTime:   true,
+		RemoveLevel:  true,
+		RemoveSource: true,
+	}))
+
+	for _, tc := range []struct {
+		name string
+		doc  any
+		c    string
+		t    string
+		j    string
+		m    string
+		b    string
+	}{
+		{
+			name: "Numbers",
+			doc: must.NotFail(types.NewDocument(
+				"f64", 42.0,
+				"inf", float64(math.Inf(1)),
+				"neg_inf", float64(math.Inf(-1)),
+				"zero", math.Copysign(0, 1),
+				"neg_zero", math.Copysign(0, -1),
+				"nan", float64(math.NaN()),
+				"i32", int32(42),
+				"i64", int64(42),
+			)),
+			c: `	{"v":{"f64":42,"i32":42,"i64":42,"inf":"+Inf","nan":"NaN","neg_inf":"-Inf","neg_zero":-0,"zero":0}}`,
+			t: `v.f64=42 v.inf=+Inf v.neg_inf=-Inf v.zero=0 v.neg_zero=-0 v.nan=NaN v.i32=42 v.i64=42`,
+			j: `{"v":{"f64":42,"inf":"+Inf","neg_inf":"-Inf","zero":0,"neg_zero":-0,"nan":"NaN","i32":42,"i64":42}}`,
+			m: `
+			{
+			  "f64": 42.0,
+			  "inf": +Inf,
+			  "neg_inf": -Inf,
+			  "zero": 0.0,
+			  "neg_zero": -0.0,
+			  "nan": NaN,
+			  "i32": 42,
+			  "i64": int64(42),
+			}`,
+			b: `
+			{
+			  "f64": 42.0,
+			  "inf": +Inf,
+			  "neg_inf": -Inf,
+			  "zero": 0.0,
+			  "neg_zero": -0.0,
+			  "nan": NaN,
+			  "i32": 42,
+			  "i64": int64(42),
+			}`,
+		},
+		{
+			name: "Scalars",
+			doc: must.NotFail(types.NewDocument(
+				"null", types.Null,
+				"id", types.ObjectID{0x42},
+				"bool", true,
+				"time", time.Date(2023, 3, 6, 13, 14, 42, 123456789, time.FixedZone("", int(4*time.Hour.Seconds()))),
+			)),
+			c: `	{"v":{"bool":true,"id":"ObjectID(420000000000000000000000)","null":null,"time":"2023-03-06T09:14:42.123Z"}}`,
+			t: `v.null=<nil> v.id=ObjectID(420000000000000000000000) v.bool=true v.time=2023-03-06T09:14:42.123Z`,
+			j: `{"v":{"null":null,"id":"ObjectID(420000000000000000000000)","bool":true,"time":"2023-03-06T09:14:42.123Z"}}`,
+			m: `
+			{
+			  "null": null,
+			  "id": ObjectID(420000000000000000000000),
+			  "bool": true,
+			  "time": 2023-03-06T09:14:42.123Z,
+			}`,
+			b: `
+			{
+			  "null": null,
+			  "id": ObjectID(420000000000000000000000),
+			  "bool": true,
+			  "time": 2023-03-06T09:14:42.123Z,
+			}`,
+		},
+		{
+			name: "Composites",
+			doc: must.NotFail(types.NewDocument(
+				"doc", must.NotFail(types.NewDocument(
+					"foo", "bar",
+					"baz", must.NotFail(types.NewDocument(
+						"qux", "quux",
+					)),
+				)),
+				"doc_empty", must.NotFail(types.NewDocument()),
+				"array", must.NotFail(types.NewArray(
+					"foo",
+					"bar",
+					must.NotFail(types.NewArray("baz", "qux")),
+				)),
+			)),
+			c: `	{"v":{"array":{"0":"foo","1":"bar","2":{"0":"baz","1":"qux"}},` +
+				`"doc":{"baz":{"qux":"quux"},"foo":"bar"}}}`,
+			t: `v.doc.foo=bar v.doc.baz.qux=quux ` +
+				`v.array.0=foo v.array.1=bar v.array.2.0=baz v.array.2.1=qux`,
+			j: `{"v":{"doc":{"foo":"bar","baz":{"qux":"quux"}},` +
+				`"array":{"0":"foo","1":"bar","2":{"0":"baz","1":"qux"}}}}`,
+			m: `
+			{
+			  "doc": {"foo": "bar", "baz": {"qux": "quux"}},
+			  "doc_empty": {},
+			  "array": ["foo", "bar", ["baz", "qux"]],
+			}`,
+			b: `
+			{
+			  "doc": {
+			    "foo": "bar",
+			    "baz": {
+			      "qux": "quux",
+			    },
+			  },
+			  "doc_empty": {},
+			  "array": [
+			    "foo",
+			    "bar",
+			    [
+			      "baz",
+			      "qux",
+			    ],
+			  ],
+			}`,
+		},
+		{
+			name: "Nested",
+			doc:  makeNested(false, 20).(*types.Document),
+			c: `	{"v":{"f":{"0":{"f":{"0":{"f":{"0":{"f":{"0":{"f":{"0":{"f":{"0":` +
+				`{"f":{"0":{"f":{"0":{"f":{"0":{"f":{"0":null}}}}}}}}}}}}}}}}}}}}}`,
+			t: `v.f.0.f.0.f.0.f.0.f.0.f.0.f.0.f.0.f.0.f.0=<nil>`,
+			j: `{"v":{"f":{"0":{"f":{"0":{"f":{"0":{"f":{"0":{"f":{"0":{"f":{"0":` +
+				`{"f":{"0":{"f":{"0":{"f":{"0":{"f":{"0":null}}}}}}}}}}}}}}}}}}}}}`,
+			m: `
+			{
+			  "f": [
+			    {
+			      "f": [{"f": [{"f": [{"f": [{"f": [{"f": [{"f": [{"f": [{"f": [null]}]}]}]}]}]}]}]}],
+			    },
+			  ],
+			}`,
+			b: `
+			{
+			  "f": [
+			    {
+			      "f": [
+			        {
+			          "f": [
+			            {
+			              "f": [
+			                {
+			                  "f": [
+			                    {
+			                      "f": [
+			                        {
+			                          "f": [
+			                            {
+			                              "f": [
+			                                {
+			                                  "f": [
+			                                    {
+			                                      "f": [
+			                                        null,
+			                                      ],
+			                                    },
+			                                  ],
+			                                },
+			                              ],
+			                            },
+			                          ],
+			                        },
+			                      ],
+			                    },
+			                  ],
+			                },
+			              ],
+			            },
+			          ],
+			        },
+			      ],
+			    },
+			  ],
+			}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clog.InfoContext(ctx, "", slog.Any("v", tc.doc))
+			assert.Equal(t, tc.c+"\n", cbuf.String(), "console output mismatch")
+			cbuf.Reset()
+
+			tlog.InfoContext(ctx, "", slog.Any("v", tc.doc))
+			assert.Equal(t, tc.t+"\n", tbuf.String(), "text output mismatch")
+			tbuf.Reset()
+
+			jlog.InfoContext(ctx, "", slog.Any("v", tc.doc))
+			assert.Equal(t, tc.j+"\n", jbuf.String(), "json output mismatch")
+			jbuf.Reset()
+		})
+	}
+}
+
+// makeNested creates a nested document or array with the given depth.
+func makeNested(array bool, depth int) any {
+	if depth < 1 {
+		panic("depth must be at least 1")
+	}
+
+	var child any = types.Null
+
+	if depth > 1 {
+		child = makeNested(!array, depth-1)
+	}
+
+	if array {
+		return must.NotFail(types.NewArray(child))
+	}
+
+	return must.NotFail(types.NewDocument("f", child))
+}

--- a/internal/types/logging_test.go
+++ b/internal/types/logging_test.go
@@ -68,8 +68,6 @@ func TestLogging(t *testing.T) {
 		c    string
 		t    string
 		j    string
-		m    string
-		b    string
 	}{
 		{
 			name: "Numbers",
@@ -86,28 +84,6 @@ func TestLogging(t *testing.T) {
 			c: `	{"v":{"f64":42,"i32":42,"i64":42,"inf":"+Inf","nan":"NaN","neg_inf":"-Inf","neg_zero":-0,"zero":0}}`,
 			t: `v.f64=42 v.inf=+Inf v.neg_inf=-Inf v.zero=0 v.neg_zero=-0 v.nan=NaN v.i32=42 v.i64=42`,
 			j: `{"v":{"f64":42,"inf":"+Inf","neg_inf":"-Inf","zero":0,"neg_zero":-0,"nan":"NaN","i32":42,"i64":42}}`,
-			m: `
-			{
-			  "f64": 42.0,
-			  "inf": +Inf,
-			  "neg_inf": -Inf,
-			  "zero": 0.0,
-			  "neg_zero": -0.0,
-			  "nan": NaN,
-			  "i32": 42,
-			  "i64": int64(42),
-			}`,
-			b: `
-			{
-			  "f64": 42.0,
-			  "inf": +Inf,
-			  "neg_inf": -Inf,
-			  "zero": 0.0,
-			  "neg_zero": -0.0,
-			  "nan": NaN,
-			  "i32": 42,
-			  "i64": int64(42),
-			}`,
 		},
 		{
 			name: "Scalars",
@@ -120,20 +96,6 @@ func TestLogging(t *testing.T) {
 			c: `	{"v":{"bool":true,"id":"ObjectID(420000000000000000000000)","null":null,"time":"2023-03-06T09:14:42.123Z"}}`,
 			t: `v.null=<nil> v.id=ObjectID(420000000000000000000000) v.bool=true v.time=2023-03-06T09:14:42.123Z`,
 			j: `{"v":{"null":null,"id":"ObjectID(420000000000000000000000)","bool":true,"time":"2023-03-06T09:14:42.123Z"}}`,
-			m: `
-			{
-			  "null": null,
-			  "id": ObjectID(420000000000000000000000),
-			  "bool": true,
-			  "time": 2023-03-06T09:14:42.123Z,
-			}`,
-			b: `
-			{
-			  "null": null,
-			  "id": ObjectID(420000000000000000000000),
-			  "bool": true,
-			  "time": 2023-03-06T09:14:42.123Z,
-			}`,
 		},
 		{
 			name: "Composites",
@@ -157,30 +119,6 @@ func TestLogging(t *testing.T) {
 				`v.array.0=foo v.array.1=bar v.array.2.0=baz v.array.2.1=qux`,
 			j: `{"v":{"doc":{"foo":"bar","baz":{"qux":"quux"}},` +
 				`"array":{"0":"foo","1":"bar","2":{"0":"baz","1":"qux"}}}}`,
-			m: `
-			{
-			  "doc": {"foo": "bar", "baz": {"qux": "quux"}},
-			  "doc_empty": {},
-			  "array": ["foo", "bar", ["baz", "qux"]],
-			}`,
-			b: `
-			{
-			  "doc": {
-			    "foo": "bar",
-			    "baz": {
-			      "qux": "quux",
-			    },
-			  },
-			  "doc_empty": {},
-			  "array": [
-			    "foo",
-			    "bar",
-			    [
-			      "baz",
-			      "qux",
-			    ],
-			  ],
-			}`,
 		},
 		{
 			name: "Nested",
@@ -190,56 +128,6 @@ func TestLogging(t *testing.T) {
 			t: `v.f.0.f.0.f.0.f.0.f.0.f.0.f.0.f.0.f.0.f.0=<nil>`,
 			j: `{"v":{"f":{"0":{"f":{"0":{"f":{"0":{"f":{"0":{"f":{"0":{"f":{"0":` +
 				`{"f":{"0":{"f":{"0":{"f":{"0":{"f":{"0":null}}}}}}}}}}}}}}}}}}}}}`,
-			m: `
-			{
-			  "f": [
-			    {
-			      "f": [{"f": [{"f": [{"f": [{"f": [{"f": [{"f": [{"f": [{"f": [null]}]}]}]}]}]}]}]}],
-			    },
-			  ],
-			}`,
-			b: `
-			{
-			  "f": [
-			    {
-			      "f": [
-			        {
-			          "f": [
-			            {
-			              "f": [
-			                {
-			                  "f": [
-			                    {
-			                      "f": [
-			                        {
-			                          "f": [
-			                            {
-			                              "f": [
-			                                {
-			                                  "f": [
-			                                    {
-			                                      "f": [
-			                                        null,
-			                                      ],
-			                                    },
-			                                  ],
-			                                },
-			                              ],
-			                            },
-			                          ],
-			                        },
-			                      ],
-			                    },
-			                  ],
-			                },
-			              ],
-			            },
-			          ],
-			        },
-			      ],
-			    },
-			  ],
-			}`,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/types/null.go
+++ b/internal/types/null.go
@@ -14,6 +14,8 @@
 
 package types
 
+import "log/slog"
+
 type (
 	// NullType represents BSON type Null.
 	//
@@ -23,3 +25,13 @@ type (
 
 // Null represents BSON value Null.
 var Null = NullType{}
+
+// LogValue implements [slog.LogValuer].
+func (n NullType) LogValue() slog.Value {
+	return slogValue(n, 1)
+}
+
+// check interfaces
+var (
+	_ slog.LogValuer = NullType{}
+)

--- a/internal/types/object_id.go
+++ b/internal/types/object_id.go
@@ -16,6 +16,7 @@ package types
 
 import (
 	"encoding/binary"
+	"log/slog"
 	"math/rand"
 	"sync/atomic"
 	"time"
@@ -68,3 +69,13 @@ func init() {
 	must.NotFail(rand.Read(objectIDProcess[:]))
 	objectIDCounter.Store(rand.Uint32())
 }
+
+// LogValue implements [slog.LogValuer].
+func (o ObjectID) LogValue() slog.Value {
+	return slogValue(o, 1)
+}
+
+// check interfaces
+var (
+	_ slog.LogValuer = ObjectID{}
+)

--- a/internal/types/regex.go
+++ b/internal/types/regex.go
@@ -16,6 +16,7 @@ package types
 
 import (
 	"fmt"
+	"log/slog"
 	"regexp"
 	"regexp/syntax"
 
@@ -120,3 +121,13 @@ func (r Regex) Compile() (*regexp.Regexp, error) {
 
 	return nil, lazyerrors.Error(err)
 }
+
+// LogValue implements [slog.LogValuer].
+func (r Regex) LogValue() slog.Value {
+	return slogValue(r, 1)
+}
+
+// check interfaces
+var (
+	_ slog.LogValuer = Regex{}
+)

--- a/internal/types/timestamp.go
+++ b/internal/types/timestamp.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"log/slog"
 	"sync/atomic"
 	"time"
 )
@@ -49,3 +50,13 @@ func (ts Timestamp) Time() time.Time {
 func (ts Timestamp) Signed() int64 {
 	return int64(ts)
 }
+
+// LogValue implements [slog.LogValuer].
+func (ts Timestamp) LogValue() slog.Value {
+	return slogValue(ts, 1)
+}
+
+// check interfaces
+var (
+	_ slog.LogValuer = Timestamp(0)
+)


### PR DESCRIPTION
# Description

It will be used by logger in
* https://github.com/FerretDB/FerretDB/pull/4470/files#diff-6ca503e8ccb89677a82fa7b0b9f4d187b8f5ef8ac15622dd9f365b88e058b622R67
* https://github.com/FerretDB/FerretDB/pull/4470/files#diff-6ca503e8ccb89677a82fa7b0b9f4d187b8f5ef8ac15622dd9f365b88e058b622R67
* https://github.com/FerretDB/FerretDB/pull/4462/files#diff-beab5e5a6ad47631f2f20fadadb143272b0380767d7b3e4109fccb5655b16f39R378

Closes #4013.

## Readiness checklist

- [x] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
