### PR TITLE
Update `listDatabases` integration test filter input

### DIFF
--- a/integration/commands_administration_test.go
+++ b/integration/commands_administration_test.go
@@ -181,8 +181,7 @@ func TestCommandsAdministrationListDatabases(t *testing.T) {
 		},
 		"Regex": {
 			filter: bson.D{
-				{Key: "name", Value: name},
-				{Key: "name", Value: primitive.Regex{Pattern: "^Test", Options: "i"}},
+				{Key: "name", Value: primitive.Regex{Pattern: "ListDatabases$", Options: "i"}},
 			},
 			expected: mongo.ListDatabasesResult{
 				Databases: []mongo.DatabaseSpecification{{
@@ -192,8 +191,7 @@ func TestCommandsAdministrationListDatabases(t *testing.T) {
 		},
 		"RegexNameOnly": {
 			filter: bson.D{
-				{Key: "name", Value: name},
-				{Key: "name", Value: primitive.Regex{Pattern: "^Test", Options: "i"}},
+				{Key: "name", Value: primitive.Regex{Pattern: "ListDatabases$", Options: "i"}},
 			},
 			opts: []*options.ListDatabasesOptions{
 				options.ListDatabases().SetNameOnly(true),
@@ -213,7 +211,6 @@ func TestCommandsAdministrationListDatabases(t *testing.T) {
 		},
 		"RegexNotFound": {
 			filter: bson.D{
-				{Key: "name", Value: name},
 				{Key: "name", Value: primitive.Regex{Pattern: "^xyz$", Options: "i"}},
 			},
 			expected: mongo.ListDatabasesResult{
@@ -222,7 +219,6 @@ func TestCommandsAdministrationListDatabases(t *testing.T) {
 		},
 		"RegexNotFoundNameOnly": {
 			filter: bson.D{
-				{Key: "name", Value: name},
 				{Key: "name", Value: primitive.Regex{Pattern: "^xyz$", Options: "i"}},
 			},
 			opts: []*options.ListDatabasesOptions{


### PR DESCRIPTION
# Description

The filter input to `listDatabases` test cases contain duplicate field `name`. When we move on to using `github.com/FerretDB/wire/wirebson` package, only the first field is fetched from a document if there are duplicate field names. 

Closes FerretDB/engineering#179.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [x] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
