### PR TITLE
Update duplicate field handling

### DIFF
--- a/integration/aggregate_documents_test.go
+++ b/integration/aggregate_documents_test.go
@@ -206,6 +206,9 @@ func TestAggregateGroupErrors(t *testing.T) {
 				Name:    "Location16406",
 				Message: "duplicate field name specified in object literal: { v: \"$v\", v: \"$non-existent\" }",
 			},
+			// message is different due to wirebson package cannot get values of duplicate field names
+			// TODO https://github.com/FerretDB/FerretDB/issues/2412
+			altMessage: "duplicate field name specified in object literal: v",
 		},
 		"IDExpressionEmptyPath": {
 			pipeline: bson.A{

--- a/integration/query_projection_compat_test.go
+++ b/integration/query_projection_compat_test.go
@@ -307,6 +307,10 @@ func TestQueryProjectionPositionalOperatorCompat(t *testing.T) {
 				{"v", bson.D{{"$gt", 41}}},
 			},
 			projection: bson.D{{"v.$", true}},
+			// FerretDB wirebson package only gets the first filter value due to
+			// the duplicate key causing the second filter value to be ignored
+			// TODO https://github.com/FerretDB/FerretDB/issues/2412
+			skip: "https://github.com/FerretDB/FerretDB/issues/2412",
 		},
 		"TwoConflictingLtGt": {
 			filter: bson.D{

--- a/internal/handler/common/aggregations/stages/group.go
+++ b/internal/handler/common/aggregations/stages/group.go
@@ -198,7 +198,7 @@ func validateGroupKey(groupKey any) error {
 		if _, ok := fields[k]; ok {
 			return handlererrors.NewCommandErrorMsgWithArgument(
 				handlererrors.ErrGroupDuplicateFieldName,
-				fmt.Sprintf("duplicate field name specified in object literal: %s", types.FormatAnyValue(doc)),
+				fmt.Sprintf("duplicate field name specified in object literal: %s", k),
 				"$group (stage)",
 			)
 		}


### PR DESCRIPTION
# Description

When we use `github.com/FerretDB/wire/wirebson` package, upon duplicate fields, the first value is always fetched. So error message cannot display the input request with duplicate field, and duplicate filter input may be ignored.

Alternatively, we can update wirebson to get _i_-th index value of the document.

Closes FerretDB/engineering#179.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [x] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
