### PR TITLE
Close connection on `NaN` value

### DIFF
--- a/integration/basic_test.go
+++ b/integration/basic_test.go
@@ -522,27 +522,22 @@ func TestDebugError(t *testing.T) {
 
 	t.Parallel()
 
-	ctx, collection := setup.Setup(t)
-	db := collection.Database()
-
 	// TODO https://github.com/FerretDB/FerretDB/issues/2412
-
 	t.Run("ValidationError", func(t *testing.T) {
 		t.Parallel()
 
-		err := db.RunCommand(ctx, bson.D{{"debugError", bson.D{{"NaN", math.NaN()}}}}).Err()
-		expected := mongo.CommandError{
-			Code: 2,
-			Name: "BadValue",
-		}
-		AssertMatchesCommandError(t, expected, err)
-		assert.ErrorContains(t, err, "NaN is not supported")
+		ctx, collection := setup.Setup(t)
+		db := collection.Database()
 
-		require.NoError(t, db.Client().Ping(ctx, nil), "validation errors should not close connection")
+		err := db.RunCommand(ctx, bson.D{{"debugError", bson.D{{"NaN", math.NaN()}}}}).Err()
+		require.ErrorContains(t, err, "socket was unexpectedly closed")
 	})
 
 	t.Run("LazyError", func(t *testing.T) {
 		t.Parallel()
+
+		ctx, collection := setup.Setup(t)
+		db := collection.Database()
 
 		err := db.RunCommand(ctx, bson.D{{"debugError", "lazy error"}}).Err()
 		expected := mongo.CommandError{
@@ -557,6 +552,9 @@ func TestDebugError(t *testing.T) {
 
 	t.Run("OtherError", func(t *testing.T) {
 		t.Parallel()
+
+		ctx, collection := setup.Setup(t)
+		db := collection.Database()
 
 		err := db.RunCommand(ctx, bson.D{{"debugError", "other error"}}).Err()
 		expected := mongo.CommandError{

--- a/internal/clientconn/conn.go
+++ b/internal/clientconn/conn.go
@@ -250,45 +250,8 @@ func (c *conn) run(ctx context.Context) (err error) {
 		var reqBody wire.MsgBody
 		var resHeader *wire.MsgHeader
 		var resBody wire.MsgBody
-		var validationErr *wire.ValidationError
 
 		reqHeader, reqBody, err = wire.ReadMessage(bufr)
-		if err != nil && errors.As(err, &validationErr) {
-			// Currently, we respond with OP_MSG containing an error and don't close the connection.
-			// That's probably not right. First, we always respond with OP_MSG, even to OP_QUERY.
-			// Second, we don't know what command it was, if any,
-			// and if the client could handle returned error for it.
-			//
-			// TODO https://github.com/FerretDB/FerretDB/issues/2412
-
-			// get protocol error to return correct error document
-			protoErr := handlererrors.ProtocolError(validationErr)
-
-			var res wire.OpMsg
-			must.NoError(res.SetSections(wire.MakeOpMsgSection(
-				protoErr.Document(),
-			)))
-
-			b := must.NotFail(res.MarshalBinary())
-
-			resHeader = &wire.MsgHeader{
-				OpCode:        reqHeader.OpCode,
-				RequestID:     c.lastRequestID.Add(1),
-				ResponseTo:    reqHeader.RequestID,
-				MessageLength: int32(wire.MsgHeaderLen + len(b)),
-			}
-
-			if err = wire.WriteMessage(bufw, resHeader, &res); err != nil {
-				return
-			}
-
-			if err = bufw.Flush(); err != nil {
-				return
-			}
-
-			continue
-		}
-
 		if err != nil {
 			return
 		}

--- a/internal/handler/handlererrors/error.go
+++ b/internal/handler/handlererrors/error.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 
 	"github.com/FerretDB/FerretDB/internal/types"
-	"github.com/FerretDB/FerretDB/internal/wire"
 )
 
 //go:generate ../../../bin/stringer -linecomment -type ErrorCode
@@ -364,7 +363,6 @@ type ProtoErr interface {
 //
 // Nil panics (it never should be passed),
 // [*CommandError] or [*WriteErrors] (possibly wrapped) are returned unwrapped,
-// [*wire.ValidationError] (possibly wrapped) is returned as CommandError with BadValue code,
 // any other values (including lazy errors) are returned as CommandError with InternalError code.
 func ProtocolError(err error) ProtoErr {
 	if err == nil {
@@ -379,12 +377,6 @@ func ProtocolError(err error) ProtoErr {
 	var writeErr *WriteErrors
 	if errors.As(err, &writeErr) {
 		return writeErr
-	}
-
-	var validationErr *wire.ValidationError
-	if errors.As(err, &validationErr) {
-		//nolint:errorlint // only *CommandError could be returned
-		return NewCommandError(ErrBadValue, err).(*CommandError)
 	}
 
 	//nolint:errorlint // only *CommandError could be returned


### PR DESCRIPTION
# Description

This PR extract logic related to handling `NaN` in https://github.com/FerretDB/FerretDB/pull/4490.

Encountering `NaN` closes connection, previously `BadValue` command error was returned. It's a question how each driver would have to handled them

Closes FerretDB/engineering#179.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [ ] I ensured that PR title is good enough for the changelog.
- [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [ ] I marked all done items in this checklist.
