### PR TITLE
Fix critical typo in telemetry documentation

### DIFF
--- a/website/docs/telemetry.md
+++ b/website/docs/telemetry.md
@@ -18,7 +18,7 @@ The following data is collected:
 - FerretDB version
 - Random instance UUID
 - [Autonomous system](<https://en.wikipedia.org/wiki/Autonomous_system_(Internet)>) number,
-  cloud provider region, or country derived from IP address (but the IP address itself)
+  cloud provider region, or country derived from IP address (but not the IP address itself)
 - Uptime
 - Backend (PostgreSQL or SQLite) version
 - Installation type (Docker, package, cloud provider marketplace, self-built)

--- a/website/versioned_docs/version-v1.21/telemetry.md
+++ b/website/versioned_docs/version-v1.21/telemetry.md
@@ -18,7 +18,7 @@ The following data is collected:
 - FerretDB version
 - Random instance UUID
 - [Autonomous system](<https://en.wikipedia.org/wiki/Autonomous_system_(Internet)>) number,
-  cloud provider region, or country derived from IP address (but the IP address itself)
+  cloud provider region, or country derived from IP address (but not the IP address itself)
 - Uptime
 - Backend (PostgreSQL or SQLite) version
 - Installation type (Docker, package, cloud provider marketplace, self-built)

--- a/website/versioned_docs/version-v1.22/telemetry.md
+++ b/website/versioned_docs/version-v1.22/telemetry.md
@@ -18,7 +18,7 @@ The following data is collected:
 - FerretDB version
 - Random instance UUID
 - [Autonomous system](<https://en.wikipedia.org/wiki/Autonomous_system_(Internet)>) number,
-  cloud provider region, or country derived from IP address (but the IP address itself)
+  cloud provider region, or country derived from IP address (but not the IP address itself)
 - Uptime
 - Backend (PostgreSQL or SQLite) version
 - Installation type (Docker, package, cloud provider marketplace, self-built)

--- a/website/versioned_docs/version-v1.23/telemetry.md
+++ b/website/versioned_docs/version-v1.23/telemetry.md
@@ -18,7 +18,7 @@ The following data is collected:
 - FerretDB version
 - Random instance UUID
 - [Autonomous system](<https://en.wikipedia.org/wiki/Autonomous_system_(Internet)>) number,
-  cloud provider region, or country derived from IP address (but the IP address itself)
+  cloud provider region, or country derived from IP address (but not the IP address itself)
 - Uptime
 - Backend (PostgreSQL or SQLite) version
 - Installation type (Docker, package, cloud provider marketplace, self-built)


### PR DESCRIPTION
# Description

We never collected IP addresses, but that missing "not" is embarrassing.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [x] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
