### PR TITLE
Ignore Stable API fields

### DIFF
--- a/internal/handler/common/count.go
+++ b/internal/handler/common/count.go
@@ -34,6 +34,10 @@ type CountParams struct {
 
 	Fields any `ferretdb:"fields,ignored"` // legacy MongoDB shell adds it, but it is never actually used
 
+	APIVersion           string `ferretdb:"apiVersion,ignored"`
+	APIString            string `ferretdb:"apiStrict,ignored"`
+	APIDeprecationErrors bool   `ferretdb:"apiDeprecationErrors,ignored"`
+
 	MaxTimeMS      int64           `ferretdb:"maxTimeMS,ignored"`
 	Hint           any             `ferretdb:"hint,ignored"`
 	ReadConcern    *types.Document `ferretdb:"readConcern,ignored"`

--- a/internal/handler/common/count.go
+++ b/internal/handler/common/count.go
@@ -35,7 +35,7 @@ type CountParams struct {
 	Fields any `ferretdb:"fields,ignored"` // legacy MongoDB shell adds it, but it is never actually used
 
 	APIVersion           string `ferretdb:"apiVersion,ignored"`
-	APIString            string `ferretdb:"apiStrict,ignored"`
+	APIStrict            bool   `ferretdb:"apiStrict,ignored"`
 	APIDeprecationErrors bool   `ferretdb:"apiDeprecationErrors,ignored"`
 
 	MaxTimeMS      int64           `ferretdb:"maxTimeMS,ignored"`

--- a/internal/handler/common/delete_params.go
+++ b/internal/handler/common/delete_params.go
@@ -35,7 +35,7 @@ type DeleteParams struct {
 	Let *types.Document `ferretdb:"let,unimplemented"`
 
 	APIVersion           string `ferretdb:"apiVersion,ignored"`
-	APIString            string `ferretdb:"apiStrict,ignored"`
+	APIStrict            bool   `ferretdb:"apiStrict,ignored"`
 	APIDeprecationErrors bool   `ferretdb:"apiDeprecationErrors,ignored"`
 
 	MaxTimeMS      int64           `ferretdb:"maxTimeMS,ignored"`

--- a/internal/handler/common/delete_params.go
+++ b/internal/handler/common/delete_params.go
@@ -34,6 +34,10 @@ type DeleteParams struct {
 
 	Let *types.Document `ferretdb:"let,unimplemented"`
 
+	APIVersion           string `ferretdb:"apiVersion,ignored"`
+	APIString            string `ferretdb:"apiStrict,ignored"`
+	APIDeprecationErrors bool   `ferretdb:"apiDeprecationErrors,ignored"`
+
 	MaxTimeMS      int64           `ferretdb:"maxTimeMS,ignored"`
 	WriteConcern   *types.Document `ferretdb:"writeConcern,ignored"`
 	LSID           any             `ferretdb:"lsid,ignored"`

--- a/internal/handler/common/distinct.go
+++ b/internal/handler/common/distinct.go
@@ -42,7 +42,7 @@ type DistinctParams struct {
 	Collation *types.Document `ferretdb:"collation,unimplemented"`
 
 	APIVersion           string `ferretdb:"apiVersion,ignored"`
-	APIString            string `ferretdb:"apiStrict,ignored"`
+	APIStrict            bool   `ferretdb:"apiStrict,ignored"`
 	APIDeprecationErrors bool   `ferretdb:"apiDeprecationErrors,ignored"`
 
 	ReadConcern    *types.Document `ferretdb:"readConcern,ignored"`

--- a/internal/handler/common/distinct.go
+++ b/internal/handler/common/distinct.go
@@ -41,6 +41,10 @@ type DistinctParams struct {
 
 	Collation *types.Document `ferretdb:"collation,unimplemented"`
 
+	APIVersion           string `ferretdb:"apiVersion,ignored"`
+	APIString            string `ferretdb:"apiStrict,ignored"`
+	APIDeprecationErrors bool   `ferretdb:"apiDeprecationErrors,ignored"`
+
 	ReadConcern    *types.Document `ferretdb:"readConcern,ignored"`
 	LSID           any             `ferretdb:"lsid,ignored"`
 	ClusterTime    any             `ferretdb:"$clusterTime,ignored"`

--- a/internal/handler/common/explain.go
+++ b/internal/handler/common/explain.go
@@ -42,7 +42,7 @@ type ExplainParams struct {
 	Command    *types.Document `ferretdb:"-"`
 
 	APIVersion           string `ferretdb:"apiVersion,ignored"`
-	APIString            string `ferretdb:"apiStrict,ignored"`
+	APIStrict            bool   `ferretdb:"apiStrict,ignored"`
 	APIDeprecationErrors bool   `ferretdb:"apiDeprecationErrors,ignored"`
 
 	Verbosity string `ferretdb:"verbosity,ignored"`

--- a/internal/handler/common/explain.go
+++ b/internal/handler/common/explain.go
@@ -41,6 +41,10 @@ type ExplainParams struct {
 	Aggregate  bool            `ferretdb:"-"`
 	Command    *types.Document `ferretdb:"-"`
 
+	APIVersion           string `ferretdb:"apiVersion,ignored"`
+	APIString            string `ferretdb:"apiStrict,ignored"`
+	APIDeprecationErrors bool   `ferretdb:"apiDeprecationErrors,ignored"`
+
 	Verbosity string `ferretdb:"verbosity,ignored"`
 }
 

--- a/internal/handler/common/find.go
+++ b/internal/handler/common/find.go
@@ -44,6 +44,10 @@ type FindParams struct {
 	Collation *types.Document `ferretdb:"collation,unimplemented"`
 	Let       *types.Document `ferretdb:"let,unimplemented"`
 
+	APIVersion           string `ferretdb:"apiVersion,ignored"`
+	APIString            string `ferretdb:"apiStrict,ignored"`
+	APIDeprecationErrors bool   `ferretdb:"apiDeprecationErrors,ignored"`
+
 	AllowDiskUse     bool            `ferretdb:"allowDiskUse,ignored"`
 	ReadConcern      *types.Document `ferretdb:"readConcern,ignored"`
 	Max              *types.Document `ferretdb:"max,ignored"`

--- a/internal/handler/common/find.go
+++ b/internal/handler/common/find.go
@@ -45,7 +45,7 @@ type FindParams struct {
 	Let       *types.Document `ferretdb:"let,unimplemented"`
 
 	APIVersion           string `ferretdb:"apiVersion,ignored"`
-	APIString            string `ferretdb:"apiStrict,ignored"`
+	APIStrict            bool   `ferretdb:"apiStrict,ignored"`
 	APIDeprecationErrors bool   `ferretdb:"apiDeprecationErrors,ignored"`
 
 	AllowDiskUse     bool            `ferretdb:"allowDiskUse,ignored"`

--- a/internal/handler/common/findandmodify.go
+++ b/internal/handler/common/findandmodify.go
@@ -49,7 +49,7 @@ type FindAndModifyParams struct {
 	ArrayFilters *types.Array    `ferretdb:"arrayFilters,unimplemented"`
 
 	APIVersion           string `ferretdb:"apiVersion,ignored"`
-	APIString            string `ferretdb:"apiStrict,ignored"`
+	APIStrict            bool   `ferretdb:"apiStrict,ignored"`
 	APIDeprecationErrors bool   `ferretdb:"apiDeprecationErrors,ignored"`
 
 	Hint                     string          `ferretdb:"hint,ignored"`

--- a/internal/handler/common/findandmodify.go
+++ b/internal/handler/common/findandmodify.go
@@ -48,6 +48,10 @@ type FindAndModifyParams struct {
 	Fields       *types.Document `ferretdb:"fields,unimplemented"`
 	ArrayFilters *types.Array    `ferretdb:"arrayFilters,unimplemented"`
 
+	APIVersion           string `ferretdb:"apiVersion,ignored"`
+	APIString            string `ferretdb:"apiStrict,ignored"`
+	APIDeprecationErrors bool   `ferretdb:"apiDeprecationErrors,ignored"`
+
 	Hint                     string          `ferretdb:"hint,ignored"`
 	WriteConcern             *types.Document `ferretdb:"writeConcern,ignored"`
 	BypassDocumentValidation bool            `ferretdb:"bypassDocumentValidation,ignored"`

--- a/internal/handler/common/insert.go
+++ b/internal/handler/common/insert.go
@@ -34,7 +34,7 @@ type InsertParams struct {
 	Ordered    bool         `ferretdb:"ordered,opt"`
 
 	APIVersion           string `ferretdb:"apiVersion,ignored"`
-	APIString            string `ferretdb:"apiStrict,ignored"`
+	APIStrict            bool   `ferretdb:"apiStrict,ignored"`
 	APIDeprecationErrors bool   `ferretdb:"apiDeprecationErrors,ignored"`
 
 	MaxTimeMS                int64           `ferretdb:"maxTimeMS,ignored"`

--- a/internal/handler/common/insert.go
+++ b/internal/handler/common/insert.go
@@ -33,6 +33,10 @@ type InsertParams struct {
 	Collection string       `ferretdb:"insert,collection"`
 	Ordered    bool         `ferretdb:"ordered,opt"`
 
+	APIVersion           string `ferretdb:"apiVersion,ignored"`
+	APIString            string `ferretdb:"apiStrict,ignored"`
+	APIDeprecationErrors bool   `ferretdb:"apiDeprecationErrors,ignored"`
+
 	MaxTimeMS                int64           `ferretdb:"maxTimeMS,ignored"`
 	WriteConcern             any             `ferretdb:"writeConcern,ignored"`
 	BypassDocumentValidation bool            `ferretdb:"bypassDocumentValidation,ignored"`

--- a/internal/handler/common/update_params.go
+++ b/internal/handler/common/update_params.go
@@ -37,7 +37,7 @@ type UpdateParams struct {
 	Let *types.Document `ferretdb:"let,unimplemented"`
 
 	APIVersion           string `ferretdb:"apiVersion,ignored"`
-	APIString            string `ferretdb:"apiStrict,ignored"`
+	APIStrict            bool   `ferretdb:"apiStrict,ignored"`
 	APIDeprecationErrors bool   `ferretdb:"apiDeprecationErrors,ignored"`
 
 	Ordered                  bool            `ferretdb:"ordered,ignored"`

--- a/internal/handler/common/update_params.go
+++ b/internal/handler/common/update_params.go
@@ -36,6 +36,10 @@ type UpdateParams struct {
 
 	Let *types.Document `ferretdb:"let,unimplemented"`
 
+	APIVersion           string `ferretdb:"apiVersion,ignored"`
+	APIString            string `ferretdb:"apiStrict,ignored"`
+	APIDeprecationErrors bool   `ferretdb:"apiDeprecationErrors,ignored"`
+
 	Ordered                  bool            `ferretdb:"ordered,ignored"`
 	BypassDocumentValidation bool            `ferretdb:"bypassDocumentValidation,ignored"`
 	WriteConcern             *types.Document `ferretdb:"writeConcern,ignored"`


### PR DESCRIPTION
# Description

Closes #3121.

No test added, I think this is something better tested with relevant driver in dance.

The test script https://github.com/FerretDB/FerretDB/pull/4344 contains unimplemented CollMod command which causes fail after this fix.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
