### PR TITLE
Use `wireclient` login function in integration test

### DIFF
--- a/integration/go.mod
+++ b/integration/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/FerretDB/wire v0.0.7
 	github.com/prometheus/client_golang v1.19.1
 	github.com/stretchr/testify v1.9.0
-	github.com/xdg-go/scram v1.1.2
 	go.mongodb.org/mongo-driver v1.16.0
 	go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo v0.53.0
 	go.opentelemetry.io/otel v1.28.0
@@ -52,6 +51,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/scram v1.1.2 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.28.0 // indirect

--- a/integration/setup/listener.go
+++ b/integration/setup/listener.go
@@ -74,7 +74,7 @@ func listenerMongoDBURI(tb testtb.TB, hostPort, unixSocketPath string, disableNe
 			"tls":                   []string{"true"},
 			"tlsCertificateKeyFile": []string{filepath.Join(testutil.BuildCertsDir, "client.pem")},
 			"tlsCaFile":             []string{filepath.Join(testutil.BuildCertsDir, "rootCA-cert.pem")},
-			"authMechanism":         []string{"SCRAM-SHA-1"},
+			"authMechanism":         []string{"SCRAM-SHA-256"},
 		}
 		user = url.UserPassword("username", "password")
 

--- a/integration/setup/listener.go
+++ b/integration/setup/listener.go
@@ -74,6 +74,7 @@ func listenerMongoDBURI(tb testtb.TB, hostPort, unixSocketPath string, disableNe
 			"tls":                   []string{"true"},
 			"tlsCertificateKeyFile": []string{filepath.Join(testutil.BuildCertsDir, "client.pem")},
 			"tlsCaFile":             []string{filepath.Join(testutil.BuildCertsDir, "rootCA-cert.pem")},
+			"authMechanism":         []string{"SCRAM-SHA-1"},
 		}
 		user = url.UserPassword("username", "password")
 

--- a/integration/users/connection_test.go
+++ b/integration/users/connection_test.go
@@ -350,20 +350,22 @@ func TestAuthenticationAuthSource(t *testing.T) {
 			u, err := url.Parse(s.MongoDBURI)
 			require.NoError(t, err)
 
-			u.User = testURI.User
-			u.Path = testURI.Path
+			testURI.Host = u.Host
 
 			// tls related query values are necessary
-			q := u.Query()
-			for k, v := range testURI.Query() {
-				q.Set(k, v[0])
+			q := testURI.Query()
+			for k, v := range u.Query() {
+				switch k {
+				case "tls", "tlsCertificateKeyFile", "tlsCaFile":
+					q.Set(k, v[0])
+				}
 			}
 
-			u.RawQuery = q.Encode()
+			testURI.RawQuery = q.Encode()
 
-			opts := options.Client().ApplyURI(u.String())
+			opts := options.Client().ApplyURI(testURI.String())
 
-			t.Log("Connecting", u.String())
+			t.Log("Connecting", testURI.String())
 
 			client, err := mongo.Connect(ctx, opts)
 			require.NoError(t, err)


### PR DESCRIPTION
# Description
Port setup using wireconn.

Closes #<issue_number>.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [ ] I ensured that PR title is good enough for the changelog.
- [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [ ] I marked all done items in this checklist.
