### PR TITLE
Use `admin` database in integration test setup

### DIFF
--- a/integration/setup/listener.go
+++ b/integration/setup/listener.go
@@ -51,7 +51,7 @@ func unixSocketPath(tb testtb.TB) string {
 }
 
 // listenerMongoDBURI builds MongoDB URI for in-process FerretDB.
-func listenerMongoDBURI(tb testtb.TB, hostPort, unixSocketPath, newAuthDB string, tlsAndAuth bool) string {
+func listenerMongoDBURI(tb testtb.TB, hostPort, unixSocketPath string, disableNewAuth, tlsAndAuth bool) string {
 	tb.Helper()
 
 	var host string
@@ -74,23 +74,19 @@ func listenerMongoDBURI(tb testtb.TB, hostPort, unixSocketPath, newAuthDB string
 			"tls":                   []string{"true"},
 			"tlsCertificateKeyFile": []string{filepath.Join(testutil.BuildCertsDir, "client.pem")},
 			"tlsCaFile":             []string{filepath.Join(testutil.BuildCertsDir, "rootCA-cert.pem")},
-			"authMechanism":         []string{"PLAIN"},
 		}
 		user = url.UserPassword("username", "password")
-	}
 
-	path := "/"
-
-	if newAuthDB != "" {
-		q.Set("authMechanism", "SCRAM-SHA-256")
-		path += newAuthDB
+		if disableNewAuth {
+			q.Add("authMechanism", "PLAIN")
+		}
 	}
 
 	// TODO https://github.com/FerretDB/FerretDB/issues/1507
 	u := &url.URL{
 		Scheme:   "mongodb",
 		Host:     host,
-		Path:     path,
+		Path:     "/",
 		User:     user,
 		RawQuery: q.Encode(),
 	}
@@ -195,7 +191,7 @@ func setupListener(tb testtb.TB, ctx context.Context, logger *slog.Logger, opts 
 	}
 
 	if !opts.DisableNewAuth {
-		handlerOpts.SetupDatabase = "test"
+		handlerOpts.SetupDatabase = "admin"
 		handlerOpts.SetupUsername = "username"
 		handlerOpts.SetupPassword = password.WrapPassword("password")
 		handlerOpts.SetupTimeout = 20 * time.Second // CI may be slow for many parallel tests
@@ -258,19 +254,17 @@ func setupListener(tb testtb.TB, ctx context.Context, logger *slog.Logger, opts 
 	})
 
 	var hostPort, unixSocketPath string
-	var tlsAndAuth bool
 
 	switch {
 	case *targetTLSF:
 		hostPort = l.TLSAddr().String()
-		tlsAndAuth = true
 	case *targetUnixSocketF:
 		unixSocketPath = l.UnixAddr().String()
 	default:
 		hostPort = l.TCPAddr().String()
 	}
 
-	uri := listenerMongoDBURI(tb, hostPort, unixSocketPath, handlerOpts.SetupDatabase, tlsAndAuth)
+	uri := listenerMongoDBURI(tb, hostPort, unixSocketPath, opts.DisableNewAuth, *targetTLSF)
 
 	logger.InfoContext(ctx, "Listener started", slog.String("handler", handler), slog.String("uri", uri))
 


### PR DESCRIPTION
# Description

The database to setup in integration test should be `admin` database, to prepare integration test to use `wireclient`. It has to be the same as the user setup by MongoDB docker.

Closes #4448.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [x] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
