### PR TITLE
Fix Docker's `HEALTHCHECK` in production image

### DIFF
--- a/build/ferretdb/all-in-one.Dockerfile
+++ b/build/ferretdb/all-in-one.Dockerfile
@@ -138,7 +138,7 @@ ENTRYPOINT [ "/entrypoint.sh" ]
 # all-in-one hacks stop there
 
 HEALTHCHECK --interval=1m --timeout=5s --retries=1 --start-period=30s --start-interval=5s \
-  CMD /ferretdb ping
+  CMD ["/ferretdb", "ping"]
 
 WORKDIR /
 VOLUME /state

--- a/build/ferretdb/development.Dockerfile
+++ b/build/ferretdb/development.Dockerfile
@@ -119,7 +119,7 @@ COPY --from=development-build /src/bin/ferretdb /ferretdb
 ENTRYPOINT [ "/ferretdb" ]
 
 HEALTHCHECK --interval=1m --timeout=5s --retries=1 --start-period=30s --start-interval=5s \
-  CMD /ferretdb ping
+  CMD ["/ferretdb", "ping"]
 
 WORKDIR /
 VOLUME /state

--- a/build/ferretdb/production.Dockerfile
+++ b/build/ferretdb/production.Dockerfile
@@ -111,7 +111,7 @@ COPY --from=production-build --chown=ferretdb:ferretdb /state /state
 ENTRYPOINT [ "/ferretdb" ]
 
 HEALTHCHECK --interval=1m --timeout=5s --retries=1 --start-period=30s --start-interval=5s \
-  CMD /ferretdb ping
+  CMD ["/ferretdb", "ping"]
 
 WORKDIR /
 VOLUME /state


### PR DESCRIPTION
# Description

A Dockerfile `HEALTHCHECK` instruction accepts either shell or exec array form for `CMD`, as mentioned in <https://docs.docker.com/reference/dockerfile/#healthcheck>:
> The command after the `CMD` keyword can be either a shell command (e.g. `HEALTHCHECK CMD /bin/check-running`) or an exec array (as with other Dockerfile commands; see e.g. `ENTRYPOINT` for details).

By using a shell command the healthcheck is run in the containers shell, which fails if there is none.

I rewrote all Dockerfiles' HEALTHCHECK CMD as an exec array, as `production.Dockerfile` builds an image without `/bin/sh`, making `dockerd` log multiple messages each second:

```
Aug 22 03:06:16 host dockerd[3578693]: time="2024-08-22T03:06:16.000432331+02:00" level=error msg="stream copy error: reading from a closed fifo"
Aug 22 03:06:16 host dockerd[3578693]: time="2024-08-22T03:06:16.000432413+02:00" level=error msg="stream copy error: reading from a closed fifo"
Aug 22 03:06:16 host dockerd[3578693]: time="2024-08-22T03:06:16.002688602+02:00" level=warning msg="Health check for container ed71f1ce11d83d911a0692020124dc51b82217a63e9094301d3043b28009ea42 error: OCI runtime exec failed: exec failed: unable to start container process: exec: \"/bin/sh\": stat /bin/sh: no such file or directory: unknown"
```

## Readiness checklist

<!-- Please check all items in this checklist that were done. -->

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [ ] I ensured that PR title is good enough for the changelog.
- [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [ ] I marked all done items in this checklist.
