### PR TITLE
Fix duplicate field on `hello` op query

### DIFF
--- a/internal/handler/cmd_query.go
+++ b/internal/handler/cmd_query.go
@@ -88,12 +88,13 @@ func (h *Handler) CmdQuery(connCtx context.Context, query *wire.OpQuery) (*wire.
 			return wire.NewOpReply(must.NotFail(bson.FromDocument(reply)))
 		}
 
-		h.L.DebugContext(connCtx, "Speculative authentication passed")
-
 		reply.Set("speculativeAuthenticate", speculativeAuthenticate)
 
-		// saslSupportedMechs is used by the client as default mechanisms if `mechanisms` is unset
-		reply.Set("saslSupportedMechs", must.NotFail(types.NewArray("SCRAM-SHA-1", "SCRAM-SHA-256", "PLAIN")))
+		// ok field is the last field
+		reply.Remove("ok")
+		reply.Set("ok", float64(1))
+
+		h.L.DebugContext(connCtx, "Speculative authentication passed")
 
 		return wire.NewOpReply(must.NotFail(bson.FromDocument(reply)))
 	}


### PR DESCRIPTION
# Description

Duplicate field `saslSupportedMechs` was set on `hello` op query upon `speculativeAuthenticate`.

Closes #4065.

## Readiness checklist

<!-- Please check all items in this checklist that were done. -->

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
