### PR TITLE
Fix new lines in README's mermaid diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ using PostgreSQL or SQLite as a database engine.
 
 ```mermaid
 flowchart LR
-  A["Any application<br />Any MongoDB driver"]
+  A["Any application<br>Any MongoDB driver"]
   F{{FerretDB}}
   P[(PostgreSQL)]
   S[("SQLite")]
 
-  A -- "MongoDB protocol<br />BSON" --> F
-  F -- "PostgreSQL protocol<br />SQL" --> P
-  F -. "SQLite library<br />SQL" .-> S
+  A -- "MongoDB protocol<br>BSON" --> F
+  F -- "PostgreSQL protocol<br>SQL" --> P
+  F -. "SQLite library<br>SQL" .-> S
 ```
 
 ## Why do we need FerretDB?

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ using PostgreSQL or SQLite as a database engine.
 
 ```mermaid
 flowchart LR
-  A["Any application\nAny MongoDB driver"]
+  A["Any application<br />Any MongoDB driver"]
   F{{FerretDB}}
   P[(PostgreSQL)]
   S[("SQLite")]
 
-  A -- "MongoDB protocol\nBSON" --> F
-  F -- "PostgreSQL protocol\nSQL" --> P
-  F -. "SQLite library\nSQL" .-> S
+  A -- "MongoDB protocol<br />BSON" --> F
+  F -- "PostgreSQL protocol<br />SQL" --> P
+  F -. "SQLite library<br />SQL" .-> S
 ```
 
 ## Why do we need FerretDB?

--- a/website/docs/understanding-ferretdb.md
+++ b/website/docs/understanding-ferretdb.md
@@ -10,14 +10,14 @@ It uses the same commands, drivers, and tools as MongoDB.
 
 ```mermaid
 flowchart LR
-  A["Any application\nAny MongoDB driver"]
+  A["Any application<br>Any MongoDB driver"]
   F{{FerretDB}}
   P[(PostgreSQL)]
   S[("SQLite")]
 
-  A -- "MongoDB protocol\nBSON" --> F
-  F -- "PostgreSQL protocol\nSQL" --> P
-  F -. "SQLite library\nSQL" .-> S
+  A -- "MongoDB protocol<br>BSON" --> F
+  F -- "PostgreSQL protocol<br>SQL" --> P
+  F -. "SQLite library<br>SQL" .-> S
 ```
 
 :::tip

--- a/website/versioned_docs/version-v1.22/understanding-ferretdb.md
+++ b/website/versioned_docs/version-v1.22/understanding-ferretdb.md
@@ -10,14 +10,14 @@ It uses the same commands, drivers, and tools as MongoDB.
 
 ```mermaid
 flowchart LR
-  A["Any application\nAny MongoDB driver"]
+  A["Any application<br>Any MongoDB driver"]
   F{{FerretDB}}
   P[(PostgreSQL)]
   S[("SQLite")]
 
-  A -- "MongoDB protocol\nBSON" --> F
-  F -- "PostgreSQL protocol\nSQL" --> P
-  F -. "SQLite library\nSQL" .-> S
+  A -- "MongoDB protocol<br>BSON" --> F
+  F -- "PostgreSQL protocol<br>SQL" --> P
+  F -. "SQLite library<br>SQL" .-> S
 ```
 
 :::tip

--- a/website/versioned_docs/version-v1.23/understanding-ferretdb.md
+++ b/website/versioned_docs/version-v1.23/understanding-ferretdb.md
@@ -10,14 +10,14 @@ It uses the same commands, drivers, and tools as MongoDB.
 
 ```mermaid
 flowchart LR
-  A["Any application\nAny MongoDB driver"]
+  A["Any application<br>Any MongoDB driver"]
   F{{FerretDB}}
   P[(PostgreSQL)]
   S[("SQLite")]
 
-  A -- "MongoDB protocol\nBSON" --> F
-  F -- "PostgreSQL protocol\nSQL" --> P
-  F -. "SQLite library\nSQL" .-> S
+  A -- "MongoDB protocol<br>BSON" --> F
+  F -- "PostgreSQL protocol<br>SQL" --> P
+  F -. "SQLite library<br>SQL" .-> S
 ```
 
 :::tip

--- a/website/versioned_docs/version-v1.24/understanding-ferretdb.md
+++ b/website/versioned_docs/version-v1.24/understanding-ferretdb.md
@@ -10,14 +10,14 @@ It uses the same commands, drivers, and tools as MongoDB.
 
 ```mermaid
 flowchart LR
-  A["Any application\nAny MongoDB driver"]
+  A["Any application<br>Any MongoDB driver"]
   F{{FerretDB}}
   P[(PostgreSQL)]
   S[("SQLite")]
 
-  A -- "MongoDB protocol\nBSON" --> F
-  F -- "PostgreSQL protocol\nSQL" --> P
-  F -. "SQLite library\nSQL" .-> S
+  A -- "MongoDB protocol<br>BSON" --> F
+  F -- "PostgreSQL protocol<br>SQL" --> P
+  F -. "SQLite library<br>SQL" .-> S
 ```
 
 :::tip


### PR DESCRIPTION
# Description

If I undertstand correctly, GitHub's mermaid doesn't support `\n` as EOL, but `<br>` is used in mermaid's docs and works, see [here](https://mermaid.js.org/syntax/examples.html#larger-flowchart-with-some-styling). On docusaurus, `\n` works well, so I haven't touched it.

Before:
<img width="846" alt="Screenshot 2024-09-16 at 13 40 30" src="https://github.com/user-attachments/assets/033d17fd-6421-48dc-b631-92f1728488d6">

After:
<img width="869" alt="Screenshot 2024-09-16 at 13 40 54" src="https://github.com/user-attachments/assets/d5ae829d-507c-4e1c-894b-1f8f34551440">

## Readiness checklist

<!-- Please check all items in this checklist that were done. -->

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [x] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
