### PR TITLE
Avoid noisy docker log about endSessions authentication

### DIFF
--- a/integration/endsessions_test.go
+++ b/integration/endsessions_test.go
@@ -162,6 +162,57 @@ func TestEndSessionsErrors(t *testing.T) {
 	})
 }
 
+func TestEndSessionsUnauthenticated(t *testing.T) {
+	t.Parallel()
+
+	s := setup.SetupWithOpts(t, &setup.SetupOpts{WireConn: setup.WireConnNoAuth})
+
+	ctx, db, conn := s.Ctx, s.Collection, s.WireConn
+	dbName := db.Name()
+
+	randomUUID := must.NotFail(uuid.NewRandom())
+	sessionID := wirebson.Binary{B: randomUUID[:], Subtype: wirebson.BinaryUUID}
+
+	_, resBody, err := conn.Request(ctx, wire.MustOpMsg(
+		"ping", int32(1),
+		"lsid", wirebson.MustDocument("id", sessionID),
+		"$db", dbName,
+	))
+	require.NoError(t, err)
+
+	var res *wirebson.Document
+	res, err = must.NotFail(resBody.(*wire.OpMsg).RawDocument()).DecodeDeep()
+	require.NoError(t, err)
+
+	fixCluster(t, res)
+
+	expected := wirebson.MustDocument(
+		"ok", float64(1),
+	)
+
+	testutil.AssertEqual(t, expected, res)
+
+	_, resBody, err = conn.Request(ctx, wire.MustOpMsg(
+		"endSessions", wirebson.MustArray(wirebson.MustDocument("id", sessionID)),
+		"$db", dbName,
+	))
+	require.NoError(t, err)
+
+	res, err = must.NotFail(resBody.(*wire.OpMsg).RawDocument()).DecodeDeep()
+	require.NoError(t, err)
+
+	fixCluster(t, res)
+
+	expected = must.NotFail(wirebson.NewDocument(
+		"ok", float64(0),
+		"errmsg", "Command endSessions requires authentication",
+		"code", int32(13),
+		"codeName", "Unauthorized",
+	))
+
+	testutil.AssertEqual(t, expected, res)
+}
+
 // endSession sends a request to end the given session.
 // If expectedErr is not nil, the error is checked, otherwise it checks the response.
 func endSessions(t testing.TB, ctx context.Context, conn *wireclient.Conn, dbName string, sessions any, expectedErr *wirebson.Document) {


### PR DESCRIPTION
# Description

Closes #4692.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [ ] I ensured that PR title is good enough for the changelog.
- [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [ ] I marked all done items in this checklist.
