### PR TITLE
Make embeddable package logging configurable

### DIFF
--- a/ferretdb/ferretdb_test.go
+++ b/ferretdb/ferretdb_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"log/slog"
 	"os/exec"
 	"testing"
 
@@ -87,6 +88,8 @@ func TestFerretDB(t *testing.T) {
 		PostgreSQLURL: testutil.PostgreSQLURI(t),
 		ListenAddr:    "127.0.0.1:0",
 		StateDir:      t.TempDir(),
+		LogLevel:      slog.LevelDebug,
+		LogOutput:     testutil.NewLogWriter(t),
 	})
 	require.NoError(t, err)
 

--- a/internal/util/testutil/logging.go
+++ b/internal/util/testutil/logging.go
@@ -28,6 +28,11 @@ type logWriter struct {
 	tb testing.TB
 }
 
+// NewLogWriter returns a new [io.Writer] for [testing.TB].
+func NewLogWriter(tb testing.TB) io.Writer {
+	return &logWriter{tb: tb}
+}
+
 // Write implements [io.Writer].
 func (lw *logWriter) Write(p []byte) (int, error) {
 	// "logging.go:xx" is added by testing.TB.Log itself; there is nothing we can do about it.
@@ -45,7 +50,7 @@ func Logger(tb testing.TB) *slog.Logger {
 
 // LevelLogger returns a slog test logger for the given level (which might be dynamic).
 func LevelLogger(tb testing.TB, level slog.Leveler) *slog.Logger {
-	h := logging.NewHandler(&logWriter{tb: tb}, &logging.NewHandlerOpts{
+	h := logging.NewHandler(NewLogWriter(tb), &logging.NewHandlerOpts{
 		Base:       "console",
 		Level:      level,
 		RemoveTime: true,


### PR DESCRIPTION
# Description

Closes #4750.

## Readiness checklist

- [x] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [x] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
