### PR TITLE
Move comment in docs to fix DocCard

### DIFF
--- a/website/docs/migration/diff.md
+++ b/website/docs/migration/diff.md
@@ -4,12 +4,14 @@ sidebar_position: 11
 
 # Known differences
 
-<!--
-   Each numbered point should have a corresponding, numbered test file https://github.com/FerretDB/FerretDB/tree/main/integration/diff_*_test.go
-   Bullet subpoints should be in the same file as the parent point.
--->
-
 1. FerretDB uses the same protocol error names and codes, but the exact error messages may be different in some cases.
 2. Collection name must be valid UTF-8.
 
 If you encounter some other difference in behavior, please [join our community](/#community) to report a problem.
+
+<!--
+   Each numbered point should have a corresponding, numbered test file https://github.com/FerretDB/FerretDB/tree/main/integration/diff_*_test.go
+   Bullet subpoints should be in the same file as the parent point.
+
+   This comment should not be on top to avoid showing on a DocCard: https://github.com/facebook/docusaurus/issues/10589.
+-->


### PR DESCRIPTION
# Description

https://docs.ferretdb.io/migration/

![CleanShot 2025-02-28 at 12 26 38@2x](https://github.com/user-attachments/assets/d7f96128-273f-4e96-82fb-0fc4ccc6b138)

## Readiness checklist

<!-- Please check all items in this checklist that were done. -->

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [x] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
