### PR TITLE
Update URL to join Slack

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Quick question
-    url: https://join.slack.com/t/ferretdb/shared_invite/zt-zqe9hj8g-ZcMG3~5Cs5u9uuOPnZB8~A
+    url: https://slack.ferretdb.io/
     about: Please join our Slack chat.
   - name: General question or discussion
     url: https://github.com/FerretDB/FerretDB/discussions/categories/general

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ See [there](https://pkg.go.dev/github.com/FerretDB/FerretDB/v2/build/version) fo
 - Documentation: https://docs.ferretdb.io/.
 - X (Twitter): [@ferret_db](https://x.com/ferret_db).
 - Mastodon: [@ferretdb@techhub.social](https://techhub.social/@ferretdb).
-- [Slack chat](https://join.slack.com/t/ferretdb/shared_invite/zt-zqe9hj8g-ZcMG3~5Cs5u9uuOPnZB8~A) for quick questions.
+- [Slack chat](https://slack.ferretdb.io/) for quick questions.
 - [GitHub Discussions](https://github.com/FerretDB/FerretDB/discussions) for longer topics.
 - [GitHub Issues](https://github.com/FerretDB/FerretDB/issues) for bugs and missing features.
 - [Open Office Hours meeting](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=NGhrZTA5dXZ0MzQzN2gyaGVtZmx2aWxmN2pfMjAyNDA0MDhUMTcwMDAwWiBjX24zN3RxdW9yZWlsOWIwMm0wNzQwMDA3MjQ0QGc&tmsrc=c_n37tquoreil9b02m0740007244%40group.calendar.google.com&scp=ALL)

--- a/website/blog/2022-10-03-introducing-ferretdb-beacon-telemetry-service.md
+++ b/website/blog/2022-10-03-introducing-ferretdb-beacon-telemetry-service.md
@@ -43,5 +43,5 @@ And if you decide to opt out, we hope that you can join our community and provid
 Most importantly, we remain committed to the principles of open source and community, recognizing that we cannot do this without your help and support.
 In light of this, we'd like to get your opinion on some of the concerns you might have regarding the use of FerretDB Beacon and how we can ease those fears.
 
-If you have any questions or concerns you would like to raise, kindly reach out to us on [Slack chat](https://join.slack.com/t/ferretdb/shared_invite/zt-zqe9hj8g-ZcMG3~5Cs5u9uuOPnZB8~A) and [GitHub Discussions](https://github.com/FerretDB/FerretDB/discussions) for more information.
+If you have any questions or concerns you would like to raise, kindly reach out to us on [Slack chat](https://slack.ferretdb.io/) and [GitHub Discussions](https://github.com/FerretDB/FerretDB/discussions) for more information.
 You can also join our [open office hours meeting](https://calendar.google.com/event?action=TEMPLATE&tmeid=NjNkdTkyN3VoNW5zdHRiaHZybXFtb2l1OWtfMjAyMTEyMTNUMTgwMDAwWiBjX24zN3RxdW9yZWlsOWIwMm0wNzQwMDA3MjQ0QGc&tmsrc=c_n37tquoreil9b02m0740007244%40group.calendar.google.com&scp=ALL) every Monday at 18:00 UTC at [Google Meet](https://meet.google.com/mcb-arhw-qbq).

--- a/website/blog/2022-10-12-contribute-to-ferretdb-on-windows.md
+++ b/website/blog/2022-10-12-contribute-to-ferretdb-on-windows.md
@@ -144,7 +144,7 @@ For Windows users, starting your contribution journey to FerretDB might feel a b
 We've covered all the known Windows-specific issues you might encounter in this article when contributing to FerretDB on Windows.
 
 An excellent place to start contributing is to select any issue labeled as the [good first issue](https://github.com/FerretDB/FerretDB/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
-Not to mention, we have an awesome community [Slack group where you can connect!](https://join.slack.com/t/ferretdb/shared_invite/zt-zqe9hj8g-ZcMG3~5Cs5u9uuOPnZB8~A) And if you experience any other issues that aren't covered in this article or have any questions, please feel free to reach out to us on Slack or GitHub Discussions.
+Not to mention, we have an awesome community [Slack group where you can connect!](https://slack.ferretdb.io/) And if you experience any other issues that aren't covered in this article or have any questions, please feel free to reach out to us on Slack or GitHub Discussions.
 
 With your Windows environment configured and set up, read our contributing guide to start contributing to FerretDB on Windows.
 

--- a/website/blog/2024-04-29-deploy-ferretdb-in-kubernetes-using-kubedb-managed-postgres.md
+++ b/website/blog/2024-04-29-deploy-ferretdb-in-kubernetes-using-kubedb-managed-postgres.md
@@ -348,4 +348,4 @@ spec:
 
 This blog post shows you how to deploy a [FerretDB](https://www.ferretdb.com/) instance in Kubernetes using KubeDB.
 Ensure to experiment and try it out.
-If you have any questions or just want to contact us, please do so via the [FerretDB Slack channel here](https://join.slack.com/t/ferretdb/shared_invite/zt-zqe9hj8g-ZcMG3~5Cs5u9uuOPnZB8~A).
+If you have any questions or just want to contact us, please do so via the [FerretDB Slack channel here](https://slack.ferretdb.io/).

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -55,7 +55,7 @@ See our:
 - Website and blog: https://www.ferretdb.com/.
 - Twitter: [@ferret_db](https://twitter.com/ferret_db).
 - Mastodon: [@ferretdb@techhub.social](https://techhub.social/@ferretdb).
-- [Slack chat](https://join.slack.com/t/ferretdb/shared_invite/zt-zqe9hj8g-ZcMG3~5Cs5u9uuOPnZB8~A) for quick questions.
+- [Slack chat](https://slack.ferretdb.io/) for quick questions.
 - [GitHub Discussions](https://github.com/FerretDB/FerretDB/discussions) for longer topics.
 - [GitHub Issues](https://github.com/FerretDB/FerretDB/issues) for bugs and missing features.
 - [Open Office Hours meeting](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=NGhrZTA5dXZ0MzQzN2gyaGVtZmx2aWxmN2pfMjAyNDA0MDhUMTcwMDAwWiBjX24zN3RxdW9yZWlsOWIwMm0wNzQwMDA3MjQ0QGc&tmsrc=c_n37tquoreil9b02m0740007244%40group.calendar.google.com&scp=ALL)

--- a/website/docusaurus.config-blog.js
+++ b/website/docusaurus.config-blog.js
@@ -144,7 +144,7 @@ const config = {
               },
               {
                 label: "Slack",
-                href: "https://join.slack.com/t/ferretdb/shared_invite/zt-zqe9hj8g-ZcMG3~5Cs5u9uuOPnZB8~A",
+                href: "https://slack.ferretdb.io/",
               },
               {
                 label: "X (Twitter)",

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -152,7 +152,7 @@ const config = {
               },
               {
                 label: "Slack",
-                href: "https://join.slack.com/t/ferretdb/shared_invite/zt-zqe9hj8g-ZcMG3~5Cs5u9uuOPnZB8~A",
+                href: "https://slack.ferretdb.io/",
               },
               {
                 label: "X (Twitter)",

--- a/website/versioned_docs/version-v1.24/main.md
+++ b/website/versioned_docs/version-v1.24/main.md
@@ -34,7 +34,7 @@ and [contributing guidelines](https://github.com/FerretDB/FerretDB/blob/main-v1/
 - Website and blog: https://www.ferretdb.com/.
 - Twitter: [@ferret_db](https://twitter.com/ferret_db).
 - Mastodon: [@ferretdb@techhub.social](https://techhub.social/@ferretdb).
-- [Slack chat](https://join.slack.com/t/ferretdb/shared_invite/zt-zqe9hj8g-ZcMG3~5Cs5u9uuOPnZB8~A) for quick questions.
+- [Slack chat](https://slack.ferretdb.io/) for quick questions.
 - [GitHub Discussions](https://github.com/FerretDB/FerretDB/discussions) for longer topics.
 - [GitHub Issues](https://github.com/FerretDB/FerretDB/issues) for bugs and missing features.
 - [Open Office Hours meeting](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=NGhrZTA5dXZ0MzQzN2gyaGVtZmx2aWxmN2pfMjAyNDA0MDhUMTcwMDAwWiBjX24zN3RxdW9yZWlsOWIwMm0wNzQwMDA3MjQ0QGc&tmsrc=c_n37tquoreil9b02m0740007244%40group.calendar.google.com&scp=ALL)


### PR DESCRIPTION
# Description

See:
- https://slack.ferretdb.io/
- https://github.com/FerretDB/slack

Please avoid using join.slack.com/XXX from now on.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [x] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.

---

This pull request updates various references to the Slack chat URL across multiple documentation files and configuration files. The new URL is `https://slack.ferretdb.io/`.

The most important changes include:

Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L113-R113): Updated the Slack chat URL for quick questions.
* [`website/blog/2022-10-03-introducing-ferretdb-beacon-telemetry-service.md`](diffhunk://#diff-cbc6f7db44137d4a9177a4ce4733f01d4c7cdd89a58db278f1b141736513f2d0L46-R46): Updated the Slack chat URL for raising questions or concerns.
* [`website/blog/2022-10-12-contribute-to-ferretdb-on-windows.md`](diffhunk://#diff-38ed8f98771044f26c16f0c82de3bbc1417c4799e5c813c611e010b1a8a9066dL147-R147): Updated the Slack group URL for connecting with the community.
* [`website/blog/2024-04-29-deploy-ferretdb-in-kubernetes-using-kubedb-managed-postgres.md`](diffhunk://#diff-8bd608740938bbfa90b58dca36a6ceb725204a4b63cf8b2cd4ab3bc738393319L351-R351): Updated the Slack channel URL for contacting the team.
* [`website/docs/introduction.md`](diffhunk://#diff-0890f0ba3d12d890012a1b6135b69b25354212692889e02df86a130262bb3405L58-R58): Updated the Slack chat URL for quick questions.

Configuration updates:
* [`.github/ISSUE_TEMPLATE/config.yml`](diffhunk://#diff-1c0d972ee49103af56fd608a77a28e1eb12f6908f263f0f183d46868fdcd8ea2L7-R7): Updated the Slack chat URL in the contact links.
* [`website/docusaurus.config-blog.js`](diffhunk://#diff-fe169a84feeee40a2247dda369b6e98096d50d5f7e6ac8f1fad29a1f254066e8L147-R147): Updated the Slack chat URL in the configuration.
* [`website/docusaurus.config.js`](diffhunk://#diff-bc4913d026ae51bef2bc8b7a1c040fdf52b999d99e6fa40d87b379f98a60e0eaL155-R155): Updated the Slack chat URL in the configuration.
* [`website/versioned_docs/version-v1.24/main.md`](diffhunk://#diff-18d1064c7984d9fdde3234fb3538d38713bfb645e7a1d2cf727395448601db19L37-R37): Updated the Slack chat URL for quick questions.