### PR TITLE
Use GitHub-hosted CI runners

### DIFF
--- a/.github/workflows/_integration.yml
+++ b/.github/workflows/_integration.yml
@@ -41,11 +41,7 @@ jobs:
   run:
     # make it short to fit in GitHub UI; all parameters are already in the caller's name
     name: Run
-
-    # https://www.ubicloud.com/docs/about/pricing#github-actions
-    # https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#per-minute-rates-for-larger-runners
-    runs-on: ubicloud-standard-4
-
+    runs-on: ubuntu-24.04
     timeout-minutes: 25
 
     steps:


### PR DESCRIPTION
# Description

For now, at least.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
