### PR TITLE
Make production builds of the `main` branch

### DIFF
--- a/tools/definedockertag/main.go
+++ b/tools/definedockertag/main.go
@@ -204,6 +204,9 @@ func defineForBranch(owner, repo, branch string) (*result, error) {
 		developmentImages: []string{
 			fmt.Sprintf("ghcr.io/%s/%s-dev:%s", owner, repo, branch),
 		},
+		productionImages: []string{
+			fmt.Sprintf("ghcr.io/%s/%s-dev:%s-prod", owner, repo, branch),
+		},
 	}
 
 	// forks don't have Quay.io and Docker Hub orgs
@@ -218,9 +221,11 @@ func defineForBranch(owner, repo, branch string) (*result, error) {
 
 	res.evaluationImages = append(res.evaluationImages, fmt.Sprintf("quay.io/ferretdb/ferretdb-eval:%s", branch))
 	res.developmentImages = append(res.developmentImages, fmt.Sprintf("quay.io/ferretdb/ferretdb-dev:%s", branch))
+	res.productionImages = append(res.productionImages, fmt.Sprintf("quay.io/ferretdb/ferretdb-dev:%s-prod", branch))
 
 	res.evaluationImages = append(res.evaluationImages, fmt.Sprintf("ferretdb/ferretdb-eval:%s", branch))
 	res.developmentImages = append(res.developmentImages, fmt.Sprintf("ferretdb/ferretdb-dev:%s", branch))
+	res.productionImages = append(res.productionImages, fmt.Sprintf("ferretdb/ferretdb-dev:%s-prod", branch))
 
 	return res, nil
 }

--- a/tools/definedockertag/main_test.go
+++ b/tools/definedockertag/main_test.go
@@ -176,6 +176,11 @@ func TestDefine(t *testing.T) {
 					"ghcr.io/ferretdb/ferretdb-dev:main",
 					"quay.io/ferretdb/ferretdb-dev:main",
 				},
+				productionImages: []string{
+					"ferretdb/ferretdb-dev:main-prod",
+					"ghcr.io/ferretdb/ferretdb-dev:main-prod",
+					"quay.io/ferretdb/ferretdb-dev:main-prod",
+				},
 			},
 		},
 		"push/main-other": {
@@ -193,6 +198,9 @@ func TestDefine(t *testing.T) {
 				},
 				developmentImages: []string{
 					"ghcr.io/otherorg/otherrepo-dev:main",
+				},
+				productionImages: []string{
+					"ghcr.io/otherorg/otherrepo-dev:main-prod",
 				},
 			},
 		},
@@ -217,6 +225,11 @@ func TestDefine(t *testing.T) {
 					"ghcr.io/ferretdb/ferretdb-dev:main-v1",
 					"quay.io/ferretdb/ferretdb-dev:main-v1",
 				},
+				productionImages: []string{
+					"ferretdb/ferretdb-dev:main-v1-prod",
+					"ghcr.io/ferretdb/ferretdb-dev:main-v1-prod",
+					"quay.io/ferretdb/ferretdb-dev:main-v1-prod",
+				},
 			},
 		},
 		"push/main-v1-other": {
@@ -234,6 +247,9 @@ func TestDefine(t *testing.T) {
 				},
 				developmentImages: []string{
 					"ghcr.io/otherorg/otherrepo-dev:main-v1",
+				},
+				productionImages: []string{
+					"ghcr.io/otherorg/otherrepo-dev:main-v1-prod",
 				},
 			},
 		},
@@ -258,6 +274,11 @@ func TestDefine(t *testing.T) {
 					"ghcr.io/ferretdb/ferretdb-dev:releases-2.1",
 					"quay.io/ferretdb/ferretdb-dev:releases-2.1",
 				},
+				productionImages: []string{
+					"ferretdb/ferretdb-dev:releases-2.1-prod",
+					"ghcr.io/ferretdb/ferretdb-dev:releases-2.1-prod",
+					"quay.io/ferretdb/ferretdb-dev:releases-2.1-prod",
+				},
 			},
 		},
 		"push/release-other": {
@@ -275,6 +296,9 @@ func TestDefine(t *testing.T) {
 				},
 				developmentImages: []string{
 					"ghcr.io/otherorg/otherrepo-dev:releases-2.1",
+				},
+				productionImages: []string{
+					"ghcr.io/otherorg/otherrepo-dev:releases-2.1-prod",
 				},
 			},
 		},
@@ -624,6 +648,11 @@ func TestDefine(t *testing.T) {
 					"ghcr.io/ferretdb/ferretdb-dev:main",
 					"quay.io/ferretdb/ferretdb-dev:main",
 				},
+				productionImages: []string{
+					"ferretdb/ferretdb-dev:main-prod",
+					"ghcr.io/ferretdb/ferretdb-dev:main-prod",
+					"quay.io/ferretdb/ferretdb-dev:main-prod",
+				},
 			},
 		},
 		"schedule-other": {
@@ -641,6 +670,9 @@ func TestDefine(t *testing.T) {
 				},
 				developmentImages: []string{
 					"ghcr.io/otherorg/otherrepo-dev:main",
+				},
+				productionImages: []string{
+					"ghcr.io/otherorg/otherrepo-dev:main-prod",
 				},
 			},
 		},
@@ -665,6 +697,11 @@ func TestDefine(t *testing.T) {
 					"ghcr.io/ferretdb/ferretdb-dev:main",
 					"quay.io/ferretdb/ferretdb-dev:main",
 				},
+				productionImages: []string{
+					"ferretdb/ferretdb-dev:main-prod",
+					"ghcr.io/ferretdb/ferretdb-dev:main-prod",
+					"quay.io/ferretdb/ferretdb-dev:main-prod",
+				},
 			},
 		},
 		"workflow_run-other": {
@@ -682,6 +719,9 @@ func TestDefine(t *testing.T) {
 				},
 				developmentImages: []string{
 					"ghcr.io/otherorg/otherrepo-dev:main",
+				},
+				productionImages: []string{
+					"ghcr.io/otherorg/otherrepo-dev:main-prod",
 				},
 			},
 		},


### PR DESCRIPTION
# Description

Development (non-release) image that tracks the `main` branch with non-development (no race detector, etc) build inside. Mainly for tracking performance per commit, not per release.

Closes FerretDB/dance#1154.

## Readiness checklist

- [x] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
