### PR TITLE
Sync flags grouping with docs

### DIFF
--- a/cmd/ferretdb/main.go
+++ b/cmd/ferretdb/main.go
@@ -58,32 +58,32 @@ import (
 //
 // Keep structure and order in sync with documentation and embeddable package.
 //
-//nolint:lll // Long struct tags need to be formatted for readability.
+//nolint:lll // for readability
 var cli struct {
 	// We hide `run` command to show only `ping` in the help message.
 	Run  struct{} `cmd:"" default:"1"                             hidden:""`
 	Ping struct{} `cmd:"" help:"Ping existing FerretDB instance."`
 
-	Version bool `default:"false" help:"Print version to stdout and exit." env:"-" group:"Miscellaneous"`
+	Version bool `default:"false" help:"Print version to stdout and exit." env:"-"`
 
 	PostgreSQLURL string `name:"postgresql-url" default:"postgres://127.0.0.1:5432/postgres" help:"PostgreSQL URL." group:"PostgreSQL"`
 
 	Listen struct {
-		Addr        string `default:"127.0.0.1:27017" help:"Listen TCP address for MongoDB protocol."             group:"Interfaces"`
-		Unix        string `default:""                help:"Listen Unix domain socket path for MongoDB protocol." group:"Interfaces"`
-		TLS         string `default:""                help:"Listen TLS address for MongoDB protocol."             group:"Interfaces"`
-		TLSCertFile string `default:""                help:"TLS cert file path."                                  group:"Interfaces"`
-		TLSKeyFile  string `default:""                help:"TLS key file path."                                   group:"Interfaces"`
-		TLSCaFile   string `default:""                help:"TLS CA file path."                                    group:"Interfaces"`
-		DataAPIAddr string `default:""                help:"Listen TCP address for HTTP Data API."                group:"Interfaces"`
-	} `embed:"" prefix:"listen-"`
+		Addr        string `default:"127.0.0.1:27017" help:"Listen TCP address for MongoDB protocol."`
+		Unix        string `default:""                help:"Listen Unix domain socket path for MongoDB protocol."`
+		TLS         string `default:""                help:"Listen TLS address for MongoDB protocol."`
+		TLSCertFile string `default:""                help:"TLS cert file path."`
+		TLSKeyFile  string `default:""                help:"TLS key file path."`
+		TLSCaFile   string `default:""                help:"TLS CA file path."`
+		DataAPIAddr string `default:""                help:"Listen TCP address for HTTP Data API."`
+	} `embed:"" prefix:"listen-" group:"Interfaces"`
 
 	Proxy struct {
-		Addr        string `default:"" help:"Proxy address."            group:"Interfaces"`
-		TLSCertFile string `default:"" help:"Proxy TLS cert file path." group:"Interfaces"`
-		TLSKeyFile  string `default:"" help:"Proxy TLS key file path."  group:"Interfaces"`
-		TLSCaFile   string `default:"" help:"Proxy TLS CA file path."   group:"Interfaces"`
-	} `embed:"" prefix:"proxy-"`
+		Addr        string `default:"" help:"Proxy address."`
+		TLSCertFile string `default:"" help:"Proxy TLS cert file path."`
+		TLSKeyFile  string `default:"" help:"Proxy TLS key file path."`
+		TLSCaFile   string `default:"" help:"Proxy TLS CA file path."`
+	} `embed:"" prefix:"proxy-" group:"Interfaces"`
 
 	DebugAddr string `default:"127.0.0.1:8088" help:"Listen address for HTTP handlers for metrics, pprof, etc." group:"Interfaces"`
 
@@ -92,10 +92,10 @@ var cli struct {
 	Auth     bool   `default:"true"            help:"Enable authentication (on by default)." group:"Miscellaneous" negatable:""`
 
 	Log struct {
-		Level  string `default:"${default_log_level}" help:"${help_log_level}"                      group:"Miscellaneous"`
-		Format string `default:"console"              help:"${help_log_format}"                     enum:"${enum_log_format}" group:"Miscellaneous"`
-		UUID   bool   `default:"false"                help:"Add instance UUID to all log messages." group:"Miscellaneous"     negatable:""`
-	} `embed:"" prefix:"log-"`
+		Level  string `default:"${default_log_level}" help:"${help_log_level}"`
+		Format string `default:"console"              help:"${help_log_format}"                     enum:"${enum_log_format}"`
+		UUID   bool   `default:"false"                help:"Add instance UUID to all log messages." negatable:""`
+	} `embed:"" prefix:"log-" group:"Miscellaneous"`
 
 	MetricsUUID bool `default:"false" help:"Add instance UUID to all metrics." group:"Miscellaneous" negatable:""`
 
@@ -108,7 +108,7 @@ var cli struct {
 	Telemetry telemetry.Flag `default:"undecided" help:"${help_telemetry}" group:"Miscellaneous"`
 
 	Dev struct {
-		ReplSetName string `default:"" help:"Replica set name."`
+		ReplSetName string `default:"" help:"Replica set name." hidden:""`
 
 		RecordsDir string `hidden:""`
 

--- a/website/docs/configuration/flags.md
+++ b/website/docs/configuration/flags.md
@@ -19,7 +19,14 @@ Some default values are overridden in [our Docker image](../installation/ferretd
 <!-- markdownlint-capture -->
 <!-- markdownlint-disable MD033 -->
 
-## PostgreSQL with DocumentDB extension
+## General
+
+| Flag           | Description                      | Environment Variable | Default Value |
+| -------------- | -------------------------------- | -------------------- | ------------- |
+| `-h`, `--help` | Show context-sensitive help      |                      |               |
+| `--version`    | Print version to stdout and exit |                      |               |
+
+## PostgreSQL
 
 | Flag               | Description               | Environment Variable      | Default Value                        |
 | ------------------ | ------------------------- | ------------------------- | ------------------------------------ |
@@ -59,8 +66,6 @@ Additionally:
 
 | Flag                  | Description                                                                                                                 | Environment Variable       | Default Value                  |
 | --------------------- | --------------------------------------------------------------------------------------------------------------------------- | -------------------------- | ------------------------------ |
-| `-h`, `--help`        | Show context-sensitive help                                                                                                 |                            |                                |
-| `--version`           | Print version to stdout and exit                                                                                            |                            |                                |
 | `--mode`              | [Operation mode](operation-modes.md)                                                                                        | `FERRETDB_MODE`            | `normal`                       |
 | `--state-dir`         | Path to the FerretDB state directory                                                                                        | `FERRETDB_STATE_DIR`       | `.`<br />(`/state` for Docker) |
 | `--[no-]auth`         | [Enable authentication](../security/authentication.md)                                                                      | `FERRETDB_AUTH`            | enabled                        |


### PR DESCRIPTION
# Description

```
Usage: ferretdb <command> [flags]

Flags:
  -h, --help       Show context-sensitive help.
      --version    Print version to stdout and exit.

PostgreSQL
  --postgresql-url="postgres://127.0.0.1:5432/postgres"    PostgreSQL URL ($FERRETDB_POSTGRESQL_URL).

Interfaces
  --listen-addr="127.0.0.1:27017"    Listen TCP address for MongoDB protocol ($FERRETDB_LISTEN_ADDR).
  --listen-unix=""                   Listen Unix domain socket path for MongoDB protocol ($FERRETDB_LISTEN_UNIX).
  --listen-tls=""                    Listen TLS address for MongoDB protocol ($FERRETDB_LISTEN_TLS).
  --listen-tls-cert-file=""          TLS cert file path ($FERRETDB_LISTEN_TLS_CERT_FILE).
  --listen-tls-key-file=""           TLS key file path ($FERRETDB_LISTEN_TLS_KEY_FILE).
  --listen-tls-ca-file=""            TLS CA file path ($FERRETDB_LISTEN_TLS_CA_FILE).
  --listen-data-api-addr=""          Listen TCP address for HTTP Data API ($FERRETDB_LISTEN_DATA_API_ADDR).
  --proxy-addr=""                    Proxy address ($FERRETDB_PROXY_ADDR).
  --proxy-tls-cert-file=""           Proxy TLS cert file path ($FERRETDB_PROXY_TLS_CERT_FILE).
  --proxy-tls-key-file=""            Proxy TLS key file path ($FERRETDB_PROXY_TLS_KEY_FILE).
  --proxy-tls-ca-file=""             Proxy TLS CA file path ($FERRETDB_PROXY_TLS_CA_FILE).
  --debug-addr="127.0.0.1:8088"      Listen address for HTTP handlers for metrics, pprof, etc ($FERRETDB_DEBUG_ADDR).

Miscellaneous
  --mode="normal"           Operation mode: 'normal', 'proxy', 'diff-normal', 'diff-proxy' ($FERRETDB_MODE).
  --state-dir="."           Process state directory ($FERRETDB_STATE_DIR).
  --[no-]auth               Enable authentication (on by default) ($FERRETDB_AUTH).
  --log-level="DEBUG"       Log level: 'DEBUG', 'INFO', 'WARN', 'ERROR' ($FERRETDB_LOG_LEVEL).
  --log-format="console"    Log format: 'console', 'text', 'json', 'mongo' ($FERRETDB_LOG_FORMAT).
  --[no-]log-uuid           Add instance UUID to all log messages ($FERRETDB_LOG_UUID).
  --[no-]metrics-uuid       Add instance UUID to all metrics ($FERRETDB_METRICS_UUID).
  --otel-traces-url=""      OpenTelemetry OTLP/HTTP traces endpoint URL (e.g. 'http://host:4318/v1/traces') ($FERRETDB_OTEL_TRACES_URL).
  --telemetry=undecided     Enable or disable basic telemetry reporting. See https://beacon.ferretdb.com ($FERRETDB_TELEMETRY).

Commands:
  ping [flags]
    Ping existing FerretDB instance.

Run "ferretdb <command> --help" for more information on a command.
```

Closes #4746.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [x] I added/updated comments and checked rendering.
- [x] I made spot refactorings.
- [x] I updated user documentation.
- [x] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
