### PR TITLE
Handle `OP_QUERY` in middleware using interface

### DIFF
--- a/internal/handler/cmd_query.go
+++ b/internal/handler/cmd_query.go
@@ -20,9 +20,9 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/FerretDB/wire"
 	"github.com/FerretDB/wire/wirebson"
 
+	"github.com/FerretDB/FerretDB/v2/internal/handler/middleware"
 	"github.com/FerretDB/FerretDB/v2/internal/mongoerrors"
 	"github.com/FerretDB/FerretDB/v2/internal/util/lazyerrors"
 	"github.com/FerretDB/FerretDB/v2/internal/util/must"
@@ -31,7 +31,7 @@ import (
 // CmdQuery implements deprecated OP_QUERY message handling.
 //
 // The passed context is canceled when the client connection is closed.
-func (h *Handler) CmdQuery(connCtx context.Context, query *wire.OpQuery) (*wire.OpReply, error) {
+func (h *Handler) CmdQuery(connCtx context.Context, query *middleware.QueryRequest) (*middleware.ReplyResponse, error) {
 	q := query.Query()
 	cmd := q.Command()
 	collection := query.FullCollectionName
@@ -39,11 +39,11 @@ func (h *Handler) CmdQuery(connCtx context.Context, query *wire.OpQuery) (*wire.
 	suffix := ".$cmd"
 	if !strings.HasSuffix(collection, suffix) {
 		// TODO https://github.com/FerretDB/FerretDB-DocumentDB/issues/527
-		return wire.NewOpReply(must.NotFail(wirebson.NewDocument(
+		return middleware.Reply(wirebson.MustDocument(
 			"$err", "OP_QUERY is no longer supported. The client driver may require an upgrade.",
 			"code", int32(mongoerrors.ErrLocation5739101),
 			"ok", float64(0),
-		)))
+		))
 	}
 
 	if query.NumberToReturn != 1 && query.NumberToReturn != -1 {
@@ -61,7 +61,7 @@ func (h *Handler) CmdQuery(connCtx context.Context, query *wire.OpQuery) (*wire.
 			return nil, lazyerrors.Error(err)
 		}
 
-		return wire.NewOpReply(reply)
+		return middleware.Reply(reply)
 
 	case "saslStart":
 		if slices.Contains(q.FieldNames(), "$db") {
@@ -79,7 +79,7 @@ func (h *Handler) CmdQuery(connCtx context.Context, query *wire.OpQuery) (*wire.
 
 		must.NoError(reply.Add("ok", float64(1)))
 
-		return wire.NewOpReply(reply)
+		return middleware.Reply(reply)
 
 	case "saslContinue":
 		if slices.Contains(q.FieldNames(), "$db") {
@@ -95,7 +95,7 @@ func (h *Handler) CmdQuery(connCtx context.Context, query *wire.OpQuery) (*wire.
 			return nil, err
 		}
 
-		return wire.NewOpReply(reply)
+		return middleware.Reply(reply)
 	}
 
 	return nil, mongoerrors.NewWithArgument(

--- a/internal/handler/commands.go
+++ b/internal/handler/commands.go
@@ -317,12 +317,16 @@ func (h *Handler) initCommands() {
 
 	h.commands = make(map[string]*command, len(commands))
 
+	o := &middleware.Observability{
+		L: logging.WithName(h.L, "observability"),
+	}
+
 	for name, cmd := range commands {
 		if cmd.Handler == nil {
 			cmd.Handler = notImplemented(name)
 		}
 
-		cmd.Handler = middleware.Observability(cmd.Handler, logging.WithName(h.L, "observability"))
+		cmd.Handler = o.HandleOpMsg(cmd.Handler)
 
 		if h.Auth && !cmd.anonymous {
 			cmd.Handler = middleware.Auth(cmd.Handler, logging.WithName(h.L, "auth"), name)

--- a/internal/handler/middleware/middleware.go
+++ b/internal/handler/middleware/middleware.go
@@ -35,6 +35,23 @@ type MsgResponse struct {
 	*wire.OpMsg
 }
 
+// QueryRequest is a deprecated request message type.
+// It is still used by commands including `hello` and `isMaster`.
+type QueryRequest struct {
+	*wire.OpQuery
+}
+
+// ReplyResponse is a deprecated response message type used for the response to [QueryRequest].
+type ReplyResponse struct {
+	*wire.OpReply
+}
+
+// Middleware represents functions for handling incoming requests.
+type Middleware interface {
+	HandleOpMsg(next MsgHandlerFunc) MsgHandlerFunc
+	HandleOpReply(next QueryHandlerFunc) QueryHandlerFunc
+}
+
 // Response constructs a [*MsgResponse] from a single document.
 func Response(doc wirebson.AnyDocument) (*MsgResponse, error) {
 	msg, err := wire.NewOpMsg(doc)
@@ -45,7 +62,22 @@ func Response(doc wirebson.AnyDocument) (*MsgResponse, error) {
 	return &MsgResponse{OpMsg: msg}, nil
 }
 
+// Reply constructs a [*ReplyResponse] from a single document.
+func Reply(doc wirebson.AnyDocument) (*ReplyResponse, error) {
+	reply, err := wire.NewOpReply(doc)
+	if err != nil {
+		return nil, lazyerrors.Error(err)
+	}
+
+	return &ReplyResponse{OpReply: reply}, nil
+}
+
 // MsgHandlerFunc represents a function/method that processes a single OP_MSG command.
 //
 // The passed context is canceled when the client disconnects.
 type MsgHandlerFunc func(ctx context.Context, req *MsgRequest) (resp *MsgResponse, err error)
+
+// QueryHandlerFunc represents a function/method that processes a single OP_QUERY command.
+//
+// The passed context is canceled when the client disconnects.
+type QueryHandlerFunc func(ctx context.Context, req *QueryRequest) (resp *ReplyResponse, err error)

--- a/internal/handler/middleware/observability.go
+++ b/internal/handler/middleware/observability.go
@@ -14,16 +14,28 @@
 
 package middleware
 
-import (
-	"context"
-	"log/slog"
-)
+import "log/slog"
 
 // Observability is a middleware that will wrap the command handler with logs, traces, and metrics.
 //
 // TODO https://github.com/FerretDB/FerretDB/issues/4439
-func Observability(next MsgHandlerFunc, l *slog.Logger) MsgHandlerFunc {
-	return func(ctx context.Context, req *MsgRequest) (*MsgResponse, error) {
-		return next(ctx, req)
-	}
+type Observability struct {
+	L *slog.Logger
 }
+
+// HandleOpMsg represents a function/method that processes a single OP_MSG command.
+//
+// The passed context is canceled when the client disconnects.
+func (o *Observability) HandleOpMsg(next MsgHandlerFunc) MsgHandlerFunc {
+	return next
+}
+
+// HandleOpReply represents a function/method that processes a single OP_QUERY command.
+//
+// The passed context is canceled when the client disconnects.
+func (o *Observability) HandleOpReply(next QueryHandlerFunc) QueryHandlerFunc {
+	return next
+}
+
+// check interface.
+var _ Middleware = (*Observability)(nil)

--- a/internal/handler/middleware/observability.go
+++ b/internal/handler/middleware/observability.go
@@ -23,16 +23,12 @@ type Observability struct {
 	L *slog.Logger
 }
 
-// HandleOpMsg represents a function/method that processes a single OP_MSG command.
-//
-// The passed context is canceled when the client disconnects.
+// HandleOpMsg implements Middleware.
 func (o *Observability) HandleOpMsg(next MsgHandlerFunc) MsgHandlerFunc {
 	return next
 }
 
-// HandleOpReply represents a function/method that processes a single OP_QUERY command.
-//
-// The passed context is canceled when the client disconnects.
+// HandleOpReply implements Middleware.
 func (o *Observability) HandleOpReply(next QueryHandlerFunc) QueryHandlerFunc {
 	return next
 }


### PR DESCRIPTION
# Description

Closes #1997.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [x] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
