### PR TITLE
Backport documentation changes to v2.0

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -36,6 +36,7 @@ const config = {
           { to: "/migration/diff", from: "/diff" },
           { to: "/reference", from: ["/reference/supported_commands", "/reference/supported-commands"] },
           { to: "/installation", from: "/quickstart" },
+          { to: "/guides/full-text-search", from: "/guides/text-search" },
         ],
 
         createRedirects(existingPath) {

--- a/website/versioned_docs/version-v2.0/configuration/observability.md
+++ b/website/versioned_docs/version-v2.0/configuration/observability.md
@@ -18,7 +18,7 @@ Structured log format is not stable yet; field names and formatting of values mi
 
 FerretDB provides the following log formats:
 
-- `console` is a human-readable format with optional colors.
+- `console` is a human-readable format.
 - `text` is machine-readable [logfmt](https://brandur.org/logfmt)-like format
   (powered by [Go's `slog.TextHandler`](https://pkg.go.dev/log/slog#TextHandler)).
 - `json` is machine-readable JSON format
@@ -28,6 +28,8 @@ FerretDB provides the following log formats:
   Fields required in the output format but not yet implemented, will not be included.
 
 There are four logging levels:
+
+<!-- https://github.com/FerretDB/FerretDB/issues/4439 -->
 
 - `error` is used for errors that can't be handled gracefully
   and typically result in client connection being closed;

--- a/website/versioned_docs/version-v2.0/installation/documentdb/deb.md
+++ b/website/versioned_docs/version-v2.0/installation/documentdb/deb.md
@@ -6,11 +6,13 @@ sidebar_position: 2
 
 FerretDB uses PostgreSQL with [DocumentDB extension](https://github.com/microsoft/documentdb) as a database engine.
 
-Download the DocumentDB `.deb` package from [our release page](https://github.com/FerretDB/documentdb/releases/),
-you can use `dpkg` tool to install it.
+We provide different DocumentDB `.deb` packages for various deployments on our [release page](https://github.com/FerretDB/documentdb/releases/).
 
-:::tip
-For more information on the best FerretDB version to use, see the [DocumentDB release notes](https://github.com/FerretDB/documentdb/releases/).
-:::
+- For most use cases, we recommend using the production package (e.g., `documentdb.deb`).
+- For debugging purposes, use the development package (contains either `-dev` or `-dbgsym` suffix e.g., `documentdb-dev.deb`/`documentdb-dbgsym.deb`).
+  It includes features that significantly slow down performance and is not recommended for production use.
+
+Download the appropriate DocumentDB `.deb` package from our release page.
+Then, you can use `dpkg` tool to install it.
 
 You need to install PostgreSQL and additional dependencies required by the DocumentDB extension.

--- a/website/versioned_docs/version-v2.0/installation/documentdb/docker.md
+++ b/website/versioned_docs/version-v2.0/installation/documentdb/docker.md
@@ -8,8 +8,8 @@ FerretDB uses PostgreSQL with [DocumentDB extension](https://github.com/microsof
 
 We provide two Docker images for setting up PostgreSQL with DocumentDB extension:
 
-- **a development image**: for debugging problems
-- **a production image**: for all other cases
+- Production image for stable and optimized deployments.
+- Development image for debugging problems.
 
 ## Production image for PostgreSQL with DocumentDB extension
 

--- a/website/versioned_docs/version-v2.0/installation/evaluation.md
+++ b/website/versioned_docs/version-v2.0/installation/evaluation.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Evaluation
 
-We provide an **evaluation** image
+We provide an evaluation image
 [`ghcr.io/ferretdb/ferretdb-eval:2`](https://ghcr.io/ferretdb/ferretdb-eval:2)
 for quick testing and experiments.
 

--- a/website/versioned_docs/version-v2.0/installation/ferretdb/deb.md
+++ b/website/versioned_docs/version-v2.0/installation/ferretdb/deb.md
@@ -7,7 +7,13 @@ sidebar_position: 2
 To install the `.deb` packages for FerretDB on your Debian, Ubuntu, and other `.deb`-based systems,
 you can use `dpkg` tool.
 
-Download the FerretDB `.deb` package from [our release pages](https://github.com/FerretDB/FerretDB/releases/),
+We provide different `.deb` packages for various deployments on [our release page](https://github.com/FerretDB/FerretDB/releases/).
+
+- For most use cases, we recommend using the production package (e.g., `ferretdb.deb`).
+- For debugging purposes, use the development package (contains a `-dev` suffix e.g., `ferretdb-dev.deb`).
+  It includes features that significantly slow down performance and is not recommended for production use.
+
+Download the appropriate FerretDB `.deb` package from our release page,
 rename it to `ferretdb.deb`,
 then run the following command in your terminal:
 
@@ -15,7 +21,7 @@ then run the following command in your terminal:
 sudo dpkg -i ferretdb.deb
 ```
 
-You can check that FerretDB was installed by running
+You can check that FerretDB was installed by running:
 
 ```sh
 ferretdb --version

--- a/website/versioned_docs/version-v2.0/installation/ferretdb/docker.md
+++ b/website/versioned_docs/version-v2.0/installation/ferretdb/docker.md
@@ -7,11 +7,11 @@ description: How to set up FerretDB using Docker
 
 We provide three Docker images for various deployments:
 
-- **an evaluation image**: for quick testing and experiments
-- **a development image**: for debugging problems
-- **a production image**: for all other cases
+- Evaluation image for quick testing and experiments.
+- Production image for stable and optimized deployments.
+- Development image for debugging problems.
 
-An evaluation image is documented [separately](../evaluation.md).
+The evaluation image is documented [separately](../evaluation.md).
 The rest are covered below.
 
 All Docker images include a [`HEALTHCHECK` instruction](https://docs.docker.com/reference/dockerfile/#healthcheck)

--- a/website/versioned_docs/version-v2.0/installation/ferretdb/rpm.md
+++ b/website/versioned_docs/version-v2.0/installation/ferretdb/rpm.md
@@ -7,7 +7,13 @@ sidebar_position: 3
 To install the `.rpm` packages for FerretDB on your RHEL, CentOS, and other `.rpm`-based systems,
 you can use `rpm` tool.
 
-Download the latest FerretDB `.rpm` package from [our release pages](https://github.com/FerretDB/FerretDB/releases/latest),
+We provide different `.rpm` packages for various deployments on [our release page](https://github.com/FerretDB/FerretDB/releases/).
+
+- For most use cases, we recommend using the production package (e.g., `ferretdb.rpm`).
+- For debugging purposes, use the development package (contains a `-dev` suffix e.g., `ferretdb-dev.rpm`).
+  It includes features that significantly slow down performance and is not recommended for production use.
+
+Download the appropriate FerretDB `.rpm` package from our release page,
 rename it to `ferretdb.rpm`,
 then run the following command in your terminal:
 


### PR DESCRIPTION
# Description

All that applies to 2.0.0, too.
Future PRs should do that themselves.

Closes #4921.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [x] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
