### PR TITLE
Fix docker health check on evaluation image

### DIFF
--- a/build/ferretdb/eval-dev.Dockerfile
+++ b/build/ferretdb/eval-dev.Dockerfile
@@ -122,7 +122,7 @@ COPY --from=eval-dev-build /src/build/ferretdb/evaluation/entrypoint.sh /usr/loc
 ENTRYPOINT ["entrypoint.sh"]
 
 HEALTHCHECK --interval=1m --timeout=5s --retries=1 --start-period=30s --start-interval=5s \
-  CMD ["/ferretdb", "ping"]
+  CMD ["/usr/local/bin/ferretdb", "ping"]
 
 EXPOSE 27017 27018 8088
 

--- a/build/ferretdb/evaluation/entrypoint.sh
+++ b/build/ferretdb/evaluation/entrypoint.sh
@@ -12,6 +12,10 @@ if [ "${POSTGRES_DB:-postgres}" != "postgres" ]; then
     exit 1
 fi
 
+# explicitly set POSTGRES_DB, because if POSTGRES_DB is unset it uses POSTGRES_USER value
+# see https://hub.docker.com/_/postgres
+export POSTGRES_DB="postgres"
+
 export FERRETDB_POSTGRESQL_URL="postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@127.0.0.1:5432/postgres"
 
 exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/build/ferretdb/evaluation/entrypoint.sh
+++ b/build/ferretdb/evaluation/entrypoint.sh
@@ -12,10 +12,10 @@ if [ "${POSTGRES_DB:-postgres}" != "postgres" ]; then
     exit 1
 fi
 
-# explicitly set POSTGRES_DB, because if POSTGRES_DB is unset it uses POSTGRES_USER value
+# prevent unset POSTGRES_DB using the value of POSTGRES_USER,
 # see https://hub.docker.com/_/postgres
 export POSTGRES_DB="postgres"
 
-export FERRETDB_POSTGRESQL_URL="postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@127.0.0.1:5432/postgres"
+export FERRETDB_POSTGRESQL_URL="postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@127.0.0.1:5432/${POSTGRES_DB}"
 
 exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
# Description

Also always set `POSTGRES_DB` to `postgres`

Closes #4976.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
