### PR TITLE
Systemd unit hardening

### DIFF
--- a/build/ferretdb.service
+++ b/build/ferretdb.service
@@ -21,7 +21,8 @@ Restart=on-failure
 
 # Configure the FerretDB service with `systemctl edit ferretdb`.
 # For more configuration options check https://docs.ferretdb.io/configuration/flags/
-
+# Warning! Don't put your postgres password in this file.
+# Use FERRETDB_POSTGRESQL_URL_FILE to point to another file with chmod 600
 Environment=FERRETDB_POSTGRESQL_URL=postgres://127.0.0.1:5432/postgres \
             FERRETDB_STATE_DIR=%S/ferretdb \
             FERRETDB_LISTEN_UNIX=%t/ferretdb/ferretdb.sock \

--- a/build/ferretdb.service
+++ b/build/ferretdb.service
@@ -5,13 +5,26 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
+User=ferretdb
+Group=ferretdb
+RemoveIPC=true
+PrivateTmp=disconnected
+NoNewPrivileges=true
+RestrictSUIDSGID=true
+ProtectSystem=strict
+ProtectHome=read-only
+ProtectProc=invisible
+RuntimeDirectory=ferretdb
+StateDirectory=ferretdb
 ExecStart=/usr/bin/ferretdb
 Restart=on-failure
 
 # Configure the FerretDB service with `systemctl edit ferretdb`.
 # For more configuration options check https://docs.ferretdb.io/configuration/flags/
 
-Environment="FERRETDB_POSTGRESQL_URL=postgres://127.0.0.1:5432/postgres"
+Environment=FERRETDB_POSTGRESQL_URL=postgres://127.0.0.1:5432/postgres \
+            FERRETDB_STATE_DIR=%S/ferretdb \
+            FERRETDB_LISTEN_UNIX=%t/ferretdb/ferretdb.sock \
 
 [Install]
 WantedBy=multi-user.target

--- a/build/nfpm.yml
+++ b/build/nfpm.yml
@@ -16,6 +16,9 @@ license: Apache License 2.0
 suggests:
   - postgresql
 
+scripts:
+  preinstall: build/preinstall.sh
+
 contents:
   - src: tmp/build/linux_${DIR_ARCH}/ferretdb
     dst: /usr/bin/ferretdb

--- a/build/preinstall.sh
+++ b/build/preinstall.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+adduser --system --no-create-home --group --disabled-password --quiet ferretd

--- a/website/docs/installation/ferretdb/systemd.md
+++ b/website/docs/installation/ferretdb/systemd.md
@@ -12,30 +12,18 @@ If you encounter any problem, please [join our community](/#community) to report
 With both DEB and RPM package we ship the systemd unit, to start FerretDB automatically.
 If FerretDB is not installed yet, please refer to the [`.deb`](deb.md) or [`.rpm`](rpm.md) installation pages.
 
-The unit file provides some basic environment variables as an example.
-They should be overwritten with the proper [configuration](../../configuration/flags.md).
-
-```systemd
-[Service]
-ExecStart=/usr/bin/ferretdb
-Restart=on-failure
-
-# Configure the FerretDB service with `systemctl edit ferretdb`.
-# For more configuration options check https://docs.ferretdb.io/configuration/flags/
-
-Environment="FERRETDB_POSTGRESQL_URL=postgres://127.0.0.1:5432/postgres"
-```
-
-You can modify them by using `systemctl edit ferretdb` command.
+The unit file connects to a local postgresql server by default.
+You can overwrite the [configuration](../../configuration/flags.md)
+by using the `systemctl edit ferretdb` command.
 This'll open a text editor that'll allow you to override the systemd options of choice.
-For example, if we want to listen on the Unix domain socket, we could write something like:
+For example, you can reference an external file for your postgres URl and password:
 
 ```systemd
 ### Editing /etc/systemd/system/ferretdb.service.d/override.conf
 ### Anything between here and the comment below will become the new contents of the file
 
 [Service]
-Environment="FERRETDB_LISTEN_UNIX=/var/lib/ferretdb/ferretdb.sock"
+Environment="FERRETDB_POSTGRESQL_URL_FILE=/etc/my_protected_ferretdb_url"
 
 ### Lines below this comment will be discarded
 ...


### PR DESCRIPTION
# Description
Standard systemd service hardening:
- don't run as root
- use sandboxing to isolate the ferretdb process

Since ferretdb is primarily developed for container images, it works really well with all systemd sandbox options turned on. I considered using systemd dynamic users instead of creating one, but having a static system user makes it easier to integrate with postgresql when using "peer" auth.

The sandboxing restricts the state and runtime directories, so I added environment variables to point at the right locations. This turns on unix socket by default, but most users of the deb/rpm package will want it anyway, and this mirrors postgresql's defaults in ubuntu and Red Hat.

I updated the docs with an example that shows users the proper way to protect their postgres password (it shouldn't go in the systemd unit file because it's probably world readable)

## Readiness checklist

<!-- Please check all items in this checklist that were done. -->

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [x] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [ ] I marked all done items in this checklist.
