### PR TITLE
Make `conninfo` a resource

### DIFF
--- a/internal/clientconn/conn.go
+++ b/internal/clientconn/conn.go
@@ -146,6 +146,9 @@ func (c *conn) run(ctx context.Context) (err error) {
 	}()
 
 	connInfo := conninfo.New()
+
+	defer connInfo.Close()
+
 	if c.netConn.RemoteAddr().Network() != "unix" {
 		connInfo.Peer, err = netip.ParseAddrPort(c.netConn.RemoteAddr().String())
 		if err != nil {

--- a/internal/clientconn/conninfo/conninfo.go
+++ b/internal/clientconn/conninfo/conninfo.go
@@ -47,7 +47,7 @@ func New() *ConnInfo {
 	return res
 }
 
-// Close closes ConnInfo and untracks it.
+// Close untracks ConnInfo.
 func (ci *ConnInfo) Close() {
 	resource.Untrack(ci, ci.token)
 }

--- a/internal/clientconn/conninfo/conninfo.go
+++ b/internal/clientconn/conninfo/conninfo.go
@@ -19,6 +19,7 @@ import (
 	"net/netip"
 	"sync"
 
+	"github.com/FerretDB/FerretDB/v2/internal/util/resource"
 	"github.com/FerretDB/FerretDB/v2/internal/util/scram"
 )
 
@@ -31,11 +32,24 @@ type ConnInfo struct {
 	rw           sync.RWMutex   // rw
 	metadataRecv bool           // protected by rw
 	steps        int            // protected by rw
+
+	token *resource.Token
 }
 
 // New creates a new ConnInfo.
 func New() *ConnInfo {
-	return new(ConnInfo)
+	res := &ConnInfo{
+		token: resource.NewToken(),
+	}
+
+	resource.Track(res, res.token)
+
+	return res
+}
+
+// Close closes ConnInfo and untracks it.
+func (ci *ConnInfo) Close() {
+	resource.Untrack(ci, ci.token)
 }
 
 // Conv returns SCRAM conversation.

--- a/internal/dataapi/listener.go
+++ b/internal/dataapi/listener.go
@@ -24,7 +24,6 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/FerretDB/FerretDB/v2/internal/clientconn/conninfo"
 	"github.com/FerretDB/FerretDB/v2/internal/dataapi/api"
 	"github.com/FerretDB/FerretDB/v2/internal/dataapi/server"
 	"github.com/FerretDB/FerretDB/v2/internal/handler"
@@ -71,10 +70,10 @@ func (lis *Listener) Run(ctx context.Context) {
 	}
 
 	srv := &http.Server{
-		Handler:  srvHandler,
+		Handler:  lis.srv.ConnInfoMiddleware(srvHandler),
 		ErrorLog: slog.NewLogLogger(lis.opts.L.Handler(), slog.LevelError),
 		BaseContext: func(net.Listener) context.Context {
-			return conninfo.Ctx(ctx, conninfo.New())
+			return ctx
 		},
 	}
 


### PR DESCRIPTION
# Description

Closes #5048.

Manually tested, checking no panic is raised for tracked resources.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
