### PR TITLE
Disable Markdownlint rule that clashes with MDX

### DIFF
--- a/build/.markdownlint.yml
+++ b/build/.markdownlint.yml
@@ -11,5 +11,7 @@ MD006: false # deprecated
 MD013: false # we use https://sembr.org that could lead to long lines
 MD026: { punctuation: ".,;:。，；：" } # default is .,;:!。，；：！
 MD029: { style: ordered }
+MD033: false # for MDX
 MD034: false # autolink tags <link> no longer supported by MDX
 MD037: false # clashes with MDX comments
+MD059: false # not yet

--- a/website/blog/2022-11-14-mongodb-crud-operations-with-ferretdb.mdx
+++ b/website/blog/2022-11-14-mongodb-crud-operations-with-ferretdb.mdx
@@ -28,8 +28,6 @@ They allow users to easily interact with the database to create, sort, filter, m
 
 For users looking for an open-source MongoDB alternative, FerretDB offers you a direct replacement where you can still use all your favorite MongoDB CRUD methods and commands, without having to learn entirely new commands.
 
-<!-- markdownlint-disable MD033 -->
-
 ### How to set up FerretDB database
 
 To set up FerretDB locally, you can install it using [Docker](https://www.docker.com/) or the .deb and .rpm packages available for each [release](https://github.com/FerretDB/FerretDB/releases).
@@ -369,8 +367,6 @@ template="/blog/2022-11-14/delete-1.tpl"
 init-delay="500"
 
 > </codapi-snippet>
-
-<!-- markdownlint-enable MD033 -->
 
 ## Get started with FerretDB
 

--- a/website/blog/2023-10-31-mongodb-sorting-scalar.md
+++ b/website/blog/2023-10-31-mongodb-sorting-scalar.md
@@ -27,9 +27,6 @@ However, if the BSON types are different, a predefined BSON comparison order is 
 
 The table below shows the predefined BSON comparison order for each BSON type.
 
-<!-- use newline in column header for appropriate spacing of columns -->
-<!-- markdownlint-disable MD033 -->
-
 | Order of Comparison<br/>(lowest to highest) | BSON Types                               |
 | ------------------------------------------- | ---------------------------------------- |
 | 1                                           | Null                                     |

--- a/website/docs/configuration/flags.md
+++ b/website/docs/configuration/flags.md
@@ -15,10 +15,6 @@ Some default values are overridden in [our Docker image](../installation/ferretd
 
 <!-- Keep order in sync with the `--help` output -->
 
-<!-- For <br /> -->
-<!-- markdownlint-capture -->
-<!-- markdownlint-disable MD033 -->
-
 ## General
 
 | Flag           | Description                      | Environment Variable | Default Value |
@@ -77,5 +73,3 @@ Additionally:
 | `--telemetry`         | Enable or disable [basic telemetry](telemetry.md)                                                                           | `FERRETDB_TELEMETRY`       | `undecided`                    |
 
 <!-- Do not document `--dev-XXX` flags -->
-
-<!-- markdownlint-restore -->

--- a/website/docs/guides/full-text-search.mdx
+++ b/website/docs/guides/full-text-search.mdx
@@ -52,8 +52,6 @@ Single full-text index is created on a single field in a collection.
 
 To create a text index, use the `createIndex` command with the field you want to index and the type set to `'text'`.
 
-<!-- markdownlint-disable MD033 -->
-
 <CodeBlock language="js">{CreateTextIndexRequest}</CodeBlock>
 
 This command creates a full-text index on the `summary` field in a `books` collection.
@@ -96,5 +94,3 @@ Let's search for books that contain the words "hunt whales" in the `summary` fie
 Even though the query does not have exact matches, the search returns documents that contain similar words.
 
 <CodeBlock language="js">{RelevanceScoreResponse}</CodeBlock>
-
-<!-- markdownlint-enable MD033 -->

--- a/website/docs/guides/ttl-indexes.mdx
+++ b/website/docs/guides/ttl-indexes.mdx
@@ -30,8 +30,6 @@ The field must have a `Date` type.
 
 For example, let's create a TTL index for the `reservation.date` field in a `books` collection.
 
-<!-- markdownlint-disable MD033 -->
-
 <CodeBlock language="js">{CreateTTLIndexRequest}</CodeBlock>
 
 Let's insert a document into the `books` collection:
@@ -39,5 +37,3 @@ Let's insert a document into the `books` collection:
 <CodeBlock language="js">{InsertTTLDataRequest}</CodeBlock>
 
 After 60 seconds, the document will be deleted in the next cleanup operation.
-
-<!-- markdownlint-enable MD033 -->

--- a/website/docs/guides/vector-search.mdx
+++ b/website/docs/guides/vector-search.mdx
@@ -33,8 +33,6 @@ FerretDB supports the following vector index kinds:
 - **Hierarchical Navigable Small World (HNSW)**: HNSW is a graph-based index that uses a hierarchical structure to store vectors, suitable for high-speed vector search in memory.
 - **Inverted File (IVF)**: IVF is an inverted file index that partitions the vector space (data sets) into clusters (inverted lists) and performs approximate nearest neighbor search within selected clusters.
 
-<!-- markdownlint-disable MD033 -->
-
 ## Creating an index
 
 Vector index can be created using the usual `createIndexes` command with the following syntax:
@@ -180,5 +178,3 @@ The query returns the two nearest neighbors of the query vector.
 </TabItem>
 
 </Tabs>
-
-<!-- markdownlint-enable MD033 -->

--- a/website/versioned_docs/version-v1.24/configuration/flags.md
+++ b/website/versioned_docs/version-v1.24/configuration/flags.md
@@ -15,10 +15,6 @@ Some default values are overridden in [our Docker image](../quickstart-guide/doc
 
 <!-- Keep order in sync with the `--help` output -->
 
-<!-- For <br /> -->
-<!-- markdownlint-capture -->
-<!-- markdownlint-disable MD033 -->
-
 ## General
 
 | Flag              | Description                                                       | Environment Variable     | Default Value                  |
@@ -117,5 +113,3 @@ For example: `file:./?mode=memory`.
 | `--telemetry`            | Enable or disable [basic telemetry](telemetry.md)                               | `FERRETDB_TELEMETRY`            | `undecided`      |
 
 <!-- Do not document `--test-XXX` flags here -->
-
-<!-- markdownlint-restore -->

--- a/website/versioned_docs/version-v1.24/pushdown.md
+++ b/website/versioned_docs/version-v1.24/pushdown.md
@@ -32,7 +32,7 @@ the table will be updated frequently.
 :::
 
 <!-- markdownlint-capture -->
-<!-- markdownlint-disable MD001 MD033 MD051 -->
+<!-- markdownlint-disable MD001 MD051 -->
 
 |        | Object | Array | Double                  | String | Binary | ObjectID | Boolean | Date | Null | Regex | Integer | Timestamp | Long                    |
 | ------ | ------ | ----- | ----------------------- | ------ | ------ | -------- | ------- | ---- | ---- | ----- | ------- | --------- | ----------------------- |

--- a/website/versioned_docs/version-v2.1/configuration/flags.md
+++ b/website/versioned_docs/version-v2.1/configuration/flags.md
@@ -15,10 +15,6 @@ Some default values are overridden in [our Docker image](../installation/ferretd
 
 <!-- Keep order in sync with the `--help` output -->
 
-<!-- For <br /> -->
-<!-- markdownlint-capture -->
-<!-- markdownlint-disable MD033 -->
-
 ## General
 
 | Flag           | Description                      | Environment Variable | Default Value |
@@ -77,5 +73,3 @@ Additionally:
 | `--telemetry`         | Enable or disable [basic telemetry](telemetry.md)                                                                           | `FERRETDB_TELEMETRY`       | `undecided`                    |
 
 <!-- Do not document `--dev-XXX` flags -->
-
-<!-- markdownlint-restore -->

--- a/website/versioned_docs/version-v2.1/guides/full-text-search.mdx
+++ b/website/versioned_docs/version-v2.1/guides/full-text-search.mdx
@@ -51,8 +51,6 @@ Single full-text index is created on a single field in a collection.
 
 To create a text index, use the `createIndex` command with the field you want to index and the type set to `'text'`.
 
-<!-- markdownlint-disable MD033 -->
-
 <CodeBlock language="js">{CreateIndex}</CodeBlock>
 
 This command creates a full-text index on the `summary` field in a `books` collection.
@@ -93,5 +91,3 @@ Let's search for books that contain the words "hunt whales" in the `summary` fie
 Even though the query does not have exact matches, the search returns documents that contain similar words.
 
 <CodeBlock language="js">{RelevanceScoreResponse}</CodeBlock>
-
-<!-- markdownlint-enable MD033 -->

--- a/website/versioned_docs/version-v2.1/guides/ttl-indexes.mdx
+++ b/website/versioned_docs/version-v2.1/guides/ttl-indexes.mdx
@@ -30,8 +30,6 @@ The field must have a `Date` type.
 
 For example, let's create a TTL index for the `reservation.date` field in a `books` collection.
 
-<!-- markdownlint-disable MD033 -->
-
 <CodeBlock language="js">{CreateIndex}</CodeBlock>
 
 Let's insert a document into the `books` collection:
@@ -39,5 +37,3 @@ Let's insert a document into the `books` collection:
 <CodeBlock language="js">{InsertTTLData}</CodeBlock>
 
 After 60 seconds, the document will be deleted in the next cleanup operation.
-
-<!-- markdownlint-enable MD033 -->

--- a/website/versioned_docs/version-v2.1/guides/vector-search.mdx
+++ b/website/versioned_docs/version-v2.1/guides/vector-search.mdx
@@ -35,8 +35,6 @@ FerretDB supports the following vector index kinds:
 - **Hierarchical Navigable Small World (HNSW)**: HNSW is a graph-based index that uses a hierarchical structure to store vectors, suitable for high-speed vector search in memory.
 - **Inverted File (IVF)**: IVF is an inverted file index that partitions the vector space (data sets) into clusters (inverted lists) and performs approximate nearest neighbor search within selected clusters.
 
-<!-- markdownlint-disable MD033 -->
-
 ## Creating an index
 
 Vector index can be created using the usual `createIndexes` command with the following syntax:
@@ -138,5 +136,3 @@ The query returns the two nearest neighbors of the query vector.
 </TabItem>
 
 </Tabs>
-
-<!-- markdownlint-enable MD033 -->

--- a/website/versioned_docs/version-v2.2/configuration/flags.md
+++ b/website/versioned_docs/version-v2.2/configuration/flags.md
@@ -15,10 +15,6 @@ Some default values are overridden in [our Docker image](../installation/ferretd
 
 <!-- Keep order in sync with the `--help` output -->
 
-<!-- For <br /> -->
-<!-- markdownlint-capture -->
-<!-- markdownlint-disable MD033 -->
-
 ## General
 
 | Flag           | Description                      | Environment Variable | Default Value |
@@ -77,5 +73,3 @@ Additionally:
 | `--telemetry`         | Enable or disable [basic telemetry](telemetry.md)                                                                           | `FERRETDB_TELEMETRY`       | `undecided`                    |
 
 <!-- Do not document `--dev-XXX` flags -->
-
-<!-- markdownlint-restore -->

--- a/website/versioned_docs/version-v2.2/guides/full-text-search.mdx
+++ b/website/versioned_docs/version-v2.2/guides/full-text-search.mdx
@@ -51,8 +51,6 @@ Single full-text index is created on a single field in a collection.
 
 To create a text index, use the `createIndex` command with the field you want to index and the type set to `'text'`.
 
-<!-- markdownlint-disable MD033 -->
-
 <CodeBlock language="js">{CreateTextIndexRequest}</CodeBlock>
 
 This command creates a full-text index on the `summary` field in a `books` collection.
@@ -97,5 +95,3 @@ Let's search for books that contain the words "hunt whales" in the `summary` fie
 Even though the query does not have exact matches, the search returns documents that contain similar words.
 
 <CodeBlock language="js">{RelevanceScoreResponse}</CodeBlock>
-
-<!-- markdownlint-enable MD033 -->

--- a/website/versioned_docs/version-v2.2/guides/ttl-indexes.mdx
+++ b/website/versioned_docs/version-v2.2/guides/ttl-indexes.mdx
@@ -30,8 +30,6 @@ The field must have a `Date` type.
 
 For example, let's create a TTL index for the `reservation.date` field in a `books` collection.
 
-<!-- markdownlint-disable MD033 -->
-
 <CodeBlock language="js">{CreateTTLIndexRequest}</CodeBlock>
 
 Let's insert a document into the `books` collection:
@@ -39,5 +37,3 @@ Let's insert a document into the `books` collection:
 <CodeBlock language="js">{InsertTTLDataRequest}</CodeBlock>
 
 After 60 seconds, the document will be deleted in the next cleanup operation.
-
-<!-- markdownlint-enable MD033 -->

--- a/website/versioned_docs/version-v2.2/guides/vector-search.mdx
+++ b/website/versioned_docs/version-v2.2/guides/vector-search.mdx
@@ -32,8 +32,6 @@ FerretDB supports the following vector index kinds:
 - **Hierarchical Navigable Small World (HNSW)**: HNSW is a graph-based index that uses a hierarchical structure to store vectors, suitable for high-speed vector search in memory.
 - **Inverted File (IVF)**: IVF is an inverted file index that partitions the vector space (data sets) into clusters (inverted lists) and performs approximate nearest neighbor search within selected clusters.
 
-<!-- markdownlint-disable MD033 -->
-
 ## Creating an index
 
 Vector index can be created using the usual `createIndexes` command with the following syntax:
@@ -181,5 +179,3 @@ The query returns the two nearest neighbors of the query vector.
 </TabItem>
 
 </Tabs>
-
-<!-- markdownlint-enable MD033 -->


### PR DESCRIPTION
# Description

Markdownlint does not really support MDX, and all MDX components are treated as HTML. On the other hand, `<!--` HTML comments syntax is invalid in MDX v2/v3.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [x] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
