### PR TITLE
Fix flaky integration test

### DIFF
--- a/integration/auth/drop_user_test.go
+++ b/integration/auth/drop_user_test.go
@@ -33,10 +33,10 @@ func TestDropUserCommand(t *testing.T) {
 	ctx, db := s.Ctx, s.Collection.Database()
 
 	// TODO https://github.com/FerretDB/FerretDB-DocumentDB/issues/864
-	_ = db.RunCommand(ctx, bson.D{{"dropUser", "a_user"}})
+	_ = db.RunCommand(ctx, bson.D{{"dropUser", "drop_a_user"}})
 
 	errcmd := db.RunCommand(ctx, bson.D{ // avoid data race with and shadowing of err in parallel subtests below
-		{"createUser", "a_user"},
+		{"createUser", "drop_a_user"},
 		{"roles", bson.A{}},
 		{"pwd", "password"},
 	}).Err()
@@ -60,7 +60,7 @@ func TestDropUserCommand(t *testing.T) {
 			failsForFerretDB: "https://github.com/FerretDB/FerretDB/issues/5323",
 		},
 		"Success": {
-			username: "a_user",
+			username: "drop_a_user",
 			expected: bson.D{
 				{"ok", float64(1)},
 			},

--- a/integration/auth/update_user_test.go
+++ b/integration/auth/update_user_test.go
@@ -149,16 +149,16 @@ func TestUpdateUserCommand(t *testing.T) {
 			failsForFerretDB: "https://github.com/FerretDB/FerretDB/issues/5313",
 		},
 		"PasswordChange": {
-			username: "a_user",
+			username: "update_a_user",
 			password: "password",
 			updatePayload: bson.D{
-				{"updateUser", "a_user"},
+				{"updateUser", "update_a_user"},
 				{"pwd", "anewpassword"},
 			},
 			expected: bson.D{
 				{"users", bson.A{bson.D{
-					{"_id", fmt.Sprintf("%s.a_user", db.Name())},
-					{"user", "a_user"},
+					{"_id", fmt.Sprintf("%s.update_a_user", db.Name())},
+					{"user", "update_a_user"},
 					{"db", db.Name()},
 					{"roles", bson.A{}},
 					{"mechanisms", bson.A{"SCRAM-SHA-256"}},


### PR DESCRIPTION
# Description

CI failure spotted https://github.com/FerretDB/FerretDB/actions/runs/16188938032/job/45699998061?pr=5336

The failure appears to be due to two tests sharing the same username.
```
ERROR	    drop_user_test.go:43: 
ERROR	        	Error Trace:	/home/runner/work/FerretDB/FerretDB/integration/auth/drop_user_test.go:43
ERROR	        	Error:      	Received unexpected error:
ERROR	        	            	(InternalError) role "a_user" already exists
ERROR	        	Test:       	TestDropUserCommand
ERROR	    setup.go:273: Keeping TestDropUserCommand.TestDropUserCommand for debugging
ERROR	    logging.go:42: INFO	clientconn/listener.go:184	127.0.0.1:43509 stopped	{"name":"listener"}
ERROR	    logging.go:42: INFO	clientconn/listener.go:220	Waiting for all connections to close	{"name":"listener"}
ERROR	    logging.go:42: INFO	clientconn/listener.go:307	Connection stopped	{"conn":"127.0.0.1:33306 -> 127.0.0.1:43509","name":"listener"}
ERROR	    logging.go:42: INFO	clientconn/listener.go:307	Connection stopped	{"conn":"127.0.0.1:33312 -> 127.0.0.1:43509","name":"listener"}
ERROR	    logging.go:42: INFO	handler/handler.go:127	Expired session deletion stopped	{"name":"handler"}
ERROR	    logging.go:42: INFO	handler/handler.go:112	Handler stopped	{"name":"handler"}
ERROR	--- FAIL: TestDropUserCommand (0.18s)
```

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [ ] I ensured that PR title is good enough for the changelog.
- [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [ ] I marked all done items in this checklist.
