### PR TITLE
Update DocumentDB

### DIFF
--- a/build/deps/postgres-documentdb.Dockerfile
+++ b/build/deps/postgres-documentdb.Dockerfile
@@ -1,5 +1,5 @@
 # Use development image and full tag close to the release.
-# FROM ghcr.io/ferretdb/postgres-documentdb-dev:17-0.106.0-ferretdb-2.5.0
+# FROM ghcr.io/ferretdb/postgres-documentdb-dev:17-0.106.0-ferretdb-2.6.0
 
 # Use moving development image during development.
 FROM ghcr.io/ferretdb/postgres-documentdb-dev:17-ferretdb

--- a/build/deps/postgres-documentdb.Dockerfile
+++ b/build/deps/postgres-documentdb.Dockerfile
@@ -1,5 +1,5 @@
 # Use development image and full tag close to the release.
-FROM ghcr.io/ferretdb/postgres-documentdb-dev:17-0.106.0-ferretdb-2.5.0
+# FROM ghcr.io/ferretdb/postgres-documentdb-dev:17-0.106.0-ferretdb-2.5.0
 
 # Use moving development image during development.
-# FROM ghcr.io/ferretdb/postgres-documentdb-dev:17-ferretdb
+FROM ghcr.io/ferretdb/postgres-documentdb-dev:17-ferretdb

--- a/build/ferretdb-bw/Dockerfile
+++ b/build/ferretdb-bw/Dockerfile
@@ -1,5 +1,5 @@
 # Use production image and full tag close to the release.
-# FROM --platform=linux/amd64 ghcr.io/ferretdb/postgres-documentdb:17-0.106.0-ferretdb-2.5.0
+# FROM --platform=linux/amd64 ghcr.io/ferretdb/postgres-documentdb:17-0.106.0-ferretdb-2.6.0
 
 # Use moving development image during development.
 FROM --platform=linux/amd64 ghcr.io/ferretdb/postgres-documentdb-dev:17-ferretdb

--- a/build/ferretdb-bw/Dockerfile
+++ b/build/ferretdb-bw/Dockerfile
@@ -1,8 +1,8 @@
 # Use production image and full tag close to the release.
-FROM --platform=linux/amd64 ghcr.io/ferretdb/postgres-documentdb:17-0.106.0-ferretdb-2.5.0
+# FROM --platform=linux/amd64 ghcr.io/ferretdb/postgres-documentdb:17-0.106.0-ferretdb-2.5.0
 
 # Use moving development image during development.
-# FROM --platform=linux/amd64 ghcr.io/ferretdb/postgres-documentdb-dev:17-ferretdb
+FROM --platform=linux/amd64 ghcr.io/ferretdb/postgres-documentdb-dev:17-ferretdb
 
 RUN --mount=type=cache,target=/var/cache/apt <<EOF
 

--- a/build/ferretdb/eval-dev.Dockerfile
+++ b/build/ferretdb/eval-dev.Dockerfile
@@ -97,7 +97,7 @@ EOF
 # final stage
 
 # Use development image and full tag close to the release.
-# FROM ghcr.io/ferretdb/postgres-documentdb-dev:17-0.106.0-ferretdb-2.5.0 AS eval-dev
+# FROM ghcr.io/ferretdb/postgres-documentdb-dev:17-0.106.0-ferretdb-2.6.0 AS eval-dev
 
 # Use moving development image during development.
 FROM ghcr.io/ferretdb/postgres-documentdb-dev:17-ferretdb AS eval-dev

--- a/build/ferretdb/eval-dev.Dockerfile
+++ b/build/ferretdb/eval-dev.Dockerfile
@@ -97,10 +97,10 @@ EOF
 # final stage
 
 # Use development image and full tag close to the release.
-FROM ghcr.io/ferretdb/postgres-documentdb-dev:17-0.106.0-ferretdb-2.5.0 AS eval-dev
+# FROM ghcr.io/ferretdb/postgres-documentdb-dev:17-0.106.0-ferretdb-2.5.0 AS eval-dev
 
 # Use moving development image during development.
-# FROM ghcr.io/ferretdb/postgres-documentdb-dev:17-ferretdb AS eval-dev
+FROM ghcr.io/ferretdb/postgres-documentdb-dev:17-ferretdb AS eval-dev
 
 RUN --mount=type=cache,sharing=locked,target=/var/cache/apt <<EOF
 apt install -y curl supervisor

--- a/build/ferretdb/eval.Dockerfile
+++ b/build/ferretdb/eval.Dockerfile
@@ -89,10 +89,10 @@ EOF
 # final stage
 
 # Use production image and full tag close to the release.
-FROM ghcr.io/ferretdb/postgres-documentdb:17-0.106.0-ferretdb-2.5.0 AS eval
+# FROM ghcr.io/ferretdb/postgres-documentdb:17-0.106.0-ferretdb-2.5.0 AS eval
 
 # Use moving development image during development.
-# FROM ghcr.io/ferretdb/postgres-documentdb-dev:17-ferretdb AS eval
+FROM ghcr.io/ferretdb/postgres-documentdb-dev:17-ferretdb AS eval
 
 RUN --mount=type=cache,sharing=locked,target=/var/cache/apt <<EOF
 apt install -y curl supervisor

--- a/build/ferretdb/eval.Dockerfile
+++ b/build/ferretdb/eval.Dockerfile
@@ -89,7 +89,7 @@ EOF
 # final stage
 
 # Use production image and full tag close to the release.
-# FROM ghcr.io/ferretdb/postgres-documentdb:17-0.106.0-ferretdb-2.5.0 AS eval
+# FROM ghcr.io/ferretdb/postgres-documentdb:17-0.106.0-ferretdb-2.6.0 AS eval
 
 # Use moving development image during development.
 FROM ghcr.io/ferretdb/postgres-documentdb-dev:17-ferretdb AS eval

--- a/build/version/documentdb.go
+++ b/build/version/documentdb.go
@@ -18,7 +18,7 @@ import "runtime"
 
 const (
 	// DocumentDB is a version of DocumentDB this version of FerretDB is compatible with.
-	DocumentDB = "0.106.0 gitref: HEAD sha:beb9d25d98 buildId:0"
+	DocumentDB = "0.107.0 gitref: ferretdb sha:349130adfc buildId:0"
 
 	// DocumentDBURL points to the release page of the DocumentDB version above.
 	DocumentDBURL = "https://github.com/FerretDB/documentdb/releases/tag/v0.106.0-ferretdb-2.5.0"

--- a/build/version/documentdb.go
+++ b/build/version/documentdb.go
@@ -21,7 +21,7 @@ const (
 	DocumentDB = "0.107.0 gitref: ferretdb sha:349130adfc buildId:0"
 
 	// DocumentDBURL points to the release page of the DocumentDB version above.
-	DocumentDBURL = "https://github.com/FerretDB/documentdb/releases/tag/v0.106.0-ferretdb-2.5.0"
+	DocumentDBURL = "https://github.com/FerretDB/documentdb/releases/tag/v0.106.0-ferretdb-2.6.0"
 )
 
 // DocumentDBSafeToUpdate represents versions of DocumentDB that FerretDB can update.
@@ -30,7 +30,7 @@ var DocumentDBSafeToUpdate = []string{
 	"0.103.0 gitref: HEAD sha:7514232 buildId:0",    // v2.2.0
 	"0.104.0 gitref: HEAD sha:2045d0e buildId:0",    // v2.3.0, v2.3.1
 	"0.105.0 gitref: HEAD sha:8453d93b buildId:0",   // v2.4.0
-	"0.106.0 gitref: HEAD sha:beb9d25d98 buildId:0", // v2.5.0
+	"0.106.0 gitref: HEAD sha:beb9d25d98 buildId:0", // v2.5.0, v2.6.0
 }
 
 // PostgreSQLTest is a version of PostgreSQL used by tests.

--- a/internal/documentdb/documentdb_api_internal/documentdb_api_internal.go
+++ b/internal/documentdb/documentdb_api_internal/documentdb_api_internal.go
@@ -1148,6 +1148,20 @@ func BsonGeonearWithinRange(ctx context.Context, conn *pgx.Conn, l *slog.Logger,
 	return
 }
 
+// BsonIndexTransform is a wrapper for
+//
+//	documentdb_api_internal.bson_index_transform(anonymous bytea, anonymous1 bytea, anonymous12 smallint, anonymous123 internal, OUT bson_index_transform bytea).
+func BsonIndexTransform(ctx context.Context, conn *pgx.Conn, l *slog.Logger, anonymous struct{}, anonymous1 struct{}, anonymous12 struct{}, anonymous123 struct{}) (outBsonIndexTransform struct{}, err error) {
+	ctx, span := otel.Tracer("").Start(ctx, "documentdb_api_internal.bson_index_transform", oteltrace.WithSpanKind(oteltrace.SpanKindClient))
+	defer span.End()
+
+	row := conn.QueryRow(ctx, "SELECT bson_index_transform FROM documentdb_api_internal.bson_index_transform($1, $2, $3, $4)", anonymous, anonymous1, anonymous12, anonymous123)
+	if err = row.Scan(&outBsonIndexTransform); err != nil {
+		err = mongoerrors.Make(ctx, err, "documentdb_api_internal.bson_index_transform", l)
+	}
+	return
+}
+
 // BsonIntegralDerivativeFinal is a wrapper for
 //
 //	documentdb_api_internal.bson_integral_derivative_final(anonymous bytea, OUT bson_integral_derivative_final documentdb_core.bson).
@@ -1428,6 +1442,20 @@ func BsonOrderbyCompare(ctx context.Context, conn *pgx.Conn, l *slog.Logger, ano
 	return
 }
 
+// BsonOrderbyCompareSortSupport is a wrapper for
+//
+//	documentdb_api_internal.bson_orderby_compare_sort_support(anonymous internal).
+func BsonOrderbyCompareSortSupport(ctx context.Context, conn *pgx.Conn, l *slog.Logger, anonymous struct{}) (err error) {
+	ctx, span := otel.Tracer("").Start(ctx, "documentdb_api_internal.bson_orderby_compare_sort_support", oteltrace.WithSpanKind(oteltrace.SpanKindClient))
+	defer span.End()
+
+	row := conn.QueryRow(ctx, "SELECT FROM documentdb_api_internal.bson_orderby_compare_sort_support($1)", anonymous)
+	if err = row.Scan(); err != nil {
+		err = mongoerrors.Make(ctx, err, "documentdb_api_internal.bson_orderby_compare_sort_support", l)
+	}
+	return
+}
+
 // BsonOrderbyEq is a wrapper for
 //
 //	documentdb_api_internal.bson_orderby_eq(anonymous documentdb_core.bson, anonymous1 documentdb_core.bson, OUT bson_orderby_eq boolean).
@@ -1494,6 +1522,20 @@ func BsonOrderbyPartition1(ctx context.Context, conn *pgx.Conn, l *slog.Logger, 
 	row := conn.QueryRow(ctx, "SELECT bson_orderby_partition::bytea FROM documentdb_api_internal.bson_orderby_partition($1::bytea, $2::bytea, $3, $4)", document, filter, istimerangewindow, collationstring)
 	if err = row.Scan(&outBsonOrderbyPartition); err != nil {
 		err = mongoerrors.Make(ctx, err, "documentdb_api_internal.bson_orderby_partition", l)
+	}
+	return
+}
+
+// BsonOrderbyReverse is a wrapper for
+//
+//	documentdb_api_internal.bson_orderby_reverse(anonymous documentdb_core.bson, anonymous1 documentdb_core.bson, OUT bson_orderby_reverse documentdb_core.bson).
+func BsonOrderbyReverse(ctx context.Context, conn *pgx.Conn, l *slog.Logger, anonymous wirebson.RawDocument, anonymous1 wirebson.RawDocument) (outBsonOrderbyReverse wirebson.RawDocument, err error) {
+	ctx, span := otel.Tracer("").Start(ctx, "documentdb_api_internal.bson_orderby_reverse", oteltrace.WithSpanKind(oteltrace.SpanKindClient))
+	defer span.End()
+
+	row := conn.QueryRow(ctx, "SELECT bson_orderby_reverse::bytea FROM documentdb_api_internal.bson_orderby_reverse($1::bytea, $2::bytea)", anonymous, anonymous1)
+	if err = row.Scan(&outBsonOrderbyReverse); err != nil {
+		err = mongoerrors.Make(ctx, err, "documentdb_api_internal.bson_orderby_reverse", l)
 	}
 	return
 }

--- a/website/docs/installation/documentdb/docker.md
+++ b/website/docs/installation/documentdb/docker.md
@@ -14,13 +14,13 @@ We provide two Docker images for setting up PostgreSQL with DocumentDB extension
 ## Installation
 
 The production image for PostgreSQL with DocumentDB extension
-[`ghcr.io/ferretdb/postgres-documentdb:17-0.106.0-ferretdb-2.5.0`](https://ghcr.io/ferretdb/postgres-documentdb:17-0.106.0-ferretdb-2.5.0)
+[`ghcr.io/ferretdb/postgres-documentdb:17-0.106.0-ferretdb-2.6.0`](https://ghcr.io/ferretdb/postgres-documentdb:17-0.106.0-ferretdb-2.6.0)
 is recommended for most deployments.
 It does not include FerretDB, so you must run it separately.
 For a complete setup that includes FerretDB, see the [FerretDB installation](../ferretdb/docker.md).
 
 :::tip
-We strongly recommend specifying the full image tag (e.g., `17-0.106.0-ferretdb-2.5.0`)
+We strongly recommend specifying the full image tag (e.g., `17-0.106.0-ferretdb-2.6.0`)
 to ensure consistency across deployments.
 For more information on the best FerretDB image to use, see the [DocumentDB release notes](https://github.com/FerretDB/documentdb/releases/).
 :::
@@ -40,7 +40,7 @@ See [Set up PostgreSQL connection](../../security/authentication.md#set-up-postg
      -e POSTGRES_DB=postgres \
      -v ./data:/var/lib/postgresql/data \
      -p 5432:5432 \
-     ghcr.io/ferretdb/postgres-documentdb:17-0.106.0-ferretdb-2.5.0
+     ghcr.io/ferretdb/postgres-documentdb:17-0.106.0-ferretdb-2.6.0
    ```
 
    Ensure to update `<username>` and `<password>` with your desired values.
@@ -54,7 +54,7 @@ See [Set up PostgreSQL connection](../../security/authentication.md#set-up-postg
    If you don't have `psql`, you can run the following command to run it inside the temporary PostgreSQL container:
 
    ```sh
-   docker run --rm -it ghcr.io/ferretdb/postgres-documentdb:17-0.106.0-ferretdb-2.5.0 \
+   docker run --rm -it ghcr.io/ferretdb/postgres-documentdb:17-0.106.0-ferretdb-2.6.0 \
      psql postgres://<username>:<password>@localhost:5432/postgres
    ```
 
@@ -75,7 +75,7 @@ Before [updating to a new FerretDB release](../ferretdb/docker.md#updating-to-a-
 The following steps are critical to ensuring a successful update.
 
 Edit your Compose file to use the matching DocumentDB image tag.
-You can find the correct tag in the DocumentDB release notes (for example: `17-0.106.0-ferretdb-2.5.0`).
+You can find the correct tag in the DocumentDB release notes (for example: `17-0.106.0-ferretdb-2.6.0`).
 Then run:
 
 ```sh

--- a/website/docs/installation/documentdb/kubernetes.md
+++ b/website/docs/installation/documentdb/kubernetes.md
@@ -12,7 +12,7 @@ You can deploy PostgreSQL with DocumentDB extension using any of our provided im
 Please see the [Docker installation docs](../documentdb/docker.md) to learn more about the available images.
 
 :::tip
-We strongly recommend specifying the full image tag (e.g., `17-0.106.0-ferretdb-2.5.0`)
+We strongly recommend specifying the full image tag (e.g., `17-0.106.0-ferretdb-2.6.0`)
 to ensure consistency across deployments.
 For more information on the best FerretDB image to use, see the [DocumentDB release notes](https://github.com/FerretDB/documentdb/releases/).
 :::
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: ghcr.io/ferretdb/postgres-documentdb:17-0.106.0-ferretdb-2.5.0
+          image: ghcr.io/ferretdb/postgres-documentdb:17-0.106.0-ferretdb-2.6.0
           ports:
             - containerPort: 5432
           env:

--- a/website/docs/installation/ferretdb/docker.md
+++ b/website/docs/installation/ferretdb/docker.md
@@ -20,14 +20,14 @@ that behaves like a [readiness probe](../../configuration/observability.md#probe
 ## Installation
 
 Our production image
-[`ghcr.io/ferretdb/ferretdb:2.5.0`](https://ghcr.io/ferretdb/ferretdb:2.5.0)
+[`ghcr.io/ferretdb/ferretdb:2.6.0`](https://ghcr.io/ferretdb/ferretdb:2.6.0)
 is recommended for most deployments.
 It does not include a PostgreSQL image with DocumentDB extension, so you must run this [pre-packaged PostgreSQL image with DocumentDB extension](../documentdb/docker.md) separately.
 
 You can do that with Docker Compose, Kubernetes, or any other means.
 
 :::tip
-We strongly recommend specifying the full image tag (e.g., `2.5.0`)
+We strongly recommend specifying the full image tag (e.g., `2.6.0`)
 to ensure consistency across deployments.
 Ensure to [enable telemetry](../../telemetry.md) to receive notifications on the latest versions.
 
@@ -43,7 +43,7 @@ The following steps describe a quick local setup:
    ```yaml
    services:
      postgres:
-       image: ghcr.io/ferretdb/postgres-documentdb:17-0.106.0-ferretdb-2.5.0
+       image: ghcr.io/ferretdb/postgres-documentdb:17-0.106.0-ferretdb-2.6.0
        restart: on-failure
        environment:
          - POSTGRES_USER=username
@@ -53,7 +53,7 @@ The following steps describe a quick local setup:
          - ./data:/var/lib/postgresql/data
 
      ferretdb:
-       image: ghcr.io/ferretdb/ferretdb:2.5.0
+       image: ghcr.io/ferretdb/ferretdb:2.6.0
        restart: on-failure
        ports:
          - 27017:27017
@@ -112,7 +112,7 @@ For this reason, it is not recommended for production use.
 Before updating your FerretDB instance, make sure to update to the matching DocumentDB image first.
 Following the [DocumentDB update guide](../documentdb/docker.md#updating-to-a-new-version) is critical for a successful update.
 
-Once DocumentDB is updated, edit your Docker compose file to point to the latest FerretDB production image tag as shown in the FerretDB release notes, for example `2.5.0`, then run:
+Once DocumentDB is updated, edit your Docker compose file to point to the latest FerretDB production image tag as shown in the FerretDB release notes, for example `2.6.0`, then run:
 
 ```sh
 docker compose pull <ferretdb-container-name>

--- a/website/docs/installation/ferretdb/kubernetes.md
+++ b/website/docs/installation/ferretdb/kubernetes.md
@@ -11,7 +11,7 @@ We provide different FerretDB images for various deployments.
 Please see the [Docker installation docs](docker.md) to learn more on the available images.
 
 :::tip
-We strongly recommend specifying the full image tag (e.g., `2.5.0`)
+We strongly recommend specifying the full image tag (e.g., `2.6.0`)
 to ensure consistency across deployments.
 Ensure to [enable telemetry](../../telemetry.md) to receive notifications on the latest versions.
 
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
         - name: ferretdb
-          image: ghcr.io/ferretdb/ferretdb:2.5.0
+          image: ghcr.io/ferretdb/ferretdb:2.6.0
           ports:
             - containerPort: 27017
           env:


### PR DESCRIPTION
# Description

Update DocumentDB to in-development 0.107, but update comments to use 0.106-2.6.0, because that's what we expect for the next version.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
