### PR TITLE
Add helpers for lazy logging

### DIFF
--- a/internal/util/logging/lazy.go
+++ b/internal/util/logging/lazy.go
@@ -1,0 +1,72 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"log/slog"
+
+	"github.com/FerretDB/wire/wirebson"
+)
+
+// lazyDecoder is a lazily evaluated [slog.LogValuer] for [wirebson.RawDocument]
+// that tries to decode the document.
+type lazyDecoder struct {
+	raw  wirebson.RawDocument
+	deep bool
+}
+
+// LogValue implements [slog.LogValuer].
+func (ld lazyDecoder) LogValue() slog.Value {
+	if len(ld.raw) == 0 {
+		return slog.Value{}
+	}
+
+	var d *wirebson.Document
+	if ld.deep {
+		d, _ = ld.raw.DecodeDeep()
+	} else {
+		d, _ = ld.raw.Decode()
+	}
+
+	if d == nil {
+		return ld.raw.LogValue()
+	}
+
+	return d.LogValue()
+}
+
+// LazyDecoder is a lazily evaluated [slog.LogValuer] for [wirebson.RawDocument]
+// that tries to decode the document.
+func LazyDecoder(raw wirebson.RawDocument) slog.LogValuer {
+	return lazyDecoder{raw: raw, deep: false}
+}
+
+// LazyDeepDecoder is a lazily evaluated [slog.LogValuer] for [wirebson.RawDocument]
+// that tries to deeply decode the document.
+func LazyDeepDecoder(raw wirebson.RawDocument) slog.LogValuer {
+	return lazyDecoder{raw: raw, deep: true}
+}
+
+// LazyString is a lazily evaluated [slog.LogValuer] for string.
+type LazyString func() string
+
+// LogValue implements [slog.LogValuer].
+func (ls LazyString) LogValue() slog.Value { return slog.StringValue(ls()) }
+
+// check interfaces
+var (
+	_ slog.LogValuer = lazyDecoder{}
+	_ slog.LogValuer = (LazyString)(nil)
+)

--- a/internal/util/logging/logging.go
+++ b/internal/util/logging/logging.go
@@ -56,12 +56,6 @@ func Error(err error) slog.Attr {
 	return slog.String("error", err.Error())
 }
 
-// LazyString is a lazily evaluated [slog.LogValuer].
-type LazyString func() string
-
-// LogValue implements [slog.LogValuer].
-func (ls LazyString) LogValue() slog.Value { return slog.StringValue(ls()) }
-
 // Logger creates a new slog handler and logger with the given output, options and UUID.
 func Logger(out io.Writer, opts *NewHandlerOpts, uuid string) *slog.Logger {
 	must.NotBeZero(opts)
@@ -83,8 +77,3 @@ func SetupDefault(opts *NewHandlerOpts, uuid string) {
 	slog.SetDefault(l)
 	slog.SetLogLoggerLevel(slog.LevelInfo + 2)
 }
-
-// check interfaces
-var (
-	_ slog.LogValuer = (LazyString)(nil)
-)


### PR DESCRIPTION
# Description

To make the next PR smaller.

## Readiness checklist

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [x] I added/updated comments and checked rendering.
- [x] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [x] I ensured that PR title is good enough for the changelog.
- [x] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [x] I marked all done items in this checklist.
