### PR TITLE
Replace `apt-key`

### DIFF
--- a/build/ferretdb-bw/Dockerfile
+++ b/build/ferretdb-bw/Dockerfile
@@ -10,8 +10,8 @@ apt install -y curl
 
 curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
 
-curl -L https://pgp.mongodb.com/server-7.0.asc | apt-key add -
-echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/debian bookworm/mongodb-org/7.0 main" | tee /etc/apt/sources.list.d/mongodb-org-7.0.list
+curl -L https://pgp.mongodb.com/server-7.0.asc | gpg --dearmor --yes --output /usr/share/keyrings/mongodb-bookworm.gpg
+echo "deb [ arch=amd64,arm64,signed-by=/usr/share/keyrings/mongodb-bookworm.gpg ] https://repo.mongodb.org/apt/debian bookworm/mongodb-org/7.0 main" | tee /etc/apt/sources.list.d/mongodb-org-7.0.list
 
 apt update
 apt install -y git-lfs mongodb-mongosh tmux nano

--- a/build/ferretdb/eval-dev.Dockerfile
+++ b/build/ferretdb/eval-dev.Dockerfile
@@ -106,8 +106,8 @@ FROM ghcr.io/ferretdb/postgres-documentdb-dev:17-ferretdb AS eval-dev
 
 RUN --mount=type=cache,sharing=locked,target=/var/cache/apt <<EOF
 apt install -y curl supervisor
-curl -L https://pgp.mongodb.com/server-7.0.asc | apt-key add -
-echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/debian bookworm/mongodb-org/7.0 main" | tee /etc/apt/sources.list.d/mongodb-org-7.0.list
+curl -L https://pgp.mongodb.com/server-7.0.asc | gpg --dearmor --yes --output /usr/share/keyrings/mongodb-bookworm.gpg
+echo "deb [ arch=amd64,arm64,signed-by=/usr/share/keyrings/mongodb-bookworm.gpg ] https://repo.mongodb.org/apt/debian bookworm/mongodb-org/7.0 main" | tee /etc/apt/sources.list.d/mongodb-org-7.0.list
 apt update
 apt install -y mongodb-mongosh
 

--- a/build/ferretdb/eval.Dockerfile
+++ b/build/ferretdb/eval.Dockerfile
@@ -98,8 +98,8 @@ FROM ghcr.io/ferretdb/postgres-documentdb-dev:17-ferretdb AS eval
 
 RUN --mount=type=cache,sharing=locked,target=/var/cache/apt <<EOF
 apt install -y curl supervisor
-curl -L https://pgp.mongodb.com/server-7.0.asc | apt-key add -
-echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/debian bookworm/mongodb-org/7.0 main" | tee /etc/apt/sources.list.d/mongodb-org-7.0.list
+curl -L https://pgp.mongodb.com/server-7.0.asc | gpg --dearmor --yes --output /usr/share/keyrings/mongodb-bookworm.gpg
+echo "deb [ arch=amd64,arm64,signed-by=/usr/share/keyrings/mongodb-bookworm.gpg ] https://repo.mongodb.org/apt/debian bookworm/mongodb-org/7.0 main" | tee /etc/apt/sources.list.d/mongodb-org-7.0.list
 apt update
 apt install -y mongodb-mongosh
 EOF


### PR DESCRIPTION
# Description

Replace `apt-key` (and fix `build/ferretdb-bw/Dockerfile` to build...)

## Readiness checklist

<!-- Please check all items in this checklist that were done. -->

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [ ] I ensured that PR title is good enough for the changelog.
- [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [ ] I marked all done items in this checklist.
