### PR TITLE
Fix spelling in `.go` files

### DIFF
--- a/build/version/version.go
+++ b/build/version/version.go
@@ -93,7 +93,7 @@ const ferretdbModule = "github.com/FerretDB/FerretDB/v2"
 // semVerTag is a https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string,
 // but with a leading `v`.
 //
-//nolint:lll // for readibility
+//nolint:lll // for readability
 var semVerTag = regexp.MustCompile(`^v(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
 
 // Get returns current build's info.

--- a/integration/auth/create_user_test.go
+++ b/integration/auth/create_user_test.go
@@ -148,10 +148,10 @@ func TestCreateUserCommand(t *testing.T) {
 		},
 		"MissingPwdOrExternal": {
 			payload: bson.D{
-				{"createUser", "mising_pwd_or_external"},
+				{"createUser", "missing_pwd_or_external"},
 				{"roles", bson.A{}},
 			},
-			user: "mising_pwd_or_external",
+			user: "missing_pwd_or_external",
 			err: &mongo.CommandError{
 				Code:    2,
 				Name:    "BadValue",

--- a/integration/commands_diagnostic_test.go
+++ b/integration/commands_diagnostic_test.go
@@ -269,48 +269,48 @@ func TestHostInfoCommand(t *testing.T) {
 	for _, elem := range a {
 		switch elem.Key {
 		case "system":
-			var elemForComparsion bson.D
+			var elemForComparison bson.D
 
 			for _, subElem := range elem.Value.(bson.D) {
 				switch subElem.Key {
 				case "currentTime":
 					assert.IsType(t, primitive.DateTime(0), subElem.Value)
-					elemForComparsion = append(elemForComparsion, bson.E{"currentTime", primitive.DateTime(0)})
+					elemForComparison = append(elemForComparison, bson.E{"currentTime", primitive.DateTime(0)})
 
 				case "hostname", "cpuArch":
 					assert.IsType(t, "", subElem.Value)
-					elemForComparsion = append(elemForComparsion, bson.E{subElem.Key, ""})
+					elemForComparison = append(elemForComparison, bson.E{subElem.Key, ""})
 
 				case "cpuAddrSize", "numCores":
 					assert.IsType(t, int32(0), subElem.Value)
-					elemForComparsion = append(elemForComparsion, bson.E{subElem.Key, int32(0)})
+					elemForComparison = append(elemForComparison, bson.E{subElem.Key, int32(0)})
 
 				case "numPhysicalCores", "numCpuSockets", "numNumaNodes", "numaEnabled", "memSizeMB", "memLimitMB":
 					// not implemented in FerretDB, do nothing
 					// TODO https://github.com/FerretDB/FerretDB-DocumentDB/issues/587
 
 				default:
-					elemForComparsion = append(elemForComparsion, subElem)
+					elemForComparison = append(elemForComparison, subElem)
 				}
 			}
 
-			actualComparable = append(actualComparable, bson.E{"system", elemForComparsion})
+			actualComparable = append(actualComparable, bson.E{"system", elemForComparison})
 
 		case "os":
-			var elemForComparsion bson.D
+			var elemForComparison bson.D
 
 			for _, subElem := range elem.Value.(bson.D) {
 				switch subElem.Key {
 				case "type", "name", "version":
 					assert.IsType(t, "", subElem.Value)
-					elemForComparsion = append(elemForComparsion, bson.E{subElem.Key, ""})
+					elemForComparison = append(elemForComparison, bson.E{subElem.Key, ""})
 
 				default:
-					elemForComparsion = append(elemForComparsion, subElem)
+					elemForComparison = append(elemForComparison, subElem)
 				}
 			}
 
-			actualComparable = append(actualComparable, bson.E{"os", elemForComparsion})
+			actualComparable = append(actualComparable, bson.E{"os", elemForComparison})
 
 		case "extra":
 			assert.IsType(t, bson.D{}, elem.Value)
@@ -349,7 +349,7 @@ func TestListCommandsCommand(t *testing.T) {
 	err := collection.Database().RunCommand(ctx, bson.D{{"listCommands", 42}}).Decode(&res)
 	require.NoError(t, err)
 
-	var actualForComparsion bson.D
+	var actualForComparison bson.D
 
 	for _, v := range res {
 		switch v.Key {
@@ -383,10 +383,10 @@ func TestListCommandsCommand(t *testing.T) {
 				}
 			}
 
-			actualForComparsion = append(actualForComparsion, bson.E{"commands", commandsComparable})
+			actualForComparison = append(actualForComparison, bson.E{"commands", commandsComparable})
 
 		default:
-			actualForComparsion = append(actualForComparsion, v)
+			actualForComparison = append(actualForComparison, v)
 		}
 	}
 
@@ -395,7 +395,7 @@ func TestListCommandsCommand(t *testing.T) {
 		{"ok", float64(1)},
 	}
 
-	AssertEqualDocuments(t, expected, actualForComparsion)
+	AssertEqualDocuments(t, expected, actualForComparison)
 }
 
 func TestValidateCommand(t *testing.T) {

--- a/integration/query_array_compat_test.go
+++ b/integration/query_array_compat_test.go
@@ -116,10 +116,10 @@ func TestQueryArrayCompatDotNotation(t *testing.T) {
 		"FieldArrayIndex": {
 			filter: bson.D{{"v.foo[0]", int32(42)}},
 		},
-		"FieldArrayAsterix": {
+		"FieldArrayAsterisk": {
 			filter: bson.D{{"v.foo[*]", int32(42)}},
 		},
-		"FieldAsterix": {
+		"FieldAsterisk": {
 			filter: bson.D{{"v.*", int32(42)}},
 		},
 		"FieldAt": {

--- a/integration/query_compat_test.go
+++ b/integration/query_compat_test.go
@@ -125,14 +125,14 @@ func testQueryCompatWithProviders(t *testing.T, providers shareddata.Providers, 
 						t = setup.FailsForFerretDB(tt, tc.failsForFerretDB)
 					}
 
-					targetIdx, tagetErr := targetCollection.Indexes().CreateOne(ctx, mongo.IndexModel{
+					targetIdx, targetErr := targetCollection.Indexes().CreateOne(ctx, mongo.IndexModel{
 						Keys: bson.D{{"v", 1}},
 					})
 					compatIdx, compatErr := compatCollection.Indexes().CreateOne(ctx, mongo.IndexModel{
 						Keys: bson.D{{"v", 1}},
 					})
 
-					require.NoError(t, tagetErr)
+					require.NoError(t, targetErr)
 					require.NoError(t, compatErr)
 					require.Equal(t, compatIdx, targetIdx)
 

--- a/integration/update_field_compat_test.go
+++ b/integration/update_field_compat_test.go
@@ -1446,7 +1446,7 @@ func TestUpdateFieldCompatSet(t *testing.T) {
 	doublesProvider := []shareddata.Provider{shareddata.Doubles}
 
 	testCases := map[string]updateCompatTestCase{
-		"SetNullInExisingField": {
+		"SetNullInExistingField": {
 			update: bson.D{{"$set", bson.D{{"v", nil}}}},
 		},
 		"DuplicateKeys": {

--- a/internal/util/must/must.go
+++ b/internal/util/must/must.go
@@ -62,7 +62,7 @@ func NotBeZero[T comparable](v T) {
 
 // BeTrue panic if the b is not true.
 //
-// Use that function only for static initialization, test code, or statemants that
+// Use that function only for static initialization, test code, or statements that
 // "can't" be false. When in doubt, don't.
 func BeTrue(b bool) {
 	if !b {

--- a/tools/definedockertag/main.go
+++ b/tools/definedockertag/main.go
@@ -53,7 +53,7 @@ type result struct {
 // semVerTag is a https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string,
 // but with a leading `v`.
 //
-//nolint:lll // for readibility
+//nolint:lll // for readability
 var semVerTag = regexp.MustCompile(`^v(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
 
 // debugEnv logs all environment variables that start with `GITHUB_` or `INPUT_`


### PR DESCRIPTION
# Description

- per https://github.com/FerretDB/FerretDB/pull/5489#pullrequestreview-3194274782

## Readiness checklist

<!-- Please check all items in this checklist that were done. -->

- [ ] I added/updated unit tests (and they pass).
- [ ] I added/updated integration/compatibility tests (and they pass).
- [ ] I added/updated comments and checked rendering.
- [ ] I made spot refactorings.
- [ ] I updated user documentation.
- [ ] I ran `task all`, and it passed.
- [ ] I ensured that PR title is good enough for the changelog.
- [ ] (for maintainers only) I set Reviewers ([`@FerretDB/core`](https://github.com/orgs/FerretDB/teams/core)), Milestone (`Next`), Labels, Project and project's Sprint fields.
- [ ] I marked all done items in this checklist.
