### PR TITLE
chore: set lll line-length to 120

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -184,7 +184,7 @@ linters-settings:
         alias: otelsemconv
   # ineffassign
   lll:
-    line-length: 130
+    line-length: 120
     tab-width: 4
   misspell:
     ignore-words:

--- a/integration/.golangci.yml
+++ b/integration/.golangci.yml
@@ -111,7 +111,7 @@ linters-settings:
         alias: otelsemconv
   # ineffassign
   lll:
-    line-length: 175 # TODO reduce it to 130
+    line-length: 120
     tab-width: 4
   misspell:
     ignore-words:


### PR DESCRIPTION
Closes #4636

Update golangci-lint `lll` (long line linter) configuration from 130/175 to 120 across both configs.

## Changes
- `.golangci.yml`: `lll.line-length` 130 → 120
- `integration/.golangci.yml`: `lll.line-length` 175 → 120 (removed TODO comment)