### PR TITLE
fix: duplicated words in genwrap/convert.go and handler.go comments

### DIFF
--- a/internal/documentdb/genwrap/convert.go
+++ b/internal/documentdb/genwrap/convert.go
@@ -143,7 +143,7 @@ type converter struct {
 	l *slog.Logger
 }
 
-// camelCase converts snake_case to to camelCase.
+// camelCase converts snake_case to camelCase.
 func (c *converter) camelCase(s string) string {
 	var res []rune
 

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -93,7 +93,7 @@ type NewOpts struct {
 func New(opts *NewOpts) (*Handler, error) {
 	sessionTimeout := time.Duration(session.LogicalSessionTimeoutMinutes) * time.Minute
 
-	// we rely on on it in the `getLog` implementation
+	// we rely on it in the `getLog` implementation
 	// TODO https://github.com/FerretDB/FerretDB/issues/4750
 	_ = opts.L.Handler().(*logging.Handler)
 


### PR DESCRIPTION
Two one-line typo fixes for duplicated words in source comments:
- `internal/documentdb/genwrap/convert.go` — "// camelCase converts snake_case to to camelCase." → "// camelCase converts snake_case to camelCase."
- `internal/handler/handler.go` — "// we rely on on it in the `getLog` implementation" → "// we rely on it in the `getLog` implementation"

No code/behavior change.