### PR TITLE
docs: apply 120-column rule to docs formatting guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -408,3 +408,4 @@ Before submitting a pull request, please make sure that:
    of our main branch.
 2. Documentation is formatted, linted, and built with `task docs`.
 3. Documentation is written according to our [writing guide](https://docs.ferretdb.io/contributing/writing-guide/).
+4. Prose and code blocks in documentation use a line length of up to 120 characters.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -846,10 +846,9 @@ tasks:
       # Note that embedded code snippets in ``` Markdown blocks are not reformatted if they can't be parsed.
       # Ensure that the code is valid and can be parsed by changing formatting manually
       # and running this task again, checking that formatting changes.
-      #
-      # TODO --print-width 120 (https://github.com/FerretDB/FerretDB/issues/4636)
       - >
         docker compose run --rm prettier --write --single-quote --trailing-comma none --no-semi
+        --print-width 120
         "**/*.md" "**/*.mdx"
 
       - >

--- a/website/docs/contributing/writing-guide.md
+++ b/website/docs/contributing/writing-guide.md
@@ -41,6 +41,12 @@ For example, if there are several pages in the folder "Getting Started", let `si
 
 Use sentence case for headers: `### Some header with URL`, not `### Some Header With URL`.
 
+## Line length
+
+Use a line length of up to 120 characters for both prose and code blocks in documentation.
+Insert line breaks manually at natural boundaries using one sentence per line, as described by
+[Semantic Line Breaks](https://sembr.org), instead of relying on random formatter wrapping.
+
 ## Links
 
 Please use relative `.md` file paths for links.

--- a/website/versioned_docs/version-v1.24/contributing/writing-guide.md
+++ b/website/versioned_docs/version-v1.24/contributing/writing-guide.md
@@ -41,6 +41,12 @@ For example, if there are several pages in the folder "Getting Started", let `si
 
 Use sentence case for headers: `### Some header with URL`, not `### Some Header With URL`.
 
+## Line length
+
+Use a line length of up to 120 characters for both prose and code blocks in documentation.
+Insert line breaks manually at natural boundaries using one sentence per line, as described by
+[Semantic Line Breaks](https://sembr.org), instead of relying on random formatter wrapping.
+
 ## Links
 
 Please use relative `.md` file paths for links.

--- a/website/versioned_docs/version-v2.5/contributing/writing-guide.md
+++ b/website/versioned_docs/version-v2.5/contributing/writing-guide.md
@@ -41,6 +41,12 @@ For example, if there are several pages in the folder "Getting Started", let `si
 
 Use sentence case for headers: `### Some header with URL`, not `### Some Header With URL`.
 
+## Line length
+
+Use a line length of up to 120 characters for both prose and code blocks in documentation.
+Insert line breaks manually at natural boundaries using one sentence per line, as described by
+[Semantic Line Breaks](https://sembr.org), instead of relying on random formatter wrapping.
+
 ## Links
 
 Please use relative `.md` file paths for links.

--- a/website/versioned_docs/version-v2.7/contributing/writing-guide.md
+++ b/website/versioned_docs/version-v2.7/contributing/writing-guide.md
@@ -41,6 +41,12 @@ For example, if there are several pages in the folder "Getting Started", let `si
 
 Use sentence case for headers: `### Some header with URL`, not `### Some Header With URL`.
 
+## Line length
+
+Use a line length of up to 120 characters for both prose and code blocks in documentation.
+Insert line breaks manually at natural boundaries using one sentence per line, as described by
+[Semantic Line Breaks](https://sembr.org), instead of relying on random formatter wrapping.
+
 ## Links
 
 Please use relative `.md` file paths for links.


### PR DESCRIPTION
## Summary
This PR contributes a first slice for #4636 by aligning documentation workflow/guidance with a 120-character line length.

### Changes
- enable `--print-width 120` for Markdown/MDX formatting in `Taskfile.yml` (`fmt-docs`)
- update `CONTRIBUTING.md` documentation checklist to require a 120-character line length
- add a new **Line length** section to writing guides (current docs + versioned guides) with semantic line-break guidance

## Notes
- This is an incremental PR, not the full repository-wide line-length migration.

Refs #4636