### PR TITLE
Add Layerbase to managed FerretDB cloud providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ See [there](https://pkg.go.dev/github.com/FerretDB/FerretDB/v2/build/version) fo
 - [Tembo](https://tembo.io/docs/tembo-stacks/mongo-alternative)
 - [Elestio](https://elest.io/open-source/ferretdb)
 - [Cozystack](https://cozystack.io/docs/components/#managed-ferretdb)
+- [Layerbase](https://layerbase.com/db/ferretdb)
 
 ## Community
 


### PR DESCRIPTION
Adds Layerbase to the Managed FerretDB at cloud providers list.

Link: https://layerbase.com/db/ferretdb

**Disclosure:** I am the founder of Layerbase, so this is a self-submission.

Layerbase offers self-serve managed FerretDB with TLS on every plan, starting at Solo $5/mo (flat, no usage meters), copy-on-write branching, and no waitlist. Happy to adjust wording if you prefer a different placement in the list.